### PR TITLE
Standardize specific User Preferences

### DIFF
--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -377,6 +377,15 @@ func IsLanguageAllowed(lang string) bool {
 	return false
 }
 
+func IsWeightUnitAllowed(unit string) bool {
+	switch unit {
+	case UserPreferenceWeightUnitKGs, UserPreferenceWeightUnitPounds:
+		return true
+	}
+
+	return false
+}
+
 // TranslateWithLang returns the translation of the string identified by translationID, for the given language.
 // Apparently i18n has a global or something that keeps track of translatable phrases once a new packr Box
 // is created.  If no new packr Box has been created, i18n.Tfunc returns an error.
@@ -409,7 +418,10 @@ func IsOtherThanNoRows(err error) bool {
 	return true
 }
 
-func GetStructFieldTags(tagType string, s interface{}) (map[string]string, error) {
+// GetStructTags creates a map with certain types of tags (e.g. json) of a struct's
+// fields.  That tag values are both the keys and values of the map - just to make
+// it easy to check if a certain value is in the map
+func GetStructTags(tagType string, s interface{}) (map[string]string, error) {
 	rt := reflect.TypeOf(s)
 	if rt.Kind() != reflect.Struct {
 		return map[string]string{}, fmt.Errorf("cannot get fieldTags of non structs, not even for %v", rt.Kind())
@@ -422,8 +434,9 @@ func GetStructFieldTags(tagType string, s interface{}) (map[string]string, error
 
 		v := strings.Split(f.Tag.Get(tagType), ",")[0] // use split to ignore tag "options" like omitempty, etc.
 		if v != "" {
-			fieldTags[f.Name] = v
+			fieldTags[v] = v
 		}
 	}
+
 	return fieldTags, nil
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -386,6 +386,17 @@ func IsWeightUnitAllowed(unit string) bool {
 	return false
 }
 
+func IsTimeZoneAllowed(name string) bool {
+	_, err := time.LoadLocation(name)
+
+	if err != nil {
+		Logger.Printf("error evaluating timezone %s ... %v", name, err)
+		return false
+	}
+
+	return true
+}
+
 // TranslateWithLang returns the translation of the string identified by translationID, for the given language.
 // Apparently i18n has a global or something that keeps track of translatable phrases once a new packr Box
 // is created.  If no new packr Box has been created, i18n.Tfunc returns an error.

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -460,6 +460,6 @@ func (ts *TestSuite) TestIsTimeZoneAllowed() {
 	ts.True(got, zone+" should be an allowed time zone")
 
 	zone = "badzone"
-	got = IsLanguageAllowed(zone)
-	ts.False(got, zone+" should not be an allowed language")
+	got = IsTimeZoneAllowed(zone)
+	ts.False(got, zone+" should not be an time zone")
 }

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -454,3 +454,17 @@ func (ts *TestSuite) TestIsWeightUnitAllowed() {
 	got = IsLanguageAllowed(unit)
 	ts.False(got, unit+" should not be an allowed weight unit")
 }
+
+func (ts *TestSuite) TestIsTimeZoneAllowed() {
+	zone := "America/New_York"
+	got := IsTimeZoneAllowed(zone)
+	ts.True(got, zone+" should be an allowed time zone")
+
+	zone = "Etc/GMT+2"
+	got = IsTimeZoneAllowed(zone)
+	ts.True(got, zone+" should be an allowed time zone")
+
+	zone = "badzone"
+	got = IsLanguageAllowed(zone)
+	ts.False(got, zone+" should not be an allowed language")
+}

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -418,22 +418,20 @@ type testStruct struct {
 func (ts *TestSuite) TestGetStructFieldTags() {
 	tStruct := testStruct{}
 
-	got, err := GetStructFieldTags("json", tStruct)
+	got, err := GetStructTags("json", tStruct)
 	ts.NoError(err)
 
 	gotCount := len(got)
 	wantCount := 2
 	ts.Equal(wantCount, gotCount, "incorrect number of tags")
 
-	fieldName := "Language"
+	fieldName := "language"
 	gotName := got[fieldName]
-	wantName := "language"
-	ts.Equal(wantName, gotName, "incorrect tag")
+	ts.Equal(fieldName, gotName, "incorrect tag")
 
-	fieldName = "TimeZone"
+	fieldName = "time_zone"
 	gotName = got[fieldName]
-	wantName = "time_zone"
-	ts.Equal(wantName, gotName, "incorrect tag")
+	ts.Equal(fieldName, gotName, "incorrect tag")
 }
 
 func (ts *TestSuite) TestIsLanguageAllowed() {
@@ -442,6 +440,16 @@ func (ts *TestSuite) TestIsLanguageAllowed() {
 	ts.True(got, lang+" should be an allowed language")
 
 	lang = "badlanguage"
-	got = IsLanguageAllowed("badlanguage")
+	got = IsLanguageAllowed(lang)
 	ts.False(got, lang+" should not be an allowed language")
+}
+
+func (ts *TestSuite) TestIsWeightUnitAllowed() {
+	unit := UserPreferenceWeightUnitKGs
+	got := IsWeightUnitAllowed(unit)
+	ts.True(got, unit+" should be an allowed weight unit")
+
+	unit = "badunit"
+	got = IsLanguageAllowed(unit)
+	ts.False(got, unit+" should not be an allowed weight unit")
 }

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -15,7 +15,7 @@ type TestSuite struct {
 	suite.Suite
 }
 
-// Test_GqlgenSuite runs the GqlgenSuite test suite
+// Test_TestSuite runs the test suite
 func Test_TestSuite(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -410,12 +410,13 @@ func (ts *TestSuite) TestIsOtherThanNoRows() {
 	}
 }
 
-type testStruct struct {
-	Language string `json:"language"`
-	TimeZone string `json:"time_zone"`
-}
-
 func (ts *TestSuite) TestGetStructFieldTags() {
+
+	type testStruct struct {
+		Language string `json:"language"`
+		TimeZone string `json:"time_zone"`
+	}
+
 	tStruct := testStruct{}
 
 	got, err := GetStructTags("json", tStruct)

--- a/application/domain/domain_test.go
+++ b/application/domain/domain_test.go
@@ -2,7 +2,7 @@ package domain
 
 import (
 	"errors"
-	"github.com/gobuffalo/suite"
+	"github.com/stretchr/testify/suite"
 	"net/http"
 	"testing"
 	"time"
@@ -12,17 +12,12 @@ import (
 
 // TestSuite establishes a test suite for domain tests
 type TestSuite struct {
-	*suite.Model
+	suite.Suite
 }
 
 // Test_GqlgenSuite runs the GqlgenSuite test suite
 func Test_TestSuite(t *testing.T) {
-	model := suite.NewModel()
-
-	gs := &TestSuite{
-		Model: model,
-	}
-	suite.Run(t, gs)
+	suite.Run(t, new(TestSuite))
 }
 
 func (ts *TestSuite) TestGetFirstStringFromSlice() {

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -167,10 +167,10 @@ type ComplexityRoot struct {
 		UpdatedAt          func(childComplexity int) int
 	}
 
-	UserPreference struct {
-		ID    func(childComplexity int) int
-		Key   func(childComplexity int) int
-		Value func(childComplexity int) int
+	UserPreferences struct {
+		Language   func(childComplexity int) int
+		TimeZone   func(childComplexity int) int
+		WeightUnit func(childComplexity int) int
 	}
 }
 
@@ -258,7 +258,7 @@ type UserResolver interface {
 	Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error)
 	Posts(ctx context.Context, obj *models.User, role PostRole) ([]models.Post, error)
 	PhotoURL(ctx context.Context, obj *models.User) (*string, error)
-	Preferences(ctx context.Context, obj *models.User) ([]models.UserPreference, error)
+	Preferences(ctx context.Context, obj *models.User) (*models.StandardPreferences, error)
 	Location(ctx context.Context, obj *models.User) (*models.Location, error)
 	UnreadMessageCount(ctx context.Context, obj *models.User) (int, error)
 }
@@ -943,26 +943,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.UpdatedAt(childComplexity), true
 
-	case "UserPreference.id":
-		if e.complexity.UserPreference.ID == nil {
+	case "UserPreferences.language":
+		if e.complexity.UserPreferences.Language == nil {
 			break
 		}
 
-		return e.complexity.UserPreference.ID(childComplexity), true
+		return e.complexity.UserPreferences.Language(childComplexity), true
 
-	case "UserPreference.key":
-		if e.complexity.UserPreference.Key == nil {
+	case "UserPreferences.timeZone":
+		if e.complexity.UserPreferences.TimeZone == nil {
 			break
 		}
 
-		return e.complexity.UserPreference.Key(childComplexity), true
+		return e.complexity.UserPreferences.TimeZone(childComplexity), true
 
-	case "UserPreference.value":
-		if e.complexity.UserPreference.Value == nil {
+	case "UserPreferences.weightUnit":
+		if e.complexity.UserPreferences.WeightUnit == nil {
 			break
 		}
 
-		return e.complexity.UserPreference.Value(childComplexity), true
+		return e.complexity.UserPreferences.WeightUnit(childComplexity), true
 
 	}
 	return 0, false
@@ -1093,15 +1093,15 @@ type User {
     organizations: [Organization!]!
     posts(role: PostRole!): [Post!]!
     photoURL: String
-    preferences: [UserPreference!]!
+    preferences: UserPreferences
     location: Location
     unreadMessageCount: Int!
 }
 
-type UserPreference {
-    id: ID!
-    key: String!
-    value: String!
+type UserPreferences {
+    language: String
+    timeZone: String
+    weightUnit: String
 }
 
 input UpdateUserInput {
@@ -1109,12 +1109,27 @@ input UpdateUserInput {
     nickname: String
     photoID: String
     location: LocationInput
-    preferences: [UpdateUserPreferenceInput!]
+    preferences: UpdateUserPreferencesInput!
 }
 
-input UpdateUserPreferenceInput {
-    key: String!
-    value: String!
+enum PreferredLanguage {
+    EN
+    FR
+    SP
+    KO
+    PT
+}
+
+enum PreferredWeightUnit {
+    POUNDS
+    KILOGRAMS
+}
+
+
+input UpdateUserPreferencesInput {
+    language: PreferredLanguage
+    timeZone: String
+    weightUnit: PreferredWeightUnit
 }
 
 enum PostType {
@@ -4714,15 +4729,12 @@ func (ec *executionContext) _User_preferences(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.([]models.UserPreference)
+	res := resTmp.(*models.StandardPreferences)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUserPreference2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUserPreference(ctx, field.Selections, res)
+	return ec.marshalOUserPreferences2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐStandardPreferences(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_location(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
@@ -4796,7 +4808,7 @@ func (ec *executionContext) _User_unreadMessageCount(ctx context.Context, field 
 	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _UserPreference_id(ctx context.Context, field graphql.CollectedField, obj *models.UserPreference) (ret graphql.Marshaler) {
+func (ec *executionContext) _UserPreferences_language(ctx context.Context, field graphql.CollectedField, obj *models.StandardPreferences) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -4806,7 +4818,7 @@ func (ec *executionContext) _UserPreference_id(ctx context.Context, field graphq
 		ec.Tracer.EndFieldExecution(ctx)
 	}()
 	rctx := &graphql.ResolverContext{
-		Object:   "UserPreference",
+		Object:   "UserPreferences",
 		Field:    field,
 		Args:     nil,
 		IsMethod: false,
@@ -4815,62 +4827,22 @@ func (ec *executionContext) _UserPreference_id(ctx context.Context, field graphq
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
+		return obj.Language, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNID2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _UserPreference_key(ctx context.Context, field graphql.CollectedField, obj *models.UserPreference) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "UserPreference",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Key, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _UserPreference_value(ctx context.Context, field graphql.CollectedField, obj *models.UserPreference) (ret graphql.Marshaler) {
+func (ec *executionContext) _UserPreferences_timeZone(ctx context.Context, field graphql.CollectedField, obj *models.StandardPreferences) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -4880,7 +4852,7 @@ func (ec *executionContext) _UserPreference_value(ctx context.Context, field gra
 		ec.Tracer.EndFieldExecution(ctx)
 	}()
 	rctx := &graphql.ResolverContext{
-		Object:   "UserPreference",
+		Object:   "UserPreferences",
 		Field:    field,
 		Args:     nil,
 		IsMethod: false,
@@ -4889,22 +4861,53 @@ func (ec *executionContext) _UserPreference_value(ctx context.Context, field gra
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Value, nil
+		return obj.TimeZone, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UserPreferences_weightUnit(ctx context.Context, field graphql.CollectedField, obj *models.StandardPreferences) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "UserPreferences",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WeightUnit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) (ret graphql.Marshaler) {
@@ -6504,7 +6507,7 @@ func (ec *executionContext) unmarshalInputUpdateUserInput(ctx context.Context, o
 			}
 		case "preferences":
 			var err error
-			it.Preferences, err = ec.unmarshalOUpdateUserPreferenceInput2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferenceInput(ctx, v)
+			it.Preferences, err = ec.unmarshalNUpdateUserPreferencesInput2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferencesInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6514,21 +6517,27 @@ func (ec *executionContext) unmarshalInputUpdateUserInput(ctx context.Context, o
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputUpdateUserPreferenceInput(ctx context.Context, obj interface{}) (UpdateUserPreferenceInput, error) {
-	var it UpdateUserPreferenceInput
+func (ec *executionContext) unmarshalInputUpdateUserPreferencesInput(ctx context.Context, obj interface{}) (UpdateUserPreferencesInput, error) {
+	var it UpdateUserPreferencesInput
 	var asMap = obj.(map[string]interface{})
 
 	for k, v := range asMap {
 		switch k {
-		case "key":
+		case "language":
 			var err error
-			it.Key, err = ec.unmarshalNString2string(ctx, v)
+			it.Language, err = ec.unmarshalOPreferredLanguage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx, v)
 			if err != nil {
 				return it, err
 			}
-		case "value":
+		case "timeZone":
 			var err error
-			it.Value, err = ec.unmarshalNString2string(ctx, v)
+			it.TimeZone, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "weightUnit":
+			var err error
+			it.WeightUnit, err = ec.unmarshalOPreferredWeightUnit2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredWeightUnit(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -7540,9 +7549,6 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._User_preferences(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			})
 		case "location":
@@ -7581,32 +7587,23 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 	return out
 }
 
-var userPreferenceImplementors = []string{"UserPreference"}
+var userPreferencesImplementors = []string{"UserPreferences"}
 
-func (ec *executionContext) _UserPreference(ctx context.Context, sel ast.SelectionSet, obj *models.UserPreference) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.RequestContext, sel, userPreferenceImplementors)
+func (ec *executionContext) _UserPreferences(ctx context.Context, sel ast.SelectionSet, obj *models.StandardPreferences) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, userPreferencesImplementors)
 
 	out := graphql.NewFieldSet(fields)
 	var invalids uint32
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("UserPreference")
-		case "id":
-			out.Values[i] = ec._UserPreference_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "key":
-			out.Values[i] = ec._UserPreference_key(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "value":
-			out.Values[i] = ec._UserPreference_value(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
+			out.Values[i] = graphql.MarshalString("UserPreferences")
+		case "language":
+			out.Values[i] = ec._UserPreferences_language(ctx, field, obj)
+		case "timeZone":
+			out.Values[i] = ec._UserPreferences_timeZone(ctx, field, obj)
+		case "weightUnit":
+			out.Values[i] = ec._UserPreferences_weightUnit(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7932,20 +7929,6 @@ func (ec *executionContext) marshalNFile2ᚕgithubᚗcomᚋsilinternationalᚋwe
 	}
 	wg.Wait()
 	return ret
-}
-
-func (ec *executionContext) unmarshalNID2int(ctx context.Context, v interface{}) (int, error) {
-	return graphql.UnmarshalIntID(v)
-}
-
-func (ec *executionContext) marshalNID2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
-	res := graphql.MarshalIntID(v)
-	if res == graphql.Null {
-		if !ec.HasError(graphql.GetResolverContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-	}
-	return res
 }
 
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {
@@ -8431,8 +8414,16 @@ func (ec *executionContext) unmarshalNUpdateUserInput2githubᚗcomᚋsilinternat
 	return ec.unmarshalInputUpdateUserInput(ctx, v)
 }
 
-func (ec *executionContext) unmarshalNUpdateUserPreferenceInput2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferenceInput(ctx context.Context, v interface{}) (UpdateUserPreferenceInput, error) {
-	return ec.unmarshalInputUpdateUserPreferenceInput(ctx, v)
+func (ec *executionContext) unmarshalNUpdateUserPreferencesInput2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferencesInput(ctx context.Context, v interface{}) (UpdateUserPreferencesInput, error) {
+	return ec.unmarshalInputUpdateUserPreferencesInput(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateUserPreferencesInput2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferencesInput(ctx context.Context, v interface{}) (*UpdateUserPreferencesInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNUpdateUserPreferencesInput2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferencesInput(ctx, v)
+	return &res, err
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx context.Context, sel ast.SelectionSet, v models.User) graphql.Marshaler {
@@ -8484,47 +8475,6 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋsilinternationalᚋwe
 		return graphql.Null
 	}
 	return ec._User(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNUserPreference2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUserPreference(ctx context.Context, sel ast.SelectionSet, v models.UserPreference) graphql.Marshaler {
-	return ec._UserPreference(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNUserPreference2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUserPreference(ctx context.Context, sel ast.SelectionSet, v []models.UserPreference) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		rctx := &graphql.ResolverContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNUserPreference2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUserPreference(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-	return ret
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {
@@ -8902,6 +8852,54 @@ func (ec *executionContext) marshalOPostSize2ᚖgithubᚗcomᚋsilinternational�
 	return ec.marshalOPostSize2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostSize(ctx, sel, *v)
 }
 
+func (ec *executionContext) unmarshalOPreferredLanguage2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx context.Context, v interface{}) (PreferredLanguage, error) {
+	var res PreferredLanguage
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalOPreferredLanguage2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx context.Context, sel ast.SelectionSet, v PreferredLanguage) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalOPreferredLanguage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx context.Context, v interface{}) (*PreferredLanguage, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOPreferredLanguage2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOPreferredLanguage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx context.Context, sel ast.SelectionSet, v *PreferredLanguage) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
+}
+
+func (ec *executionContext) unmarshalOPreferredWeightUnit2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredWeightUnit(ctx context.Context, v interface{}) (PreferredWeightUnit, error) {
+	var res PreferredWeightUnit
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalOPreferredWeightUnit2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredWeightUnit(ctx context.Context, sel ast.SelectionSet, v PreferredWeightUnit) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalOPreferredWeightUnit2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredWeightUnit(ctx context.Context, v interface{}) (*PreferredWeightUnit, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOPreferredWeightUnit2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredWeightUnit(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOPreferredWeightUnit2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredWeightUnit(ctx context.Context, sel ast.SelectionSet, v *PreferredWeightUnit) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
+}
+
 func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {
 	return graphql.UnmarshalString(v)
 }
@@ -8925,26 +8923,6 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	return ec.marshalOString2string(ctx, sel, *v)
 }
 
-func (ec *executionContext) unmarshalOUpdateUserPreferenceInput2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferenceInput(ctx context.Context, v interface{}) ([]UpdateUserPreferenceInput, error) {
-	var vSlice []interface{}
-	if v != nil {
-		if tmp1, ok := v.([]interface{}); ok {
-			vSlice = tmp1
-		} else {
-			vSlice = []interface{}{v}
-		}
-	}
-	var err error
-	res := make([]UpdateUserPreferenceInput, len(vSlice))
-	for i := range vSlice {
-		res[i], err = ec.unmarshalNUpdateUserPreferenceInput2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐUpdateUserPreferenceInput(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
 func (ec *executionContext) marshalOUser2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx context.Context, sel ast.SelectionSet, v models.User) graphql.Marshaler {
 	return ec._User(ctx, sel, &v)
 }
@@ -8963,6 +8941,17 @@ func (ec *executionContext) unmarshalOUserAdminRole2githubᚗcomᚋsilinternatio
 
 func (ec *executionContext) marshalOUserAdminRole2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUserAdminRole(ctx context.Context, sel ast.SelectionSet, v models.UserAdminRole) graphql.Marshaler {
 	return graphql.MarshalString(string(v))
+}
+
+func (ec *executionContext) marshalOUserPreferences2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐStandardPreferences(ctx context.Context, sel ast.SelectionSet, v models.StandardPreferences) graphql.Marshaler {
+	return ec._UserPreferences(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOUserPreferences2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐStandardPreferences(ctx context.Context, sel ast.SelectionSet, v *models.StandardPreferences) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UserPreferences(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValue(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -38,7 +38,7 @@ models:
         resolver: true
       unreadMessageCount:
         resolver: true
-      userPreference:
+      userPreferences:
         resolver: true
   Post:
     model: models.Post
@@ -94,8 +94,8 @@ models:
     model: models.PostSize
   UserAdminRole:
     model: models.UserAdminRole
-  UserPreference:
-    model: models.UserPreference
+  UserPreferences:
+    model: models.StandardPreferences
 
 #directives:
 #  deprecated:

--- a/application/gqlgen/gqlgenutils.go
+++ b/application/gqlgen/gqlgenutils.go
@@ -54,7 +54,10 @@ func convertUserPreferencesToStandardPreferences(input *UpdateUserPreferencesInp
 	}
 
 	if input.TimeZone != nil {
-		stPrefs.TimeZone = strings.ToLower(*input.TimeZone)
+		if !domain.IsTimeZoneAllowed(*input.TimeZone) {
+			return models.StandardPreferences{}, errors.New("user preference time zone not allowed ... " + *input.TimeZone)
+		}
+		stPrefs.TimeZone = *input.TimeZone
 	}
 
 	if input.WeightUnit != nil {

--- a/application/gqlgen/models_gen.go
+++ b/application/gqlgen/models_gen.go
@@ -64,12 +64,13 @@ type UpdateUserInput struct {
 	Nickname    *string                     `json:"nickname"`
 	PhotoID     *string                     `json:"photoID"`
 	Location    *LocationInput              `json:"location"`
-	Preferences []UpdateUserPreferenceInput `json:"preferences"`
+	Preferences *UpdateUserPreferencesInput `json:"preferences"`
 }
 
-type UpdateUserPreferenceInput struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+type UpdateUserPreferencesInput struct {
+	Language   *PreferredLanguage   `json:"language"`
+	TimeZone   *string              `json:"timeZone"`
+	WeightUnit *PreferredWeightUnit `json:"weightUnit"`
 }
 
 type PostRole string
@@ -112,5 +113,93 @@ func (e *PostRole) UnmarshalGQL(v interface{}) error {
 }
 
 func (e PostRole) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type PreferredLanguage string
+
+const (
+	PreferredLanguageEn PreferredLanguage = "EN"
+	PreferredLanguageFr PreferredLanguage = "FR"
+	PreferredLanguageSp PreferredLanguage = "SP"
+	PreferredLanguageKo PreferredLanguage = "KO"
+	PreferredLanguagePt PreferredLanguage = "PT"
+)
+
+var AllPreferredLanguage = []PreferredLanguage{
+	PreferredLanguageEn,
+	PreferredLanguageFr,
+	PreferredLanguageSp,
+	PreferredLanguageKo,
+	PreferredLanguagePt,
+}
+
+func (e PreferredLanguage) IsValid() bool {
+	switch e {
+	case PreferredLanguageEn, PreferredLanguageFr, PreferredLanguageSp, PreferredLanguageKo, PreferredLanguagePt:
+		return true
+	}
+	return false
+}
+
+func (e PreferredLanguage) String() string {
+	return string(e)
+}
+
+func (e *PreferredLanguage) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = PreferredLanguage(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid PreferredLanguage", str)
+	}
+	return nil
+}
+
+func (e PreferredLanguage) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type PreferredWeightUnit string
+
+const (
+	PreferredWeightUnitPounds    PreferredWeightUnit = "POUNDS"
+	PreferredWeightUnitKilograms PreferredWeightUnit = "KILOGRAMS"
+)
+
+var AllPreferredWeightUnit = []PreferredWeightUnit{
+	PreferredWeightUnitPounds,
+	PreferredWeightUnitKilograms,
+}
+
+func (e PreferredWeightUnit) IsValid() bool {
+	switch e {
+	case PreferredWeightUnitPounds, PreferredWeightUnitKilograms:
+		return true
+	}
+	return false
+}
+
+func (e PreferredWeightUnit) String() string {
+	return string(e)
+}
+
+func (e *PreferredWeightUnit) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = PreferredWeightUnit(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid PreferredWeightUnit", str)
+	}
+	return nil
+}
+
+func (e PreferredWeightUnit) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -65,15 +65,15 @@ type User {
     organizations: [Organization!]!
     posts(role: PostRole!): [Post!]!
     photoURL: String
-    preferences: [UserPreference!]!
+    preferences: UserPreferences
     location: Location
     unreadMessageCount: Int!
 }
 
-type UserPreference {
-    id: ID!
-    key: String!
-    value: String!
+type UserPreferences {
+    language: String
+    timeZone: String
+    weightUnit: String
 }
 
 input UpdateUserInput {
@@ -81,12 +81,27 @@ input UpdateUserInput {
     nickname: String
     photoID: String
     location: LocationInput
-    preferences: [UpdateUserPreferenceInput!]
+    preferences: UpdateUserPreferencesInput!
 }
 
-input UpdateUserPreferenceInput {
-    key: String!
-    value: String!
+enum PreferredLanguage {
+    EN
+    FR
+    SP
+    KO
+    PT
+}
+
+enum PreferredWeightUnit {
+    POUNDS
+    KILOGRAMS
+}
+
+
+input UpdateUserPreferencesInput {
+    language: PreferredLanguage
+    timeZone: String
+    weightUnit: PreferredWeightUnit
 }
 
 enum PostType {

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -212,7 +212,8 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 	return &user, nil
 }
 
-// userPreferences resolves the `preferences` property of the user query, retrieving the related records from the database.
+// Preferences resolves the `preferences` property of the user query, retrieving the related records from the database
+// and using them to hydrate a StandardPreferences struct.
 func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*models.StandardPreferences, error) {
 	if obj == nil {
 		return nil, nil
@@ -227,6 +228,7 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 		return nil, reportError(ctx, err, "GetUserPreferences", extras)
 	}
 
+	// These have particular acceptable values, unlike TimeZone
 	standardPrefs.Language = strings.ToUpper(standardPrefs.Language)
 	standardPrefs.WeightUnit = strings.ToUpper(standardPrefs.WeightUnit)
 

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -112,6 +112,12 @@ func Fixtures_UserQuery(gs *GqlgenSuite, t *testing.T) UserQueryFixtures {
 		{
 			Uuid:   domain.GetUuid(),
 			UserID: users[1].ID,
+			Key:    domain.UserPreferenceKeyTimeZone,
+			Value:  "America/New_York",
+		},
+		{
+			Uuid:   domain.GetUuid(),
+			UserID: users[1].ID,
 			Key:    domain.UserPreferenceKeyWeightUnit,
 			Value:  domain.UserPreferenceWeightUnitPounds,
 		},
@@ -177,7 +183,7 @@ func (gs *GqlgenSuite) TestUserQuery() {
 
 	var resp UserResponse
 
-	allFields := `{ id email nickname adminRole photoURL preferences {language weightUnit}  
+	allFields := `{ id email nickname adminRole photoURL preferences {language timeZone weightUnit}  
 		posts (role: CREATEDBY) {id} organizations {id}
 		location {description country latitude longitude} }`
 	testCases := []testCase{
@@ -206,7 +212,9 @@ func (gs *GqlgenSuite) TestUserQuery() {
 
 				gs.Equal(strings.ToUpper(f.UserPreferences[0].Value), *resp.User.Preferences.Language,
 					"incorrect preference - language")
-				gs.Equal(strings.ToUpper(f.UserPreferences[1].Value), *resp.User.Preferences.WeightUnit,
+				gs.Equal(f.UserPreferences[1].Value, *resp.User.Preferences.TimeZone,
+					"incorrect preference - time zone")
+				gs.Equal(strings.ToUpper(f.UserPreferences[2].Value), *resp.User.Preferences.WeightUnit,
 					"incorrect preference - weight unit")
 			},
 		},
@@ -287,7 +295,7 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 					"incorrect preference - language")
 				gs.Equal(strings.ToUpper(domain.UserPreferenceWeightUnitKGs), *resp.User.Preferences.WeightUnit,
 					"incorrect preference - weightUnit")
-				gs.Equal("", *resp.User.Preferences.TimeZone,
+				gs.Equal("America/New_York", *resp.User.Preferences.TimeZone,
 					"incorrect preference - timeZone")
 			},
 		},

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -177,7 +177,8 @@ func (gs *GqlgenSuite) TestUserQuery() {
 
 	var resp UserResponse
 
-	allFields := `{ id email nickname adminRole photoURL preferences {language weightUnit}  posts (role: CREATEDBY) {id} organizations {id}
+	allFields := `{ id email nickname adminRole photoURL preferences {language weightUnit}  
+		posts (role: CREATEDBY) {id} organizations {id}
 		location {description country latitude longitude} }`
 	testCases := []testCase{
 		{

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -2,6 +2,7 @@ package gqlgen
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gobuffalo/nulls"
@@ -25,10 +26,10 @@ type UserResponse struct {
 		Posts []struct {
 			ID string `json:"id"`
 		}
-		Preferences []struct {
-			ID    string `json:"id"`
-			Key   string `json:"key"`
-			Value string `json:"value"`
+		Preferences struct {
+			Language   *string `json:"language"`
+			TimeZone   *string `json:"timeZone"`
+			WeightUnit *string `json:"weightUnit"`
 		}
 		PhotoURL string `json:"photoURL"`
 		Location struct {
@@ -111,8 +112,8 @@ func Fixtures_UserQuery(gs *GqlgenSuite, t *testing.T) UserQueryFixtures {
 		{
 			Uuid:   domain.GetUuid(),
 			UserID: users[1].ID,
-			Key:    domain.UserPreferenceKeyUnits,
-			Value:  domain.UserPreferenceUnitsMetric,
+			Key:    domain.UserPreferenceKeyWeightUnit,
+			Value:  domain.UserPreferenceWeightUnitPounds,
 		},
 	}
 
@@ -176,7 +177,7 @@ func (gs *GqlgenSuite) TestUserQuery() {
 
 	var resp UserResponse
 
-	allFields := `{ id email nickname adminRole photoURL preferences {key}  posts (role: CREATEDBY) {id} organizations {id}
+	allFields := `{ id email nickname adminRole photoURL preferences {language weightUnit}  posts (role: CREATEDBY) {id} organizations {id}
 		location {description country latitude longitude} }`
 	testCases := []testCase{
 		{
@@ -202,9 +203,10 @@ func (gs *GqlgenSuite) TestUserQuery() {
 				gs.Equal(f.Locations[0].Latitude.Float64, resp.User.Location.Lat, "incorrect latitude")
 				gs.Equal(f.Locations[0].Longitude.Float64, resp.User.Location.Long, "incorrect longitude")
 
-				gs.Equal(2, len(resp.User.Preferences), "wrong number of UserPreferences")
-				gs.Equal(f.UserPreferences[0].Key, resp.User.Preferences[0].Key, "incorrect preference 0")
-				gs.Equal(f.UserPreferences[1].Key, resp.User.Preferences[1].Key, "incorrect preference 1")
+				gs.Equal(strings.ToUpper(f.UserPreferences[0].Value), *resp.User.Preferences.Language,
+					"incorrect preference - language")
+				gs.Equal(strings.ToUpper(f.UserPreferences[1].Value), *resp.User.Preferences.WeightUnit,
+					"incorrect preference - weight unit")
 			},
 		},
 		{
@@ -227,6 +229,7 @@ func (gs *GqlgenSuite) TestUserQuery() {
 	for _, test := range testCases {
 		TestUser = test.TestUser
 		err := c.Post(test.Payload, &resp)
+
 		if test.ExpectError {
 			gs.Error(err)
 		} else {
@@ -257,11 +260,9 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 	newNickname := "U1 New Nickname"
 	location := `{description: "Paris, France", country: "FR", latitude: 48.8588377, longitude: 2.2770202}`
 
-	updatedKey := f.UserPreferences[1].Key
-	updatedValue := f.UserPreferences[1].Value + "-UPDATED"
-	preferences := fmt.Sprintf(`[{key: "%s", value: "%s"}]`, updatedKey, updatedValue)
+	preferences := fmt.Sprintf(`{weightUnit: %s}`, strings.ToUpper(domain.UserPreferenceWeightUnitKGs))
 
-	requestedFields := `{id nickname photoURL preferences {key, value} location {description, country}}`
+	requestedFields := `{id nickname photoURL preferences {language, weightUnit} location {description, country}}`
 
 	update := fmt.Sprintf(`mutation { user: updateUser(input:{id: "%s", nickname: "%s", location: %s, preferences: %s}) %s }`,
 		userID, newNickname, location, preferences, requestedFields)
@@ -281,11 +282,10 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 				gs.Equal("Paris, France", resp.User.Location.Description, "incorrect location")
 				gs.Equal("FR", resp.User.Location.Country, "incorrect country")
 
-				gs.Equal(2, len(resp.User.Preferences), "wrong number of UserPreferences")
-				gs.Equal(f.UserPreferences[0].Key, resp.User.Preferences[0].Key, "incorrect preference 0 key")
-				gs.Equal(f.UserPreferences[0].Value, resp.User.Preferences[0].Value, "incorrect preference 0 value")
-				gs.Equal(f.UserPreferences[1].Key, resp.User.Preferences[1].Key, "incorrect preference 1 key")
-				gs.Equal(f.UserPreferences[1].Value+"-UPDATED", resp.User.Preferences[1].Value, "incorrect preference 1 value")
+				gs.Equal(strings.ToUpper(f.UserPreferences[0].Value), *resp.User.Preferences.Language,
+					"incorrect preference - language")
+				gs.Equal(strings.ToUpper(domain.UserPreferenceWeightUnitKGs), *resp.User.Preferences.WeightUnit,
+					"incorrect preference - weight unit")
 			},
 		},
 		{

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -262,7 +262,7 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 
 	preferences := fmt.Sprintf(`{weightUnit: %s}`, strings.ToUpper(domain.UserPreferenceWeightUnitKGs))
 
-	requestedFields := `{id nickname photoURL preferences {language, weightUnit} location {description, country}}`
+	requestedFields := `{id nickname photoURL preferences {language, timeZone, weightUnit} location {description, country}}`
 
 	update := fmt.Sprintf(`mutation { user: updateUser(input:{id: "%s", nickname: "%s", location: %s, preferences: %s}) %s }`,
 		userID, newNickname, location, preferences, requestedFields)
@@ -285,7 +285,9 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 				gs.Equal(strings.ToUpper(f.UserPreferences[0].Value), *resp.User.Preferences.Language,
 					"incorrect preference - language")
 				gs.Equal(strings.ToUpper(domain.UserPreferenceWeightUnitKGs), *resp.User.Preferences.WeightUnit,
-					"incorrect preference - weight unit")
+					"incorrect preference - weightUnit")
+				gs.Equal("", *resp.User.Preferences.TimeZone,
+					"incorrect preference - timeZone")
 			},
 		},
 		{

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -28,7 +28,7 @@ const TokenBytes = 32
 // Keep a map of the json tag names for the standard user preferences struct
 // e.g. "time_zone": "time_zone".
 // Having it as a map, makes it easy to check if a potential key is allowed
-var preferencesFieldJson map[string]string
+var allowedUserPreferenceKeys map[string]string
 
 func init() {
 	var err error
@@ -45,7 +45,7 @@ func init() {
 		log.Fatal(fmt.Errorf("error using crypto/rand ... %v", err))
 	}
 
-	preferencesFieldJson, err = domain.GetStructTags("json", StandardPreferences{})
+	allowedUserPreferenceKeys, err = domain.GetStructTags("json", StandardPreferences{})
 	if err != nil {
 		log.Fatal(fmt.Errorf("error loading Allowed User Preferences ... %v", err))
 	}

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -25,6 +25,11 @@ var DB *pop.Connection
 
 const TokenBytes = 32
 
+// Keep a map of the json tag names for the standard user preferences struct
+// e.g. "time_zone": "time_zone".
+// Having it as a map, makes it easy to check if a potential key is allowed
+var preferencesFieldJson map[string]string
+
 func init() {
 	var err error
 	env := domain.Env.GoEnv
@@ -38,6 +43,11 @@ func init() {
 	// Just make sure we can use the crypto/rand library on our system
 	if _, err = getRandomToken(); err != nil {
 		log.Fatal(fmt.Errorf("error using crypto/rand ... %v", err))
+	}
+
+	preferencesFieldJson, err = domain.GetStructTags("json", StandardPreferences{})
+	if err != nil {
+		log.Fatal(fmt.Errorf("error loading Allowed User Preferences ... %v", err))
 	}
 }
 

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -538,11 +538,12 @@ func (u *User) GetPreferences() (StandardPreferences, error) {
 
 	dbPreferences := map[string]string{}
 
-	// First check if all of this user's preferences in the database are allowed
+	// Build up a map of the User's Preferences in the database while also
+	// checking that they are each allowed
 	for _, uP := range uPrefs {
-		_, ok := preferencesFieldJson[uP.Key]
+		_, ok := allowedUserPreferenceKeys[uP.Key]
 		if !ok {
-			domain.Logger.Printf("in database found unexpected user preference key %s", uP.Key)
+			domain.Logger.Printf("the database included a user preference with an unexpected key %s", uP.Key)
 			continue
 		}
 		dbPreferences[uP.Key] = uP.Value

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -560,7 +560,9 @@ func (u *User) GetPreferences() (StandardPreferences, error) {
 	}
 
 	if timeZone, ok := dbPreferences[domain.UserPreferenceKeyTimeZone]; ok {
-		goodPreferences.TimeZone = timeZone
+		if domain.IsTimeZoneAllowed(timeZone) {
+			goodPreferences.TimeZone = timeZone
+		} // IsTimeZoneAllowed logs a message if it's unrecognized
 	}
 
 	if weightUnit, ok := dbPreferences[domain.UserPreferenceKeyWeightUnit]; ok {
@@ -653,6 +655,10 @@ func (u *User) UpdateStandardPreferences(prefs StandardPreferences) (StandardPre
 	}
 
 	if prefs.TimeZone != "" {
+		if !domain.IsTimeZoneAllowed(prefs.TimeZone) {
+			return StandardPreferences{}, errors.New("unexpected UserPreference time zone ... " + prefs.TimeZone)
+		}
+
 		_, err := u.updatePreferenceByKey(domain.UserPreferenceKeyTimeZone, prefs.TimeZone)
 		if err != nil {
 			return StandardPreferences{}, err

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -528,10 +528,9 @@ func (u *User) WantsPostNotification(post Post) bool {
 	return true
 }
 
-// GetPreferences returns an StandardPreferences struct
+// GetPreferences returns a StandardPreferences struct
 func (u *User) GetPreferences() (StandardPreferences, error) {
-	uPrefs := UserPreferences{}
-	if err := DB.Where("user_id = ?", u.ID).All(&uPrefs); err != nil {
+	if err := DB.Load(u, "UserPreferences"); err != nil {
 		err := errors.New("error getting user preferences ... " + err.Error())
 		return StandardPreferences{}, err
 	}
@@ -540,7 +539,7 @@ func (u *User) GetPreferences() (StandardPreferences, error) {
 
 	// Build up a map of the User's Preferences in the database while also
 	// checking that they are each allowed
-	for _, uP := range uPrefs {
+	for _, uP := range u.UserPreferences {
 		_, ok := allowedUserPreferenceKeys[uP.Key]
 		if !ok {
 			domain.Logger.Printf("the database included a user preference with an unexpected key %s", uP.Key)

--- a/application/models/user_fixtures_test.go
+++ b/application/models/user_fixtures_test.go
@@ -645,14 +645,14 @@ func CreateUserFixtures_TestGetPreference(ms *ModelSuite) UserFixtures {
 		{
 			Uuid:   domain.GetUuid(),
 			UserID: users[0].ID,
-			Key:    "User0Key1",
-			Value:  "User0Val1",
+			Key:    domain.UserPreferenceKeyLanguage,
+			Value:  domain.UserPreferenceLanguageEnglish,
 		},
 		{
 			Uuid:   domain.GetUuid(),
 			UserID: users[0].ID,
-			Key:    "User0Key2",
-			Value:  "User0Val2",
+			Key:    domain.UserPreferenceKeyWeightUnit,
+			Value:  domain.UserPreferenceWeightUnitKGs,
 		},
 	}
 

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -1099,8 +1099,9 @@ func (ms *ModelSuite) TestUser_UpdateStandardPreferences() {
 				TimeZone:   "America/New York",
 			},
 			want: StandardPreferences{
-				Language: domain.UserPreferenceLanguageFrench,
-				TimeZone: "America/New York",
+				Language:   domain.UserPreferenceLanguageFrench,
+				WeightUnit: domain.UserPreferenceWeightUnitKGs,
+				TimeZone:   "America/New York",
 			},
 		},
 		{

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -1096,12 +1096,12 @@ func (ms *ModelSuite) TestUser_UpdateStandardPreferences() {
 			SPrefs: StandardPreferences{
 				Language:   domain.UserPreferenceLanguageFrench,
 				WeightUnit: domain.UserPreferenceWeightUnitKGs,
-				TimeZone:   "America/New York",
+				TimeZone:   "America/New_York",
 			},
 			want: StandardPreferences{
 				Language:   domain.UserPreferenceLanguageFrench,
 				WeightUnit: domain.UserPreferenceWeightUnitKGs,
-				TimeZone:   "America/New York",
+				TimeZone:   "America/New_York",
 			},
 		},
 		{

--- a/application/models/userpreference.go
+++ b/application/models/userpreference.go
@@ -13,6 +13,12 @@ import (
 	"github.com/silinternational/wecarry-api/domain"
 )
 
+type StandardPreferences struct {
+	Language   string `json:"language"`
+	TimeZone   string `json:"time_zone"`
+	WeightUnit string `json:"weight_unit"`
+}
+
 type UserPreference struct {
 	ID        int       `json:"id" db:"id"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`


### PR DESCRIPTION

I created graphql enums for the language and weighUnit values. 

for example:
```
mutation { user: updateUser(input:{id: "6fc44091-c8bf-485a-9d46-a28b0f686af6", preferences: {weightUnit: KILOGRAMS}}) {id nickname preferences {language, timeZone, weightUnit}} }
```