### PR TITLE
move database access to models

### DIFF
--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -124,7 +124,7 @@ func provideOrgOptions(userOrgs models.UserOrganizations, c buffalo.Context) err
 		orgOpts = append(orgOpts, AuthOrgOption{
 			ID:      strconv.Itoa(uo.ID),
 			Name:    uo.Organization.Name,
-			LogoURL: uo.Organization.Url.String, // TODO change to a logo url when one is added to organization
+			LogoURL: "",
 		})
 	}
 

--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -124,7 +124,7 @@ func provideOrgOptions(userOrgs models.UserOrganizations, c buffalo.Context) err
 		orgOpts = append(orgOpts, AuthOrgOption{
 			ID:      strconv.Itoa(uo.ID),
 			Name:    uo.Organization.Name,
-			LogoURL: "",
+			LogoURL: uo.Organization.Url.String, // TODO change to a logo url when one is added to organization
 		})
 	}
 

--- a/application/go.mod
+++ b/application/go.mod
@@ -3,7 +3,7 @@ module github.com/silinternational/wecarry-api
 go 1.12
 
 require (
-	github.com/99designs/gqlgen v0.9.1
+	github.com/99designs/gqlgen v0.10.1
 	github.com/aws/aws-sdk-go v1.25.0
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/go-chi/chi v3.3.2+incompatible
@@ -12,11 +12,9 @@ require (
 	github.com/gobuffalo/envy v1.7.0
 	github.com/gobuffalo/events v1.4.0
 	github.com/gobuffalo/httptest v1.4.0
-	github.com/gobuffalo/mw-contenttype v0.0.0-20190224202710-36c73cc938f3
 	github.com/gobuffalo/mw-csrf v0.0.0-20190129204204-25460a055517
 	github.com/gobuffalo/mw-paramlogger v0.0.0-20190224201358-0d45762ab655
 	github.com/gobuffalo/nulls v0.1.0
-	github.com/gobuffalo/packr v1.25.0
 	github.com/gobuffalo/packr/v2 v2.5.2
 	github.com/gobuffalo/pop v4.11.2+incompatible
 	github.com/gobuffalo/suite v2.8.1+incompatible
@@ -34,7 +32,6 @@ require (
 	github.com/sendgrid/sendgrid-go v3.5.0+incompatible
 	github.com/stretchr/testify v1.4.0
 	github.com/vektah/gqlparser v1.1.2
-	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890
 )
 

--- a/application/go.sum
+++ b/application/go.sum
@@ -8,8 +8,8 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBr
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/99designs/gqlgen v0.9.1 h1:YqEOgwamerz8mNGwqL5fX/SJS3+TdQ8zE02jhHIwjx0=
-github.com/99designs/gqlgen v0.9.1/go.mod h1:HrrG7ic9EgLPsULxsZh/Ti+p0HNWgR3XRuvnD0pb5KY=
+github.com/99designs/gqlgen v0.10.1 h1:1BgB6XKGTHq7uH4G1/PYyKe2Kz7/vw3AlvMZlD3TEEY=
+github.com/99designs/gqlgen v0.10.1/go.mod h1:IviubpnyI4gbBcj8IcxSSc/Q/+af5riwCmJmwF0uaPE=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -24,8 +24,6 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.23.19 h1:QiEkjRHkDXAThgnHKSEC63JwsSjL/jfYUOA2QYFmbSw=
-github.com/aws/aws-sdk-go v1.23.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.0 h1:MyXUdCesJLBvSSKYcaKeeEwxNUwUpG6/uqVYeH/Zzfo=
 github.com/aws/aws-sdk-go v1.25.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
@@ -336,7 +334,6 @@ github.com/gobuffalo/mw-basicauth v1.0.6/go.mod h1:RFyeGeDLZlVgp/eBflqu2eavFqyv0
 github.com/gobuffalo/mw-basicauth v1.0.7/go.mod h1:xJ9/OSiOWl+kZkjaSun62srODr3Cx8OB4AKr+G4FlS4=
 github.com/gobuffalo/mw-contenttype v0.0.0-20180802152300-74f5a47f4d56/go.mod h1:7EvcmzBbeCvFtQm5GqF9ys6QnCxz2UM1x0moiWLq1No=
 github.com/gobuffalo/mw-contenttype v0.0.0-20190129203934-2554e742333b/go.mod h1:7x87+mDrr9Peh7AqhOtESyJLanMd2zQNz2Hts+vtBoE=
-github.com/gobuffalo/mw-contenttype v0.0.0-20190224202710-36c73cc938f3 h1:ODCQxdZPUTjoDHwErDroIzuAs2ua0FlOFL5YXPdJGWs=
 github.com/gobuffalo/mw-contenttype v0.0.0-20190224202710-36c73cc938f3/go.mod h1:7x87+mDrr9Peh7AqhOtESyJLanMd2zQNz2Hts+vtBoE=
 github.com/gobuffalo/mw-csrf v0.0.0-20180802151833-446ff26e108b/go.mod h1:sbGtb8DmDZuDUQoxjr8hG1ZbLtZboD9xsn6p77ppcHo=
 github.com/gobuffalo/mw-csrf v0.0.0-20190129204204-25460a055517 h1:pOOXwl1xPLLP8oZw3e3t2wwrc/KSzmlRBcaQwGpG9oo=

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -7686,7 +7686,7 @@ func (ec *executionContext) marshalNPost2ᚕᚖgithubᚗcomᚋsilinternational�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalOPost2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, sel, v[i])
+			ret[i] = ec.marshalNPost2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)

--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -12,17 +12,19 @@ model:
 resolver:
   filename: resolver.go
   type: Resolver
-autobind: []
+autobind:
+  - github.com/silinternational/wecarry-api/models
+  - github.com/silinternational/wecarry-api/gqlgen
 models:
   Organization:
-    model: github.com/silinternational/wecarry-api/models.Organization
+    model: models.Organization
     fields:
       id:
         resolver: true
   OrganizationDomain:
-    model: github.com/silinternational/wecarry-api/models.OrganizationDomain
+    model: models.OrganizationDomain
   User:
-    model: github.com/silinternational/wecarry-api/models.User
+    model: models.User
     fields:
       id:
         resolver: true
@@ -31,7 +33,7 @@ models:
       location:
         resolver: true
   Post:
-    model: github.com/silinternational/wecarry-api/models.Post
+    model: models.Post
     fields:
       id:
         resolver: true
@@ -48,7 +50,7 @@ models:
       origin:
         resolver: true
   Thread:
-    model: github.com/silinternational/wecarry-api/models.Thread
+    model: models.Thread
     fields:
       id:
         resolver: true
@@ -57,23 +59,23 @@ models:
       lastViewedAt:
         resolver: true
   Message:
-    model: github.com/silinternational/wecarry-api/models.Message
+    model: models.Message
     fields:
       id:
         resolver: true
       thread:
         resolver: true
   File:
-    model: github.com/silinternational/wecarry-api/models.File
+    model: models.File
     fields:
       id:
         resolver: true
   UpdatePostInput:
-    model: github.com/silinternational/wecarry-api/gqlgen.postInput
+    model: gqlgen.postInput
   CreatePostInput:
-    model: github.com/silinternational/wecarry-api/gqlgen.postInput
+    model: gqlgen.postInput
   Location:
-    model: github.com/silinternational/wecarry-api/models.Location
+    model: models.Location
 
 #directives:
 #  deprecated:

--- a/application/gqlgen/gqlgen_test.go
+++ b/application/gqlgen/gqlgen_test.go
@@ -1,7 +1,6 @@
 package gqlgen
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/99designs/gqlgen/client"
@@ -26,8 +25,7 @@ func Test_GqlgenSuite(t *testing.T) {
 
 func getGqlClient() *client.Client {
 	h := handler.GraphQL(NewExecutableSchema(Config{Resolvers: &Resolver{}}))
-	srv := httptest.NewServer(h)
-	c := client.New(srv.URL)
+	c := client.New(h)
 	return c
 }
 

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -44,7 +44,7 @@ func (r *messageResolver) Thread(ctx context.Context, obj *models.Message) (*mod
 	if obj == nil {
 		return nil, nil
 	}
-	selectFields := getSelectFieldsForThreads(graphql.CollectAllFields(ctx))
+	selectFields := getSelectFieldsForThreads(ctx)
 	return obj.GetThread(selectFields)
 }
 

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -49,10 +49,13 @@ func (r *messageResolver) Thread(ctx context.Context, obj *models.Message) (*mod
 }
 
 func (r *queryResolver) Message(ctx context.Context, id *string) (*models.Message, error) {
-	message := models.Message{}
+	if id == nil {
+		return nil, nil
+	}
+	var message models.Message
 	messageFields := GetSelectFieldsFromRequestFields(MessageFields(), graphql.CollectAllFields(ctx))
 
-	if err := models.DB.Select(messageFields...).Where("uuid = ?", id).First(&message); err != nil {
+	if err := message.FindByUUID(*id, messageFields...); err != nil {
 		graphql.AddError(ctx, gqlerror.Errorf("error getting message: %v", err.Error()))
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return &models.Message{}, err

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -3,6 +3,8 @@ package gqlgen
 import (
 	"context"
 
+	"github.com/silinternational/wecarry-api/domain"
+
 	"github.com/99designs/gqlgen/graphql"
 
 	"github.com/silinternational/wecarry-api/models"
@@ -45,10 +47,12 @@ func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organiza
 		return nil, nil
 	}
 
-	if err := models.DB.Load(obj, "OrganizationDomains"); err != nil {
+	domains, err := obj.GetDomains()
+	if err != nil {
+		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return nil, err
 	}
-	domains := obj.OrganizationDomains
+
 	dp := make([]*models.OrganizationDomain, len(domains))
 	for i, d := range domains {
 		dp[i] = &d

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -3,10 +3,8 @@ package gqlgen
 import (
 	"context"
 
-	"github.com/silinternational/wecarry-api/domain"
-
 	"github.com/99designs/gqlgen/graphql"
-
+	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 )
 

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -2,7 +2,6 @@ package gqlgen
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -363,27 +362,19 @@ func (r *mutationResolver) UpdatePost(ctx context.Context, input postInput) (*mo
 	post, err := convertGqlPostInputToDBPost(ctx, input, cUser)
 	if err != nil {
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return &models.Post{}, err
+		return nil, err
 	}
 
-	valErrs, err := models.DB.ValidateAndUpdate(&post)
-
-	if err != nil {
+	if err := post.Update(); err != nil {
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return &models.Post{}, err
-	}
-
-	if len(valErrs.Errors) > 0 {
-		vErrs := models.FlattenPopErrors(valErrs)
-		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), vErrs)
-		return &models.Post{}, errors.New(vErrs)
+		return nil, err
 	}
 
 	if input.Destination != nil {
 		err := post.SetDestination(convertGqlLocationInputToDBLocation(*input.Destination))
 		if err != nil {
 			domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-			return &models.Post{}, err
+			return nil, err
 		}
 	}
 
@@ -391,7 +382,7 @@ func (r *mutationResolver) UpdatePost(ctx context.Context, input postInput) (*mo
 		err := post.SetOrigin(convertGqlLocationInputToDBLocation(*input.Origin))
 		if err != nil {
 			domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-			return &models.Post{}, err
+			return nil, err
 		}
 	}
 

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -331,27 +331,19 @@ func (r *mutationResolver) CreatePost(ctx context.Context, input postInput) (*mo
 	post, err := convertGqlPostInputToDBPost(ctx, input, cUser)
 	if err != nil {
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return &models.Post{}, err
+		return nil, err
 	}
 
-	valErrs, err := models.DB.ValidateAndCreate(&post)
-
-	if err != nil {
+	if err := post.Create(); err != nil {
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return &models.Post{}, err
-	}
-
-	if len(valErrs.Errors) > 0 {
-		vErrs := models.FlattenPopErrors(valErrs)
-		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), vErrs)
-		return &models.Post{}, errors.New(vErrs)
+		return nil, err
 	}
 
 	if input.Destination != nil {
 		err := post.SetDestination(convertGqlLocationInputToDBLocation(*input.Destination))
 		if err != nil {
 			domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-			return &models.Post{}, err
+			return nil, err
 		}
 	}
 
@@ -359,7 +351,7 @@ func (r *mutationResolver) CreatePost(ctx context.Context, input postInput) (*mo
 		err := post.SetOrigin(convertGqlLocationInputToDBLocation(*input.Origin))
 		if err != nil {
 			domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-			return &models.Post{}, err
+			return nil, err
 		}
 	}
 

--- a/application/gqlgen/post_test.go
+++ b/application/gqlgen/post_test.go
@@ -397,7 +397,7 @@ func (gs *GqlgenSuite) Test_UpdatePost() {
 	TestUser = f.Users[0]
 	c.MustPost(query, &postsResp)
 
-	if err := models.DB.Load(&(f.Posts[0]), "PhotoFile", "Files"); err != nil {
+	if err := gs.DB.Load(&(f.Posts[0]), "PhotoFile", "Files"); err != nil {
 		t.Errorf("failed to load post fixture, %s", err)
 		t.FailNow()
 	}

--- a/application/gqlgen/resolver_test.go
+++ b/application/gqlgen/resolver_test.go
@@ -3,7 +3,6 @@ package gqlgen
 import (
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"time"
 
 	"github.com/99designs/gqlgen/client"
@@ -106,9 +105,7 @@ func (gs *GqlgenSuite) TestResolver() {
 	createFixture(gs, &MessageFix[0])
 
 	// Prep gql server
-	h := newHandler()
-	srv := httptest.NewServer(h)
-	c := client.New(srv.URL)
+	c := client.New(newHandler())
 
 	var intResults, intExpected int
 	var strResults, strExpected string

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -113,18 +113,18 @@ func (r *queryResolver) Threads(ctx context.Context) ([]*models.Thread, error) {
 }
 
 func (r *queryResolver) MyThreads(ctx context.Context) ([]*models.Thread, error) {
-	var threads []*models.Thread
-
-	db := models.DB
 	currentUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 
-	query := db.Q().LeftJoin("thread_participants tp", "threads.id = tp.thread_id")
-	query = query.Where("tp.user_id = ?", currentUser.ID)
-	if err := query.All(&threads); err != nil {
+	dbThreads := models.Threads{}
+	if err := dbThreads.AllForUser(currentUser); err != nil {
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return []*models.Thread{}, fmt.Errorf("error getting threads: %v", err)
 	}
 
+	threads := make([]*models.Thread, len(dbThreads))
+	for i := range dbThreads {
+		threads[i] = &dbThreads[i]
+	}
 	return threads, nil
 }
 

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -103,7 +103,7 @@ func (r *queryResolver) Threads(ctx context.Context) ([]*models.Thread, error) {
 
 	db := models.DB
 
-	selectFields := getSelectFieldsForThreads(graphql.CollectAllFields(ctx))
+	selectFields := getSelectFieldsForThreads(ctx)
 	if err := db.Select(selectFields...).All(&threads); err != nil {
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return []*models.Thread{}, fmt.Errorf("error getting threads: %v", err)
@@ -128,8 +128,8 @@ func (r *queryResolver) MyThreads(ctx context.Context) ([]*models.Thread, error)
 	return threads, nil
 }
 
-func getSelectFieldsForThreads(requestFields []string) []string {
-	selectFields := GetSelectFieldsFromRequestFields(ThreadFields(), requestFields)
+func getSelectFieldsForThreads(ctx context.Context) []string {
+	selectFields := GetSelectFieldsFromRequestFields(ThreadFields(), graphql.CollectAllFields(ctx))
 
 	selectFields = append(selectFields, "id")
 

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -115,8 +115,8 @@ func (r *queryResolver) Threads(ctx context.Context) ([]*models.Thread, error) {
 func (r *queryResolver) MyThreads(ctx context.Context) ([]*models.Thread, error) {
 	currentUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 
-	dbThreads := models.Threads{}
-	if err := dbThreads.AllForUser(currentUser); err != nil {
+	dbThreads, err := currentUser.GetThreads()
+	if err != nil {
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return []*models.Thread{}, fmt.Errorf("error getting threads: %v", err)
 	}

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -99,16 +99,16 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 }
 
 func (r *queryResolver) Threads(ctx context.Context) ([]*models.Thread, error) {
-	var threads []*models.Thread
-
-	db := models.DB
-
-	selectFields := getSelectFieldsForThreads(ctx)
-	if err := db.Select(selectFields...).All(&threads); err != nil {
+	dbThreads := models.Threads{}
+	if err := dbThreads.All(getSelectFieldsForThreads(ctx)...); err != nil {
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return []*models.Thread{}, fmt.Errorf("error getting threads: %v", err)
 	}
 
+	threads := make([]*models.Thread, len(dbThreads))
+	for i := range dbThreads {
+		threads[i] = &dbThreads[i]
+	}
 	return threads, nil
 }
 

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -141,7 +141,7 @@ func (r *queryResolver) User(ctx context.Context, id *string) (*models.User, err
 		return &dbUser, err
 	}
 
-	if err := models.DB.Select(GetSelectFieldsForUsers(ctx)...).Where("uuid = ?", id).First(&dbUser); err != nil {
+	if err := dbUser.FindByUUID(*id, GetSelectFieldsForUsers(ctx)...); err != nil {
 		graphql.AddError(ctx, gqlerror.Errorf("Error getting user: %v", err.Error()))
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return &dbUser, err

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -104,9 +104,6 @@ func (r *userResolver) UnreadMessageCount(ctx context.Context, obj *models.User)
 }
 
 func (r *queryResolver) Users(ctx context.Context) ([]*models.User, error) {
-	db := models.DB
-	var dbUsers []*models.User
-
 	currentUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 
 	if currentUser.AdminRole.String != domain.AdminRoleSuperDuperAdmin {
@@ -115,13 +112,18 @@ func (r *queryResolver) Users(ctx context.Context) ([]*models.User, error) {
 		return []*models.User{}, err
 	}
 
-	if err := db.Select(GetSelectFieldsForUsers(ctx)...).All(&dbUsers); err != nil {
+	dbUsers := models.Users{}
+	if err := dbUsers.All(GetSelectFieldsForUsers(ctx)...); err != nil {
 		graphql.AddError(ctx, gqlerror.Errorf("Error getting users: %v", err.Error()))
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return []*models.User{}, err
 	}
 
-	return dbUsers, nil
+	users := make([]*models.User, len(dbUsers))
+	for i := range dbUsers {
+		users[i] = &dbUsers[i]
+	}
+	return users, nil
 }
 
 func (r *queryResolver) User(ctx context.Context, id *string) (*models.User, error) {

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -148,7 +148,7 @@ func (gs *GqlgenSuite) Test_UserQuery() {
 			Payload:  `{user(id: "` + f.Users[1].Uuid.String() + `")` + allFields + "}",
 			TestUser: f.Users[0],
 			Test: func(t *testing.T) {
-				if err := models.DB.Load(&(f.Users[1]), "PhotoFile"); err != nil {
+				if err := gs.DB.Load(&(f.Users[1]), "PhotoFile"); err != nil {
 					t.Errorf("failed to load user fixture, %s", err)
 				}
 				gs.Equal(f.Users[1].Uuid.String(), resp.User.ID, "incorrect ID")

--- a/application/models/message.go
+++ b/application/models/message.go
@@ -138,3 +138,16 @@ func (m *Message) FindByID(id int, eagerFields ...string) error {
 
 	return DB.Find(m, id)
 }
+
+// FindByUUID loads from DB the Message record identified by the given UUID
+func (m *Message) FindByUUID(id string, selectFields ...string) error {
+	if id == "" {
+		return errors.New("error: message uuid must not be blank")
+	}
+
+	if err := DB.Where("uuid = ?", id).Select(selectFields...).First(m); err != nil {
+		return fmt.Errorf("error finding message by uuid: %s", err.Error())
+	}
+
+	return nil
+}

--- a/application/models/message_fixtures_test.go
+++ b/application/models/message_fixtures_test.go
@@ -137,3 +137,46 @@ func Fixtures_Message_FindByID(ms *ModelSuite, t *testing.T) MessageFixtures {
 		Threads:  threads,
 	}
 }
+
+func Fixtures_Message_FindByUUID(ms *ModelSuite) MessageFixtures {
+	org := &Organization{AuthConfig: "{}", Uuid: domain.GetUuid()}
+	createFixture(ms, org)
+
+	unique := domain.GetUuid().String()
+	users := Users{
+		{Email: unique + "user1@example.com", Nickname: unique + "User1", Uuid: domain.GetUuid()},
+	}
+	for i := range users {
+		createFixture(ms, &users[i])
+	}
+
+	posts := Posts{
+		{Uuid: domain.GetUuid(), CreatedByID: users[0].ID, OrganizationID: org.ID},
+	}
+	for i := range posts {
+		createFixture(ms, &posts[i])
+	}
+
+	threads := Threads{
+		{Uuid: domain.GetUuid(), PostID: posts[0].ID},
+	}
+	for i := range threads {
+		createFixture(ms, &threads[i])
+	}
+
+	messages := Messages{
+		{
+			Uuid:     domain.GetUuid(),
+			ThreadID: threads[0].ID,
+			SentByID: users[0].ID,
+			Content:  "Love must be sincere. Hate what is evil; cling to what is good.",
+		},
+	}
+	for i := range messages {
+		createFixture(ms, &messages[i])
+	}
+
+	return MessageFixtures{
+		Messages: messages,
+	}
+}

--- a/application/models/message_test.go
+++ b/application/models/message_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gobuffalo/validate"
 	"github.com/silinternational/wecarry-api/domain"
@@ -197,6 +198,55 @@ func (ms *ModelSuite) TestMessage_FindByID() {
 				ms.Equal(test.wantMessage.ID, message.ID, "bad message id")
 				ms.Equal(test.wantSentBy.ID, message.SentBy.ID, "bad message sent_by id")
 				ms.Equal(test.wantThread.Uuid, message.Thread.Uuid, "bad message thread id")
+			}
+		})
+	}
+}
+
+func (ms *ModelSuite) TestMessage_FindByUUID() {
+	t := ms.T()
+
+	f := Fixtures_Message_FindByUUID(ms)
+
+	tests := []struct {
+		name          string
+		uuid          string
+		fields        []string
+		wantID        int
+		wantContent   string
+		wantCreatedAt string
+		wantErr       bool
+	}{
+		{name: "good with no extra fields",
+			uuid:          f.Messages[0].Uuid.String(),
+			fields:        []string{"id"},
+			wantID:        f.Messages[0].ID,
+			wantContent:   "",
+			wantCreatedAt: time.Time{}.Format(time.RFC3339),
+		},
+		{name: "good with two extra fields",
+			uuid:          f.Messages[0].Uuid.String(),
+			fields:        []string{"id", "content", "created_at"},
+			wantID:        f.Messages[0].ID,
+			wantContent:   f.Messages[0].Content,
+			wantCreatedAt: f.Messages[0].CreatedAt.Format(time.RFC3339),
+		},
+		{name: "empty ID", uuid: "", wantErr: true},
+		{name: "wrong id", uuid: domain.GetUuid().String(), wantErr: true},
+		{name: "invalid UUID", uuid: "40FE092C-8FF1-45BE-BCD4-65AD66C1D0DX", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var message Message
+			err := message.FindByUUID(test.uuid, test.fields...)
+
+			if test.wantErr {
+				ms.Error(err)
+			} else {
+				ms.NoError(err)
+				ms.Equal(test.wantID, message.ID, "bad message ID")
+				ms.Equal(test.wantContent, message.Content, "bad message Content")
+				ms.Equal(test.wantCreatedAt, message.CreatedAt.Format(time.RFC3339), "bad message CreatedAt")
 			}
 		})
 	}

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -155,11 +155,11 @@ func (o *Organization) Save() error {
 	return DB.Save(o)
 }
 
-func (orgs *Organizations) ListAll() error {
+func (orgs *Organizations) All() error {
 	return DB.All(orgs)
 }
 
-func (orgs *Organizations) ListAllForUser(user User) error {
+func (orgs *Organizations) AllForUser(user User) error {
 	return DB.Q().LeftJoin("user_organizations uo", "organizations.id = uo.organization_id").
 		Where("uo.user_id = ?", user.ID).All(orgs)
 }

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -163,3 +163,12 @@ func (orgs *Organizations) ListAllForUser(user User) error {
 	return DB.Q().LeftJoin("user_organizations uo", "organizations.id = uo.organization_id").
 		Where("uo.user_id = ?", user.ID).All(orgs)
 }
+
+// GetDomains finds and returns all related OrganizationDomain rows.
+func (o *Organization) GetDomains() ([]OrganizationDomain, error) {
+	if err := DB.Load(o, "OrganizationDomains"); err != nil {
+		return nil, err
+	}
+
+	return o.OrganizationDomains, nil
+}

--- a/application/models/organization_test.go
+++ b/application/models/organization_test.go
@@ -408,7 +408,7 @@ func (ms *ModelSuite) TestOrganization_Save() {
 
 }
 
-func (ms *ModelSuite) TestOrganization_ListAll() {
+func (ms *ModelSuite) TestOrganization_All() {
 	t := ms.T()
 
 	orgFixtures := []Organization{
@@ -442,7 +442,7 @@ func (ms *ModelSuite) TestOrganization_ListAll() {
 	}
 
 	var allOrgs Organizations
-	err := allOrgs.ListAll()
+	err := allOrgs.All()
 	if err != nil {
 		t.Error(err)
 	}
@@ -453,7 +453,7 @@ func (ms *ModelSuite) TestOrganization_ListAll() {
 
 }
 
-func (ms *ModelSuite) TestOrganization_ListAllForUser() {
+func (ms *ModelSuite) TestOrganization_AllForUser() {
 	t := ms.T()
 
 	orgFixtures := []Organization{
@@ -509,7 +509,7 @@ func (ms *ModelSuite) TestOrganization_ListAllForUser() {
 	}
 
 	var userOrgs Organizations
-	err := userOrgs.ListAllForUser(userFixtures[0])
+	err := userOrgs.AllForUser(userFixtures[0])
 	if err != nil {
 		t.Error(err)
 	}

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -190,9 +190,20 @@ type updateStatusValidator struct {
 }
 
 func (v *updateStatusValidator) IsValid(errors *validate.Errors) {
+	switch v.Post.Type {
+	case PostTypeOffer:
+		v.isOfferValid(errors)
+	case PostTypeRequest:
+		v.isRequestValid(errors)
+	}
+}
 
-	// TODO Take into account PostTypeOffer as well.  This is just for PostTypeRequest
+func (v *updateStatusValidator) isOfferValid(errors *validate.Errors) {
+	v.Message = "Offer status updates not allowed at this time"
+	errors.Add(validators.GenerateKey(v.Name), v.Message)
+}
 
+func (v *updateStatusValidator) isRequestValid(errors *validate.Errors) {
 	oldPost := Post{}
 	uuid := v.Post.Uuid.String()
 	if err := oldPost.FindByUUID(uuid); err != nil {

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -84,6 +84,21 @@ func (p Posts) String() string {
 	return string(jp)
 }
 
+// Create stores the Post data as a new record in the database.
+func (p *Post) Create() error {
+	valErrs, err := DB.ValidateAndCreate(p)
+	if err != nil {
+		return err
+	}
+
+	if len(valErrs.Errors) > 0 {
+		vErrs := FlattenPopErrors(valErrs)
+		return errors.New(vErrs)
+	}
+
+	return nil
+}
+
 func (p *Post) NewWithUser(pType string, currentUser User) error {
 	p.Uuid = domain.GetUuid()
 	p.CreatedByID = currentUser.ID

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -190,20 +190,9 @@ type updateStatusValidator struct {
 }
 
 func (v *updateStatusValidator) IsValid(errors *validate.Errors) {
-	switch v.Post.Type {
-	case PostTypeOffer:
-		v.isOfferValid(errors)
-	case PostTypeRequest:
-		v.isRequestValid(errors)
-	}
-}
 
-func (v *updateStatusValidator) isOfferValid(errors *validate.Errors) {
-	v.Message = "Offer status updates not allowed at this time"
-	errors.Add(validators.GenerateKey(v.Name), v.Message)
-}
+	// TODO Take into account PostTypeOffer as well.  This is just for PostTypeRequest
 
-func (v *updateStatusValidator) isRequestValid(errors *validate.Errors) {
 	oldPost := Post{}
 	uuid := v.Post.Uuid.String()
 	if err := oldPost.FindByUUID(uuid); err != nil {

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -99,6 +99,21 @@ func (p *Post) Create() error {
 	return nil
 }
 
+// Update writes the Post data to an existing database record.
+func (p *Post) Update() error {
+	valErrs, err := DB.ValidateAndUpdate(p)
+	if err != nil {
+		return err
+	}
+
+	if len(valErrs.Errors) > 0 {
+		vErrs := FlattenPopErrors(valErrs)
+		return errors.New(vErrs)
+	}
+
+	return nil
+}
+
 func (p *Post) NewWithUser(pType string, currentUser User) error {
 	p.Uuid = domain.GetUuid()
 	p.CreatedByID = currentUser.ID

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -61,6 +61,11 @@ func (t *Thread) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
+// All retrieves all Threads from the database.
+func (t *Threads) All(selectFields ...string) error {
+	return DB.Select(selectFields...).All(t)
+}
+
 func (t *Thread) FindByUUID(uuid string) error {
 	if uuid == "" {
 		return errors.New("error: thread uuid must not be blank")

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -218,14 +218,3 @@ func (t *Thread) UnreadMessageCount(lastViewedAt time.Time) (int, error) {
 
 	return count, nil
 }
-
-// AllForUser finds all threads that given user is involved in.
-func (t *Threads) AllForUser(user User) error {
-	query := DB.Q().LeftJoin("thread_participants tp", "threads.id = tp.thread_id")
-	query = query.Where("tp.user_id = ?", user.ID)
-	if err := query.All(t); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gobuffalo/buffalo/genny/build/_fixtures/coke/models"
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
@@ -111,7 +110,7 @@ func (t *Thread) GetPost(selectFields []string) (*Post, error) {
 		return nil, fmt.Errorf("error: PostID must be positive, got %v", t.PostID)
 	}
 	post := Post{}
-	if err := models.DB.Select(selectFields...).Find(&post, t.PostID); err != nil {
+	if err := DB.Select(selectFields...).Find(&post, t.PostID); err != nil {
 		return nil, fmt.Errorf("error loading post %v %s", t.PostID, err)
 	}
 	return &post, nil
@@ -119,7 +118,7 @@ func (t *Thread) GetPost(selectFields []string) (*Post, error) {
 
 func (t *Thread) GetMessages(selectFields []string) ([]*Message, error) {
 	var messages []*Message
-	if err := models.DB.Select(selectFields...).Where("thread_id = ?", t.ID).All(&messages); err != nil {
+	if err := DB.Select(selectFields...).Where("thread_id = ?", t.ID).All(&messages); err != nil {
 		return messages, fmt.Errorf("error getting messages for thread id %v ... %v", t.ID, err)
 	}
 
@@ -164,7 +163,7 @@ func (t *Thread) CreateWithParticipants(postUuid string, user User) error {
 		Participants: participants,
 	}
 
-	if err := models.DB.Save(&thread); err != nil {
+	if err := DB.Save(&thread); err != nil {
 		err = fmt.Errorf("error saving new thread for message: %v", err.Error())
 		return err
 	}

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -218,3 +218,14 @@ func (t *Thread) UnreadMessageCount(lastViewedAt time.Time) (int, error) {
 
 	return count, nil
 }
+
+// AllForUser finds all threads that given user is involved in.
+func (t *Threads) AllForUser(user User) error {
+	query := DB.Q().LeftJoin("thread_participants tp", "threads.id = tp.thread_id")
+	query = query.Where("tp.user_id = ?", user.ID)
+	if err := query.All(t); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -449,3 +449,15 @@ func (u *User) UnreadMessageCount() ([]UnreadThread, error) {
 
 	return unreads, nil
 }
+
+// GetThreads finds all threads that the user is participating in.
+func (u *User) GetThreads() (Threads, error) {
+	var t Threads
+	query := DB.Q().LeftJoin("thread_participants tp", "threads.id = tp.thread_id")
+	query = query.Where("tp.user_id = ?", u.ID)
+	if err := query.All(&t); err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -92,6 +92,11 @@ func (u *User) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
+// All retrieves all Users from the database.
+func (u *Users) All(selectFields ...string) error {
+	return DB.Select(selectFields...).All(u)
+}
+
 // CreateAccessToken - Create and store new UserAccessToken
 func (u *User) CreateAccessToken(org Organization, clientID string) (string, int64, error) {
 	if clientID == "" {

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -246,13 +246,13 @@ func (u *User) CanEditOrganization(orgId int) bool {
 	return false
 }
 
-func (u *User) FindByUUID(uuid string) error {
-
+// FindByUUID find a User with the given UUID and loads it from the database.
+func (u *User) FindByUUID(uuid string, selectFields ...string) error {
 	if uuid == "" {
 		return errors.New("error: uuid must not be blank")
 	}
 
-	if err := DB.Where("uuid = ?", uuid).First(u); err != nil {
+	if err := DB.Select(selectFields...).Where("uuid = ?", uuid).First(u); err != nil {
 		return fmt.Errorf("error finding user by uuid: %s", err.Error())
 	}
 

--- a/application/models/user_fixtures_test.go
+++ b/application/models/user_fixtures_test.go
@@ -2,10 +2,11 @@ package models
 
 import (
 	"fmt"
-	"github.com/gobuffalo/nulls"
-	"github.com/silinternational/wecarry-api/domain"
 	"testing"
 	"time"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/silinternational/wecarry-api/domain"
 )
 
 func CreateUserFixtures(ms *ModelSuite, t *testing.T) ([]Organization, Users, UserOrganizations) {
@@ -272,5 +273,53 @@ func CreateUserFixtures_UnreadMessageCount(ms *ModelSuite, t *testing.T) UserMes
 		Threads:            threads,
 		Messages:           messages,
 		ThreadParticipants: threadParticipants,
+	}
+}
+
+type UserFixtures struct {
+	Users
+	Threads
+}
+
+func CreateUserFixtures_GetThreads(ms *ModelSuite) UserFixtures {
+	unique := domain.GetUuid().String()
+
+	org := Organization{Uuid: domain.GetUuid(), AuthConfig: "{}"}
+	createFixture(ms, &org)
+
+	users := Users{
+		{Email: unique + "_user0@example.com", Nickname: unique + "_user0", Uuid: domain.GetUuid()},
+		{Email: unique + "_user1@example.com", Nickname: unique + "_user1", Uuid: domain.GetUuid()},
+	}
+	for i := range users {
+		createFixture(ms, &users[i])
+	}
+
+	posts := Posts{
+		{CreatedByID: users[0].ID, OrganizationID: org.ID, Uuid: domain.GetUuid()},
+	}
+	for i := range posts {
+		createFixture(ms, &posts[i])
+	}
+
+	threads := []Thread{
+		{Uuid: domain.GetUuid(), PostID: posts[0].ID},
+		{Uuid: domain.GetUuid(), PostID: posts[0].ID},
+	}
+	for i := range threads {
+		createFixture(ms, &threads[i])
+	}
+
+	threadParticipants := []ThreadParticipant{
+		{ThreadID: threads[0].ID, UserID: users[0].ID},
+		{ThreadID: threads[1].ID, UserID: users[0].ID},
+	}
+	for i := range threadParticipants {
+		createFixture(ms, &threadParticipants[i])
+	}
+
+	return UserFixtures{
+		Users:   users,
+		Threads: threads,
 	}
 }

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -747,3 +747,30 @@ func (ms *ModelSuite) TestUser_UnreadMessageCount() {
 		})
 	}
 }
+
+func (ms *ModelSuite) TestUser_GetThreads() {
+	t := ms.T()
+
+	f := CreateUserFixtures_GetThreads(ms)
+
+	tests := []struct {
+		name string
+		user User
+		want []uuid.UUID
+	}{
+		{name: "no threads", user: f.Users[1], want: []uuid.UUID{}},
+		{name: "two threads", user: f.Users[0], want: []uuid.UUID{f.Threads[0].Uuid, f.Threads[1].Uuid}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.user.GetThreads()
+			ms.NoError(err)
+
+			ids := make([]uuid.UUID, len(got))
+			for i := range got {
+				ids[i] = got[i].Uuid
+			}
+			ms.Equal(test.want, ids, "incorrect list of threads returned")
+		})
+	}
+}


### PR DESCRIPTION
Removed all instances of `models.DB` with specific method calls. Did not create test functions in most cases, since these are mostly thin wrappers for Pop code.

Also updated gqlgen.