### PR TITLE
use gqlgen config to simplify object slices

### DIFF
--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -184,8 +184,8 @@ type MutationResolver interface {
 	CreateMessage(ctx context.Context, input CreateMessageInput) (*models.Message, error)
 	CreateOrganization(ctx context.Context, input CreateOrganizationInput) (*models.Organization, error)
 	UpdateOrganization(ctx context.Context, input UpdateOrganizationInput) (*models.Organization, error)
-	CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]*models.OrganizationDomain, error)
-	RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]*models.OrganizationDomain, error)
+	CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error)
+	RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]models.OrganizationDomain, error)
 	SetThreadLastViewedAt(ctx context.Context, input SetThreadLastViewedAtInput) (*models.Thread, error)
 }
 type OrganizationResolver interface {
@@ -193,7 +193,7 @@ type OrganizationResolver interface {
 
 	URL(ctx context.Context, obj *models.Organization) (*string, error)
 
-	Domains(ctx context.Context, obj *models.Organization) ([]*models.OrganizationDomain, error)
+	Domains(ctx context.Context, obj *models.Organization) ([]models.OrganizationDomain, error)
 }
 type PostResolver interface {
 	ID(ctx context.Context, obj *models.Post) (string, error)
@@ -210,26 +210,26 @@ type PostResolver interface {
 	NeededAfter(ctx context.Context, obj *models.Post) (*string, error)
 	NeededBefore(ctx context.Context, obj *models.Post) (*string, error)
 
-	Threads(ctx context.Context, obj *models.Post) ([]*models.Thread, error)
+	Threads(ctx context.Context, obj *models.Post) ([]models.Thread, error)
 
 	URL(ctx context.Context, obj *models.Post) (*string, error)
 	Cost(ctx context.Context, obj *models.Post) (*string, error)
 	Photo(ctx context.Context, obj *models.Post) (*models.File, error)
-	Files(ctx context.Context, obj *models.Post) ([]*models.File, error)
+	Files(ctx context.Context, obj *models.Post) ([]models.File, error)
 }
 type QueryResolver interface {
-	Users(ctx context.Context) ([]*models.User, error)
+	Users(ctx context.Context) ([]models.User, error)
 	User(ctx context.Context, id *string) (*models.User, error)
-	Posts(ctx context.Context) ([]*models.Post, error)
+	Posts(ctx context.Context) ([]models.Post, error)
 	Post(ctx context.Context, id *string) (*models.Post, error)
-	Threads(ctx context.Context) ([]*models.Thread, error)
-	MyThreads(ctx context.Context) ([]*models.Thread, error)
+	Threads(ctx context.Context) ([]models.Thread, error)
+	MyThreads(ctx context.Context) ([]models.Thread, error)
 	Message(ctx context.Context, id *string) (*models.Message, error)
 }
 type ThreadResolver interface {
 	ID(ctx context.Context, obj *models.Thread) (string, error)
-	Participants(ctx context.Context, obj *models.Thread) ([]*models.User, error)
-	Messages(ctx context.Context, obj *models.Thread) ([]*models.Message, error)
+	Participants(ctx context.Context, obj *models.Thread) ([]models.User, error)
+	Messages(ctx context.Context, obj *models.Thread) ([]models.Message, error)
 	PostID(ctx context.Context, obj *models.Thread) (string, error)
 	Post(ctx context.Context, obj *models.Thread) (*models.Post, error)
 	LastViewedAt(ctx context.Context, obj *models.Thread) (*time.Time, error)
@@ -240,8 +240,8 @@ type UserResolver interface {
 	ID(ctx context.Context, obj *models.User) (string, error)
 
 	AdminRole(ctx context.Context, obj *models.User) (*Role, error)
-	Organizations(ctx context.Context, obj *models.User) ([]*models.Organization, error)
-	Posts(ctx context.Context, obj *models.User, role PostRole) ([]*models.Post, error)
+	Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error)
+	Posts(ctx context.Context, obj *models.User, role PostRole) ([]models.Post, error)
 	PhotoURL(ctx context.Context, obj *models.User) (string, error)
 	Location(ctx context.Context, obj *models.User) (*models.Location, error)
 	UnreadMessageCount(ctx context.Context, obj *models.User) (int, error)
@@ -964,12 +964,12 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 
 var parsedSchema = gqlparser.MustLoadSchema(
 	&ast.Source{Name: "schema.graphql", Input: `type Query {
-    users: [User]!
+    users: [User!]!
     user(id: ID): User
-    posts: [Post]!
+    posts: [Post!]!
     post(id: ID): Post
-    threads: [Thread]!
-    myThreads: [Thread]!
+    threads: [Thread!]!
+    myThreads: [Thread!]!
     message(id: ID): Message!
 }
 
@@ -1058,7 +1058,7 @@ type Post {
     neededBefore: String
     category: String!
     status: String!
-    threads: [Thread]!
+    threads: [Thread!]!
     createdAt: Time!
     updatedAt: Time!
     url: String
@@ -2321,10 +2321,10 @@ func (ec *executionContext) _Mutation_createOrganizationDomain(ctx context.Conte
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.OrganizationDomain)
+	res := resTmp.([]models.OrganizationDomain)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganizationDomain2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
+	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_removeOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2365,10 +2365,10 @@ func (ec *executionContext) _Mutation_removeOrganizationDomain(ctx context.Conte
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.OrganizationDomain)
+	res := resTmp.([]models.OrganizationDomain)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganizationDomain2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
+	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_setThreadLastViewedAt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2628,10 +2628,10 @@ func (ec *executionContext) _Organization_domains(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.OrganizationDomain)
+	res := resTmp.([]models.OrganizationDomain)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganizationDomain2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
+	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _OrganizationDomain_domain(ctx context.Context, field graphql.CollectedField, obj *models.OrganizationDomain) (ret graphql.Marshaler) {
@@ -3270,10 +3270,10 @@ func (ec *executionContext) _Post_threads(ctx context.Context, field graphql.Col
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Thread)
+	res := resTmp.([]models.Thread)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNThread2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
+	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Post_createdAt(ctx context.Context, field graphql.CollectedField, obj *models.Post) (ret graphql.Marshaler) {
@@ -3483,10 +3483,10 @@ func (ec *executionContext) _Post_files(ctx context.Context, field graphql.Colle
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.File)
+	res := resTmp.([]models.File)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNFile2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx, field.Selections, res)
+	return ec.marshalNFile2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_users(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -3520,10 +3520,10 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.User)
+	res := resTmp.([]models.User)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_user(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -3598,10 +3598,10 @@ func (ec *executionContext) _Query_posts(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Post)
+	res := resTmp.([]models.Post)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNPost2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
+	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_post(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -3676,10 +3676,10 @@ func (ec *executionContext) _Query_threads(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Thread)
+	res := resTmp.([]models.Thread)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNThread2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
+	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_myThreads(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -3713,10 +3713,10 @@ func (ec *executionContext) _Query_myThreads(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Thread)
+	res := resTmp.([]models.Thread)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNThread2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
+	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_message(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -3906,10 +3906,10 @@ func (ec *executionContext) _Thread_participants(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.User)
+	res := resTmp.([]models.User)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalNUser2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Thread_messages(ctx context.Context, field graphql.CollectedField, obj *models.Thread) (ret graphql.Marshaler) {
@@ -3943,10 +3943,10 @@ func (ec *executionContext) _Thread_messages(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Message)
+	res := resTmp.([]models.Message)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMessage2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
+	return ec.marshalNMessage2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Thread_postID(ctx context.Context, field graphql.CollectedField, obj *models.Thread) (ret graphql.Marshaler) {
@@ -4421,10 +4421,10 @@ func (ec *executionContext) _User_organizations(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Organization)
+	res := resTmp.([]models.Organization)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+	return ec.marshalNOrganization2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_posts(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
@@ -4465,10 +4465,10 @@ func (ec *executionContext) _User_posts(ctx context.Context, field graphql.Colle
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*models.Post)
+	res := resTmp.([]models.Post)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNPost2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
+	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_photoURL(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
@@ -7454,7 +7454,7 @@ func (ec *executionContext) marshalNFile2githubᚗcomᚋsilinternationalᚋwecar
 	return ec._File(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx context.Context, sel ast.SelectionSet, v []*models.File) graphql.Marshaler {
+func (ec *executionContext) marshalNFile2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx context.Context, sel ast.SelectionSet, v []models.File) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -7478,7 +7478,7 @@ func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋsilinternational�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNFile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx, sel, v[i])
+			ret[i] = ec.marshalNFile2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -7489,16 +7489,6 @@ func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋsilinternational�
 	}
 	wg.Wait()
 	return ret
-}
-
-func (ec *executionContext) marshalNFile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐFile(ctx context.Context, sel ast.SelectionSet, v *models.File) graphql.Marshaler {
-	if v == nil {
-		if !ec.HasError(graphql.GetResolverContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._File(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNID2int(ctx context.Context, v interface{}) (int, error) {
@@ -7577,7 +7567,7 @@ func (ec *executionContext) marshalNMessage2githubᚗcomᚋsilinternationalᚋwe
 	return ec._Message(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNMessage2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx context.Context, sel ast.SelectionSet, v []*models.Message) graphql.Marshaler {
+func (ec *executionContext) marshalNMessage2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx context.Context, sel ast.SelectionSet, v []models.Message) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -7601,7 +7591,7 @@ func (ec *executionContext) marshalNMessage2ᚕᚖgithubᚗcomᚋsilinternationa
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNMessage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, sel, v[i])
+			ret[i] = ec.marshalNMessage2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -7628,7 +7618,7 @@ func (ec *executionContext) marshalNOrganization2githubᚗcomᚋsilinternational
 	return ec._Organization(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNOrganization2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx context.Context, sel ast.SelectionSet, v []*models.Organization) graphql.Marshaler {
+func (ec *executionContext) marshalNOrganization2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx context.Context, sel ast.SelectionSet, v []models.Organization) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -7652,7 +7642,7 @@ func (ec *executionContext) marshalNOrganization2ᚕᚖgithubᚗcomᚋsilinterna
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, sel, v[i])
+			ret[i] = ec.marshalNOrganization2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -7679,7 +7669,7 @@ func (ec *executionContext) marshalNOrganizationDomain2githubᚗcomᚋsilinterna
 	return ec._OrganizationDomain(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNOrganizationDomain2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx context.Context, sel ast.SelectionSet, v []*models.OrganizationDomain) graphql.Marshaler {
+func (ec *executionContext) marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx context.Context, sel ast.SelectionSet, v []models.OrganizationDomain) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -7703,7 +7693,7 @@ func (ec *executionContext) marshalNOrganizationDomain2ᚕᚖgithubᚗcomᚋsili
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNOrganizationDomain2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, sel, v[i])
+			ret[i] = ec.marshalNOrganizationDomain2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -7716,21 +7706,11 @@ func (ec *executionContext) marshalNOrganizationDomain2ᚕᚖgithubᚗcomᚋsili
 	return ret
 }
 
-func (ec *executionContext) marshalNOrganizationDomain2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx context.Context, sel ast.SelectionSet, v *models.OrganizationDomain) graphql.Marshaler {
-	if v == nil {
-		if !ec.HasError(graphql.GetResolverContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._OrganizationDomain(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNPost2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx context.Context, sel ast.SelectionSet, v models.Post) graphql.Marshaler {
 	return ec._Post(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNPost2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx context.Context, sel ast.SelectionSet, v []*models.Post) graphql.Marshaler {
+func (ec *executionContext) marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx context.Context, sel ast.SelectionSet, v []models.Post) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -7754,7 +7734,7 @@ func (ec *executionContext) marshalNPost2ᚕᚖgithubᚗcomᚋsilinternational�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNPost2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, sel, v[i])
+			ret[i] = ec.marshalNPost2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -7884,7 +7864,7 @@ func (ec *executionContext) marshalNThread2githubᚗcomᚋsilinternationalᚋwec
 	return ec._Thread(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNThread2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx context.Context, sel ast.SelectionSet, v []*models.Thread) graphql.Marshaler {
+func (ec *executionContext) marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx context.Context, sel ast.SelectionSet, v []models.Thread) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -7908,7 +7888,7 @@ func (ec *executionContext) marshalNThread2ᚕᚖgithubᚗcomᚋsilinternational
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalOThread2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, sel, v[i])
+			ret[i] = ec.marshalNThread2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -7979,7 +7959,7 @@ func (ec *executionContext) marshalNUser2githubᚗcomᚋsilinternationalᚋwecar
 	return ec._User(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx context.Context, sel ast.SelectionSet, v []*models.User) graphql.Marshaler {
+func (ec *executionContext) marshalNUser2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx context.Context, sel ast.SelectionSet, v []models.User) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -8003,7 +7983,7 @@ func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋsilinternational�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, sel, v[i])
+			ret[i] = ec.marshalNUser2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -8470,17 +8450,6 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return ec.marshalOString2string(ctx, sel, *v)
-}
-
-func (ec *executionContext) marshalOThread2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx context.Context, sel ast.SelectionSet, v models.Thread) graphql.Marshaler {
-	return ec._Thread(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalOThread2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx context.Context, sel ast.SelectionSet, v *models.Thread) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Thread(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOUser2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx context.Context, sel ast.SelectionSet, v models.User) graphql.Marshaler {

--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -12,6 +12,7 @@ model:
 resolver:
   filename: resolver.go
   type: Resolver
+omit_slice_element_pointers: true
 autobind:
   - github.com/silinternational/wecarry-api/models
   - github.com/silinternational/wecarry-api/gqlgen

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -69,54 +69,44 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 	return &org, err
 }
 
-func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]*models.OrganizationDomain, error) {
+func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error) {
 	var org models.Organization
 	err := org.FindByUUID(input.OrganizationID)
 	if err != nil {
-		return []*models.OrganizationDomain{}, err
+		return nil, err
 	}
 
 	cUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 	if !cUser.CanEditOrganization(org.ID) {
-		return []*models.OrganizationDomain{}, errors.New("user not allowed to edit organizations")
+		return nil, errors.New("user not allowed to edit organizations")
 	}
 
 	err = org.AddDomain(input.Domain)
 	if err != nil {
-		return []*models.OrganizationDomain{}, err
+		return nil, err
 	}
 
-	orgDomains := make([]*models.OrganizationDomain, len(org.OrganizationDomains))
-	for i, od := range org.OrganizationDomains {
-		orgDomains[i] = &od
-	}
-
-	return orgDomains, nil
+	return org.OrganizationDomains, nil
 }
 
-func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]*models.OrganizationDomain, error) {
+func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]models.OrganizationDomain, error) {
 	var org models.Organization
 	err := org.FindByUUID(input.OrganizationID)
 	if err != nil {
-		return []*models.OrganizationDomain{}, err
+		return nil, err
 	}
 
 	cUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 	if !cUser.CanEditOrganization(org.ID) {
-		return []*models.OrganizationDomain{}, errors.New("user not allowed to edit organizations")
+		return nil, errors.New("user not allowed to edit organizations")
 	}
 
 	err = org.RemoveDomain(input.Domain)
 	if err != nil {
-		return []*models.OrganizationDomain{}, err
+		return nil, err
 	}
 
-	orgDomains := make([]*models.OrganizationDomain, len(org.OrganizationDomains))
-	for i, od := range org.OrganizationDomains {
-		orgDomains[i] = &od
-	}
-
-	return orgDomains, nil
+	return org.OrganizationDomains, nil
 }
 
 // SetThreadLastViewedAt sets the last viewed time for the current user on the given thread

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -40,7 +40,7 @@ func (r *organizationResolver) URL(ctx context.Context, obj *models.Organization
 	return GetStringFromNullsString(obj.Url), nil
 }
 
-func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organization) ([]*models.OrganizationDomain, error) {
+func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organization) ([]models.OrganizationDomain, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -51,11 +51,7 @@ func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organiza
 		return nil, err
 	}
 
-	dp := make([]*models.OrganizationDomain, len(domains))
-	for i, d := range domains {
-		dp[i] = &d
-	}
-	return dp, nil
+	return domains, nil
 }
 
 func getSelectFieldsForOrganizations(ctx context.Context) []string {

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -130,7 +130,7 @@ func (r *postResolver) NeededBefore(ctx context.Context, obj *models.Post) (*str
 	return domain.ConvertTimeToStringPtr(obj.NeededBefore), nil
 }
 
-func (r *postResolver) Threads(ctx context.Context, obj *models.Post) ([]*models.Thread, error) {
+func (r *postResolver) Threads(ctx context.Context, obj *models.Post) ([]models.Thread, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -165,28 +165,24 @@ func (r *postResolver) Photo(ctx context.Context, obj *models.Post) (*models.Fil
 }
 
 // Files retrieves the list of files attached to the post, not including the primary photo
-func (r *postResolver) Files(ctx context.Context, obj *models.Post) ([]*models.File, error) {
+func (r *postResolver) Files(ctx context.Context, obj *models.Post) ([]models.File, error) {
 	if obj == nil {
 		return nil, nil
 	}
 	return obj.GetFiles()
 }
 
-func (r *queryResolver) Posts(ctx context.Context) ([]*models.Post, error) {
+func (r *queryResolver) Posts(ctx context.Context) ([]models.Post, error) {
 	posts := models.Posts{}
 	cUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 	selectFields := getSelectFieldsForPosts(ctx)
 	if err := posts.FindByUser(ctx, cUser, selectFields...); err != nil {
 		graphql.AddError(ctx, gqlerror.Errorf("Error getting posts: %v", err.Error()))
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return []*models.Post{}, err
+		return nil, err
 	}
 
-	pp := make([]*models.Post, len(posts))
-	for i := range posts {
-		pp[i] = &(posts[i])
-	}
-	return pp, nil
+	return posts, nil
 }
 
 func (r *queryResolver) Post(ctx context.Context, id *string) (*models.Post, error) {

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -1,10 +1,10 @@
 type Query {
-    users: [User]!
+    users: [User!]!
     user(id: ID): User
-    posts: [Post]!
+    posts: [Post!]!
     post(id: ID): Post
-    threads: [Thread]!
-    myThreads: [Thread]!
+    threads: [Thread!]!
+    myThreads: [Thread!]!
     message(id: ID): Message!
 }
 
@@ -93,7 +93,7 @@ type Post {
     neededBefore: String
     category: String!
     status: String!
-    threads: [Thread]!
+    threads: [Thread!]!
     createdAt: Time!
     updatedAt: Time!
     url: String

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -25,7 +25,7 @@ func (r *Resolver) Thread() ThreadResolver {
 
 type threadResolver struct{ *Resolver }
 
-func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) ([]*models.User, error) {
+func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) ([]models.User, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -47,7 +47,7 @@ func (r *threadResolver) LastViewedAt(ctx context.Context, obj *models.Thread) (
 	return obj.GetLastViewedAt(models.GetCurrentUserFromGqlContext(ctx, TestUser))
 }
 
-func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]*models.Message, error) {
+func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]models.Message, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -98,33 +98,25 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 	return count, nil
 }
 
-func (r *queryResolver) Threads(ctx context.Context) ([]*models.Thread, error) {
-	dbThreads := models.Threads{}
-	if err := dbThreads.All(getSelectFieldsForThreads(ctx)...); err != nil {
+func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
+	threads := models.Threads{}
+	if err := threads.All(getSelectFieldsForThreads(ctx)...); err != nil {
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return []*models.Thread{}, fmt.Errorf("error getting threads: %v", err)
+		return nil, fmt.Errorf("error getting threads: %v", err)
 	}
 
-	threads := make([]*models.Thread, len(dbThreads))
-	for i := range dbThreads {
-		threads[i] = &dbThreads[i]
-	}
 	return threads, nil
 }
 
-func (r *queryResolver) MyThreads(ctx context.Context) ([]*models.Thread, error) {
+func (r *queryResolver) MyThreads(ctx context.Context) ([]models.Thread, error) {
 	currentUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 
-	dbThreads, err := currentUser.GetThreads()
+	threads, err := currentUser.GetThreads()
 	if err != nil {
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return []*models.Thread{}, fmt.Errorf("error getting threads: %v", err)
+		return nil, fmt.Errorf("error getting threads: %v", err)
 	}
 
-	threads := make([]*models.Thread, len(dbThreads))
-	for i := range dbThreads {
-		threads[i] = &dbThreads[i]
-	}
 	return threads, nil
 }
 

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -55,14 +55,14 @@ func (r *userResolver) AdminRole(ctx context.Context, obj *models.User) (*Role, 
 	return &a, nil
 }
 
-func (r *userResolver) Organizations(ctx context.Context, obj *models.User) ([]*models.Organization, error) {
+func (r *userResolver) Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error) {
 	if obj == nil {
 		return nil, nil
 	}
 	return obj.GetOrganizations()
 }
 
-func (r *userResolver) Posts(ctx context.Context, obj *models.User, role PostRole) ([]*models.Post, error) {
+func (r *userResolver) Posts(ctx context.Context, obj *models.User, role PostRole) ([]models.Post, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -103,26 +103,22 @@ func (r *userResolver) UnreadMessageCount(ctx context.Context, obj *models.User)
 	return total, nil
 }
 
-func (r *queryResolver) Users(ctx context.Context) ([]*models.User, error) {
+func (r *queryResolver) Users(ctx context.Context) ([]models.User, error) {
 	currentUser := models.GetCurrentUserFromGqlContext(ctx, TestUser)
 
 	if currentUser.AdminRole.String != domain.AdminRoleSuperDuperAdmin {
 		err := errors.New("not authorized")
 		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return []*models.User{}, err
+		return nil, err
 	}
 
-	dbUsers := models.Users{}
-	if err := dbUsers.All(GetSelectFieldsForUsers(ctx)...); err != nil {
+	users := models.Users{}
+	if err := users.All(GetSelectFieldsForUsers(ctx)...); err != nil {
 		graphql.AddError(ctx, gqlerror.Errorf("Error getting users: %v", err.Error()))
 		domain.Error(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
-		return []*models.User{}, err
+		return nil, err
 	}
 
-	users := make([]*models.User, len(dbUsers))
-	for i := range dbUsers {
-		users[i] = &dbUsers[i]
-	}
 	return users, nil
 }
 

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -345,12 +345,12 @@ func (p *Post) GetOrganization(fields []string) (*Organization, error) {
 }
 
 // GetThreads finds all threads on this post in which the given user is participating
-func (p *Post) GetThreads(fields []string, user User) ([]*Thread, error) {
+func (p *Post) GetThreads(fields []string, user User) ([]Thread, error) {
 	if err := DB.Load(p, "Threads"); err != nil {
 		return nil, fmt.Errorf("error getting threads for post id %v ... %v", p.ID, err)
 	}
 
-	var threads []*Thread
+	var threads []Thread
 	for i, t := range p.Threads {
 		if err := DB.Load(&t, "Participants"); err != nil {
 			return nil, fmt.Errorf("error getting participants for thread id %v ... %v", t.ID, err)
@@ -358,7 +358,7 @@ func (p *Post) GetThreads(fields []string, user User) ([]*Thread, error) {
 
 		for _, participant := range t.Participants {
 			if participant.ID == user.ID {
-				threads = append(threads, &p.Threads[i])
+				threads = append(threads, p.Threads[i])
 				break
 			}
 		}
@@ -382,16 +382,16 @@ func (p *Post) AttachFile(fileID string) (File, error) {
 }
 
 // GetFiles retrieves the metadata for all of the files attached to this Post
-func (p *Post) GetFiles() ([]*File, error) {
+func (p *Post) GetFiles() ([]File, error) {
 	var pf []*PostFile
 
 	if err := DB.Eager("File").Select().Where("post_id = ?", p.ID).All(&pf); err != nil {
 		return nil, fmt.Errorf("error getting files for post id %d, %s", p.ID, err)
 	}
 
-	files := make([]*File, len(pf))
+	files := make([]File, len(pf))
 	for i, p := range pf {
-		files[i] = &p.File
+		files[i] = p.File
 		if err := files[i].RefreshURL(); err != nil {
 			return files, err
 		}

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -90,8 +90,8 @@ func (t *Thread) GetPost(selectFields []string) (*Post, error) {
 	return &post, nil
 }
 
-func (t *Thread) GetMessages(selectFields []string) ([]*Message, error) {
-	var messages []*Message
+func (t *Thread) GetMessages(selectFields []string) ([]Message, error) {
+	var messages []Message
 	if err := DB.Select(selectFields...).Where("thread_id = ?", t.ID).All(&messages); err != nil {
 		return messages, fmt.Errorf("error getting messages for thread id %v ... %v", t.ID, err)
 	}
@@ -99,8 +99,8 @@ func (t *Thread) GetMessages(selectFields []string) ([]*Message, error) {
 	return messages, nil
 }
 
-func (t *Thread) GetParticipants(selectFields []string) ([]*User, error) {
-	var users []*User
+func (t *Thread) GetParticipants(selectFields []string) ([]User, error) {
+	var users []User
 	var threadParticipants []*ThreadParticipant
 
 	if err := DB.Where("thread_id = ?", t.ID).Order("id asc").All(&threadParticipants); err != nil {
@@ -113,7 +113,7 @@ func (t *Thread) GetParticipants(selectFields []string) ([]*User, error) {
 		if err := DB.Select(selectFields...).Find(&u, tp.UserID); err != nil {
 			return users, fmt.Errorf("error finding users on thread %v ... %v", t.ID, err)
 		}
-		users = append(users, &u)
+		users = append(users, u)
 	}
 	return users, nil
 }

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -264,17 +264,12 @@ func HashClientIdAccessToken(accessToken string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(accessToken)))
 }
 
-func (u *User) GetOrganizations() ([]*Organization, error) {
+func (u *User) GetOrganizations() ([]Organization, error) {
 	if err := DB.Load(u, "Organizations"); err != nil {
-		return []*Organization{}, fmt.Errorf("error getting organizations for user id %v ... %v", u.ID, err)
+		return nil, fmt.Errorf("error getting organizations for user id %v ... %v", u.ID, err)
 	}
 
-	orgs := make([]*Organization, len(u.Organizations))
-	for i := range u.Organizations {
-		orgs[i] = &u.Organizations[i]
-	}
-
-	return orgs, nil
+	return u.Organizations, nil
 }
 
 func (u *User) FindUserOrganization(org Organization) (UserOrganization, error) {
@@ -286,10 +281,9 @@ func (u *User) FindUserOrganization(org Organization) (UserOrganization, error) 
 	return userOrg, nil
 }
 
-func (u *User) GetPosts(postRole string) ([]*Post, error) {
-	var postPtrs []*Post
+func (u *User) GetPosts(postRole string) ([]Post, error) {
 	if err := DB.Load(u, postRole); err != nil {
-		return postPtrs, fmt.Errorf("error getting posts for user id %v ... %v", u.ID, err)
+		return nil, fmt.Errorf("error getting posts for user id %v ... %v", u.ID, err)
 	}
 
 	var posts Posts
@@ -304,12 +298,7 @@ func (u *User) GetPosts(postRole string) ([]*Post, error) {
 		posts = u.PostsProviding
 	}
 
-	for _, p := range posts {
-		p1 := p
-		postPtrs = append(postPtrs, &p1)
-	}
-
-	return postPtrs, nil
+	return posts, nil
 }
 
 // AttachPhoto assigns a previously-stored File to this User as a profile photo


### PR DESCRIPTION
New config option `omit_slice_element_pointers` modifies generated interfaces so that resolver methods return slices of objects rather that slices of pointers to objects. This results in simpler resolver implementation because Pop typically provides slices of objects. Also found and fixed a couple bugs related to the way slice elements were copied.

Also note that the schema had to change slightly because of a gqlgen [bug](https://github.com/99designs/gqlgen/issues/915).