### PR TITLE
Ensure that a user created from an auth user gets unique nickname

### DIFF
--- a/application/models/nicknames.go
+++ b/application/models/nicknames.go
@@ -1,0 +1,36 @@
+package models
+
+func allPrefixes() [30]string {
+	return [30]string{
+		"Faithful",
+		"Honest",
+		"Determined",
+		"Joyful",
+		"Loving",
+		"Peaceful",
+		"Patient",
+		"Kind",
+		"Good",
+		"Selfless",
+		"Disciplined",
+		"Authentic",
+		"Powerful",
+		"Enduring",
+		"Trustworthy",
+		"Upright",
+		"Courageous",
+		"Reliable",
+		"Responsible",
+		"Generous",
+		"Compassionate",
+		"Committed",
+		"Humble",
+		"Loyal",
+		"Wise",
+		"Truthful",
+		"Diligent",
+		"Flexible",
+		"Calm",
+		"Confident",
+	}
+}

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -699,15 +699,14 @@ func (ms *ModelSuite) TestUser_AttachPhoto() {
 
 func CreateUserFixturesForNicknames(ms *ModelSuite, t *testing.T) User {
 	ResetTables(t, ms.DB)
-
-	unique := domain.GetUuid().String()
+	prefix := allPrefixes()[0]
 
 	// Load User test fixtures
 	user := User{
-		Email:     fmt.Sprintf("user1-%s@example.com", unique),
+		Email:     fmt.Sprintf("user1-%s@example.com", t.Name()),
 		FirstName: "Existing",
 		LastName:  "User",
-		Nickname:  "ExistingU",
+		Nickname:  prefix + "ExistingU",
 		Uuid:      domain.GetUuid(),
 	}
 
@@ -719,9 +718,10 @@ func CreateUserFixturesForNicknames(ms *ModelSuite, t *testing.T) User {
 	return user
 }
 
-func (ms *ModelSuite) TestGetUniqueNickname() {
+func (ms *ModelSuite) TestUniquifyNickname() {
 	t := ms.T()
 	existingUser := CreateUserFixturesForNicknames(ms, t)
+	prefix := allPrefixes()[0]
 
 	tests := []struct {
 		name     string
@@ -732,28 +732,29 @@ func (ms *ModelSuite) TestGetUniqueNickname() {
 		{
 			name: "No Change, Blank Last Name",
 			user: User{FirstName: "New"},
-			want: "New",
+			want: prefix + "New",
 		},
 		{
 			name: "No Change, OK Last Name",
 			user: User{FirstName: "New", LastName: "User"},
-			want: "NewU",
+			want: prefix + "NewU",
 		},
 		{
 			name: "Expect Change",
 			user: User{
 				FirstName: existingUser.FirstName,
 				LastName:  existingUser.LastName,
-				Nickname:  existingUser.Nickname},
+				Nickname:  existingUser.Nickname[len(prefix):], //remove the prefix so it can be added back on
+			},
 			dontWant: existingUser.Nickname,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.user.getUniqueNickname()
+			err := test.user.uniquifyNickname()
 			if err != nil {
-				t.Errorf("getUniqueNickname() returned error: %s", err)
+				t.Errorf("uniquifyNickname() returned error: %s", err)
 			}
 
 			got := test.user.Nickname


### PR DESCRIPTION
I considered getting a semi-random prefix for the nickname, but figured it wasn't worth the added complexity and bug-risk just for a few users.