### PR TITLE
Get correct org ID

### DIFF
--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -24,6 +24,9 @@ models:
         resolver: true
   OrganizationDomain:
     model: models.OrganizationDomain
+    fields:
+      organizationID:
+        resolver: true
   User:
     model: models.User
     fields:

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -86,7 +86,7 @@ func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input C
 		return nil, err
 	}
 
-	return org.OrganizationDomains, nil
+	return org.GetDomains()
 }
 
 func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]models.OrganizationDomain, error) {
@@ -106,7 +106,7 @@ func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input R
 		return nil, err
 	}
 
-	return org.OrganizationDomains, nil
+	return org.GetDomains()
 }
 
 // SetThreadLastViewedAt sets the last viewed time for the current user on the given thread

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -90,7 +90,13 @@ func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input C
 		return nil, reportError(ctx, err, "CreateOrganizationDomain", extras)
 	}
 
-	return org.GetDomains()
+	domains, err2 := org.GetDomains()
+	if err2 != nil {
+		// don't return an error since the AddDomain operation succeeded
+		_ = reportError(ctx, err2, "", extras)
+	}
+
+	return domains, nil
 }
 
 // RemoveOrganizationDomain is the resolver for the `removeOrganizationDomain` mutation
@@ -114,7 +120,13 @@ func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input R
 		return nil, reportError(ctx, err, "RemoveOrganizationDomain", extras)
 	}
 
-	return org.GetDomains()
+	domains, err2 := org.GetDomains()
+	if err2 != nil {
+		// don't return an error since the RemoveDomain operation succeeded
+		_ = reportError(ctx, err2, "", extras)
+	}
+
+	return domains, nil
 }
 
 // SetThreadLastViewedAt sets the last viewed time for the current user on the given thread

--- a/application/gqlgen/organization_test.go
+++ b/application/gqlgen/organization_test.go
@@ -1,0 +1,99 @@
+package gqlgen
+
+import (
+	"fmt"
+
+	"github.com/gobuffalo/nulls"
+	"github.com/silinternational/wecarry-api/domain"
+	"github.com/silinternational/wecarry-api/models"
+)
+
+// OrganizationResponse is for marshalling Organization query and mutation responses
+type OrganizationResponse struct {
+	Organization struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		URL       string `json:"url"`
+		CreatedAt string `json:"createdAt"`
+		UpdatedAt string `json:"updatedAt"`
+		Domains   []struct {
+			Domain         string `json:"domain"`
+			OrganizationID string `json:"organizationID"`
+		} `json:"domains"`
+	} `json:"organization"`
+}
+
+// OrganizationFixtures is for returning fixtures from Fixtures_UserQuery
+type OrganizationFixtures struct {
+	models.Organizations
+	models.Users
+}
+
+// Fixtures_CreateOrganization creates fixtures for Test_CreateOrganization
+func Fixtures_CreateOrganization(gs *GqlgenSuite) OrganizationFixtures {
+	org := models.Organization{
+		Name:       "Acme",
+		Url:        nulls.NewString("example.com"),
+		AuthType:   "saml",
+		AuthConfig: "{}",
+	}
+	// Don't save to the database, that's for the test to do.
+
+	unique := domain.GetUuid().String()
+	users := models.Users{
+		{
+			Uuid:      domain.GetUuid(),
+			Email:     unique + "_user1@example.com",
+			Nickname:  unique + " User1",
+			AdminRole: nulls.NewString(domain.AdminRoleSuperDuperAdmin),
+		},
+	}
+	for i := range users {
+		createFixture(gs, &users[i])
+	}
+
+	return OrganizationFixtures{
+		Users:         users,
+		Organizations: models.Organizations{org},
+	}
+}
+
+// Test_CreateOrganization tests the CreateOrganization GraphQL mutation
+func (gs *GqlgenSuite) Test_CreateOrganization() {
+	f := Fixtures_CreateOrganization(gs)
+	c := getGqlClient()
+
+	var resp OrganizationResponse
+
+	allFieldsQuery := `id domains { domain organizationID } name url`
+	allFieldsInput := fmt.Sprintf(
+		`name:"%s" url:"%s" authType:"%s" authConfig:"%s"`,
+		f.Organizations[0].Name,
+		f.Organizations[0].Url.String,
+		f.Organizations[0].AuthType,
+		f.Organizations[0].AuthConfig)
+
+	TestUser = f.Users[0]
+	err := c.Post(fmt.Sprintf("mutation{organization: createOrganization(input: {%s}) {%s}}",
+		allFieldsInput, allFieldsQuery), &resp)
+	gs.NoError(err)
+
+	gs.Equal(f.Organizations[0].Name, resp.Organization.Name, "received wrong name")
+	gs.Equal(f.Organizations[0].Url.String, resp.Organization.URL, "received wrong URL")
+	gs.Equal(0, len(resp.Organization.Domains))
+
+	var orgs models.Organizations
+	err = gs.DB.Where("name = ?", f.Organizations[0].Name).All(&orgs)
+	gs.NoError(err)
+
+	gs.GreaterOrEqual(1, len(orgs), "no Organization record created")
+	gs.Equal(f.Organizations[0].Name, orgs[0].Name, "Name doesn't match")
+	gs.Equal(f.Organizations[0].Url, orgs[0].Url, "URL doesn't match")
+	gs.Equal(f.Organizations[0].AuthType, orgs[0].AuthType, "AuthType doesn't match")
+	gs.Equal(f.Organizations[0].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
+
+	domains, _ := orgs[0].GetDomains()
+	gs.Equal(0, len(domains), "new organization has unexpected domains")
+
+	gs.Equal(resp.Organization.ID, orgs[0].Uuid.String(), "UUID doesn't match")
+}

--- a/application/gqlgen/organizationdomain.go
+++ b/application/gqlgen/organizationdomain.go
@@ -26,5 +26,11 @@ func (r *organizationDomainResolver) OrganizationID(ctx context.Context, obj *mo
 	if obj == nil {
 		return "", nil
 	}
-	return obj.GetOrganizationUUID()
+
+	id, err := obj.GetOrganizationUUID()
+	if err != nil {
+		return "", reportError(ctx, err, "GetOrganizationDomainOrganizationID")
+	}
+
+	return id, nil
 }

--- a/application/gqlgen/organizationdomain.go
+++ b/application/gqlgen/organizationdomain.go
@@ -1,0 +1,30 @@
+package gqlgen
+
+import (
+	"context"
+
+	"github.com/silinternational/wecarry-api/models"
+)
+
+// OrganizationDomainFields maps GraphQL fields to their equivalent database fields.
+func OrganizationDomainFields() map[string]string {
+	return map[string]string{
+		"organizationID": "organization_id",
+		"domain":         "domain",
+	}
+}
+
+// OrganizationDomain is required by gqlgen
+func (r *Resolver) OrganizationDomain() OrganizationDomainResolver {
+	return &organizationDomainResolver{r}
+}
+
+type organizationDomainResolver struct{ *Resolver }
+
+// OrganizationID converts the organization's autoincrement ID to its UUID
+func (r *organizationDomainResolver) OrganizationID(ctx context.Context, obj *models.OrganizationDomain) (string, error) {
+	if obj == nil {
+		return "", nil
+	}
+	return obj.GetOrganizationUUID()
+}

--- a/application/gqlgen/organizationdomain_test.go
+++ b/application/gqlgen/organizationdomain_test.go
@@ -1,0 +1,85 @@
+package gqlgen
+
+import (
+	"fmt"
+
+	"github.com/silinternational/wecarry-api/domain"
+	"github.com/silinternational/wecarry-api/models"
+)
+
+type OrganizationDomainFixtures struct {
+	models.Organization
+	models.Users
+}
+
+type OrganizationDomainResponse struct {
+	OrganizationDomain []struct {
+		ID     string `json:"organizationID"`
+		Domain string `json:"domain"`
+	} `json:"organizationDomain"`
+}
+
+func createFixtures_OrganizationDomain(gs *GqlgenSuite) OrganizationDomainFixtures {
+	org := models.Organization{Uuid: domain.GetUuid(), AuthConfig: "{}"}
+	createFixture(gs, &org)
+
+	unique := org.Uuid.String()
+	users := models.Users{
+		{Email: unique + "_user@example.com", Nickname: unique + " User ", Uuid: domain.GetUuid()},
+		{Email: unique + "_admin@example.com", Nickname: unique + " Admin ", Uuid: domain.GetUuid()},
+	}
+	for i := range users {
+		createFixture(gs, &(users[i]))
+	}
+
+	userOrgs := models.UserOrganizations{
+		{
+			OrganizationID: org.ID,
+			UserID:         users[0].ID,
+			Role:           "user",
+			AuthID:         users[0].Email,
+			AuthEmail:      users[0].Email,
+		},
+		{
+			OrganizationID: org.ID,
+			UserID:         users[1].ID,
+			Role:           "admin",
+			AuthID:         users[1].Email,
+			AuthEmail:      users[1].Email,
+		},
+	}
+	for i := range userOrgs {
+		createFixture(gs, &(userOrgs[i]))
+	}
+
+	return OrganizationDomainFixtures{
+		Organization: org,
+		Users:        users,
+	}
+}
+
+func (gs *GqlgenSuite) Test_CreateOrganizationDomain() {
+	f := createFixtures_OrganizationDomain(gs)
+	c := getGqlClient()
+
+	input := `organizationID: "` + f.Organization.Uuid.String() + `" 
+		domain: "example.org"`
+	query := `mutation { organizationDomain: createOrganizationDomain(input: {` + input + `})
+		{ domain organizationID }}`
+	fmt.Printf("------- query=%s\n", query)
+
+	var resp OrganizationDomainResponse
+
+	TestUser = f.Users[0]
+	gs.Error(c.Post(query, &resp))
+
+	TestUser = f.Users[1]
+	gs.NoError(c.Post(query, &resp))
+
+	gs.Equal(1, len(resp.OrganizationDomain), "received wrong number of domains")
+	gs.Equal(f.Organization.Uuid.String(), resp.OrganizationDomain[0].ID, "received incorrect org UUID")
+	gs.Equal("example.org", resp.OrganizationDomain[0].Domain, "received incorrect domain")
+
+	// removeOrganization is tested in `actions/gql_test.go`. This tests the returned data, whereas the `actions`
+	// test is more thorough with error cases.
+}

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -34,6 +34,8 @@
   translation: We had a problem finding the conversation to update its last-viewed time.
 - id: SetThreadLastViewedAt
   translation: We had a problem updating the conversation last-viewed time.
+- id: GetOrganizationDomainOrganizationID
+  translation: We had a problem finding the domain ID.
 - id: GetOrganizationDomains
   translation: We had a problem finding the list of domains for the organization.
 - id: GetPostCreator

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -109,17 +109,7 @@ func (o *Organization) AddDomain(domain string) error {
 
 	orgDomain.Domain = domain
 	orgDomain.OrganizationID = o.ID
-	err = DB.Save(&orgDomain)
-	if err != nil {
-		return err
-	}
-
-	err = DB.Load(o, "OrganizationDomains")
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return DB.Save(&orgDomain)
 }
 
 func (o *Organization) RemoveDomain(domain string) error {
@@ -129,17 +119,7 @@ func (o *Organization) RemoveDomain(domain string) error {
 		return err
 	}
 
-	err = DB.Destroy(&orgDomain)
-	if err != nil {
-		return err
-	}
-
-	err = DB.Load(o, "OrganizationDomains")
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return DB.Destroy(&orgDomain)
 }
 
 // Save wrap DB.Save() call to check for errors and operate on attached object

--- a/application/models/organization_domain.go
+++ b/application/models/organization_domain.go
@@ -1,6 +1,8 @@
 package models
 
-import "time"
+import (
+	"time"
+)
 
 type OrganizationDomain struct {
 	ID             int          `json:"id" db:"id"`
@@ -9,4 +11,12 @@ type OrganizationDomain struct {
 	OrganizationID int          `json:"organization_id" db:"organization_id"`
 	Domain         string       `json:"domain" db:"domain"`
 	Organization   Organization `belongs_to:"organizations"`
+}
+
+// GetOrganizationUUID loads the Organization record and converts its UUID to its string representation.
+func (o *OrganizationDomain) GetOrganizationUUID() (string, error) {
+	if err := DB.Load(o, "Organization"); err != nil {
+		return "", err
+	}
+	return o.Organization.Uuid.String(), nil
 }

--- a/application/models/organization_domain.go
+++ b/application/models/organization_domain.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"time"
 )
 
@@ -15,6 +16,9 @@ type OrganizationDomain struct {
 
 // GetOrganizationUUID loads the Organization record and converts its UUID to its string representation.
 func (o *OrganizationDomain) GetOrganizationUUID() (string, error) {
+	if o.OrganizationID <= 0 {
+		return "", errors.New("OrganizationID is not valid")
+	}
 	if err := DB.Load(o, "Organization"); err != nil {
 		return "", err
 	}

--- a/application/models/organization_domain_test.go
+++ b/application/models/organization_domain_test.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/silinternational/wecarry-api/domain"
+)
+
+func (ms *ModelSuite) TestOrganizationDomain_GetOrganizationUUID() {
+	t := ms.T()
+
+	org := Organization{Uuid: domain.GetUuid(), AuthConfig: "{}"}
+	createFixture(ms, &org)
+
+	orgDomain := OrganizationDomain{OrganizationID: org.ID, Domain: "example.com"}
+	createFixture(ms, &orgDomain)
+
+	tests := []struct {
+		name      string
+		orgDomain OrganizationDomain
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "valid",
+			orgDomain: orgDomain,
+			want:      org.Uuid.String(),
+		},
+		{
+			name:      "error",
+			orgDomain: OrganizationDomain{},
+			wantErr:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			o := test.orgDomain
+			got, err := o.GetOrganizationUUID()
+
+			if test.wantErr {
+				ms.Error(err)
+				return
+			}
+
+			ms.NoError(err)
+			ms.Equal(test.want, got)
+		})
+	}
+}

--- a/application/models/organization_test.go
+++ b/application/models/organization_test.go
@@ -305,34 +305,30 @@ func (ms *ModelSuite) TestOrganization_AddRemoveDomain() {
 	}
 
 	err := orgFixtures[0].AddDomain("first.com")
-	if err != nil {
-		t.Errorf("unable to add first domain to Org1: %s", err)
-	} else if len(orgFixtures[0].OrganizationDomains) != 1 {
+	ms.NoError(err, "unable to add first domain to Org1: %s", err)
+	domains, _ := orgFixtures[0].GetDomains()
+	if len(domains) != 1 {
 		t.Errorf("did not get error, but failed to add first domain to Org1")
 	}
 
 	err = orgFixtures[0].AddDomain("second.com")
-	if err != nil {
-		t.Errorf("unable to add second domain to Org1: %s", err)
-	} else if len(orgFixtures[0].OrganizationDomains) != 2 {
+	ms.NoError(err, "unable to add second domain to Org1: %s", err)
+	domains, _ = orgFixtures[0].GetDomains()
+	if len(domains) != 2 {
 		t.Errorf("did not get error, but failed to add second domain to Org1")
 	}
 
 	err = orgFixtures[1].AddDomain("second.com")
-	if err == nil {
-		t.Errorf("was to add existing domain (second.com) to Org2 but should have gotten error")
-	}
-
-	if len(orgFixtures[0].OrganizationDomains) != 2 {
+	ms.Error(err, "was to add existing domain (second.com) to Org2 but should have gotten error")
+	domains, _ = orgFixtures[0].GetDomains()
+	if len(domains) != 2 {
 		t.Errorf("after reloading org domains we did not get what we expected (%v), got: %v", 2, len(orgFixtures[0].OrganizationDomains))
 	}
 
 	err = orgFixtures[0].RemoveDomain("first.com")
-	if err != nil {
-		t.Errorf("unable to remove domain: %s", err)
-	}
-
-	if len(orgFixtures[0].OrganizationDomains) != 1 {
+	ms.NoError(err, "unable to remove domain: %s", err)
+	domains, _ = orgFixtures[0].GetDomains()
+	if len(domains) != 1 {
 		t.Errorf("org domains count after removing domain is not correct, expected %v, got: %v", 1, len(orgFixtures[0].OrganizationDomains))
 	}
 


### PR DESCRIPTION
The `organizationID` field returned from `createOrganizationDomain` and `removeOrganizationDomain` was the autocrement ID, not the UUID.