### PR TITLE
Restrict user profile data visibility

### DIFF
--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -130,6 +130,12 @@ type ComplexityRoot struct {
 		UpdatedAt    func(childComplexity int) int
 	}
 
+	PublicProfile struct {
+		AvatarURL func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Nickname  func(childComplexity int) int
+	}
+
 	Query struct {
 		Message   func(childComplexity int, id *string) int
 		MyThreads func(childComplexity int) int
@@ -183,7 +189,7 @@ type LocationResolver interface {
 }
 type MessageResolver interface {
 	ID(ctx context.Context, obj *models.Message) (string, error)
-	Sender(ctx context.Context, obj *models.Message) (*models.User, error)
+	Sender(ctx context.Context, obj *models.Message) (*PublicProfile, error)
 
 	Thread(ctx context.Context, obj *models.Message) (*models.Thread, error)
 }
@@ -212,9 +218,9 @@ type OrganizationDomainResolver interface {
 type PostResolver interface {
 	ID(ctx context.Context, obj *models.Post) (string, error)
 
-	CreatedBy(ctx context.Context, obj *models.Post) (*models.User, error)
-	Receiver(ctx context.Context, obj *models.Post) (*models.User, error)
-	Provider(ctx context.Context, obj *models.Post) (*models.User, error)
+	CreatedBy(ctx context.Context, obj *models.Post) (*PublicProfile, error)
+	Receiver(ctx context.Context, obj *models.Post) (*PublicProfile, error)
+	Provider(ctx context.Context, obj *models.Post) (*PublicProfile, error)
 	Organization(ctx context.Context, obj *models.Post) (*models.Organization, error)
 
 	Description(ctx context.Context, obj *models.Post) (*string, error)
@@ -244,7 +250,7 @@ type QueryResolver interface {
 }
 type ThreadResolver interface {
 	ID(ctx context.Context, obj *models.Thread) (string, error)
-	Participants(ctx context.Context, obj *models.Thread) ([]models.User, error)
+	Participants(ctx context.Context, obj *models.Thread) ([]PublicProfile, error)
 	Messages(ctx context.Context, obj *models.Thread) ([]models.Message, error)
 	PostID(ctx context.Context, obj *models.Thread) (string, error)
 	Post(ctx context.Context, obj *models.Thread) (*models.Post, error)
@@ -727,6 +733,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.UpdatedAt(childComplexity), true
 
+	case "PublicProfile.avatarURL":
+		if e.complexity.PublicProfile.AvatarURL == nil {
+			break
+		}
+
+		return e.complexity.PublicProfile.AvatarURL(childComplexity), true
+
+	case "PublicProfile.id":
+		if e.complexity.PublicProfile.ID == nil {
+			break
+		}
+
+		return e.complexity.PublicProfile.ID(childComplexity), true
+
+	case "PublicProfile.nickname":
+		if e.complexity.PublicProfile.Nickname == nil {
+			break
+		}
+
+		return e.complexity.PublicProfile.Nickname(childComplexity), true
+
 	case "Query.message":
 		if e.complexity.Query.Message == nil {
 			break
@@ -1132,6 +1159,13 @@ input UpdateUserPreferencesInput {
     weightUnit: PreferredWeightUnit
 }
 
+"User fields that can safely be visible to any user in the system"
+type PublicProfile {
+    id: ID
+    nickname: String
+    avatarURL: String
+}
+
 enum PostType {
     REQUEST
     OFFER
@@ -1140,9 +1174,9 @@ enum PostType {
 type Post {
     id: ID!
     type: PostType!
-    createdBy: User!
-    receiver: User
-    provider: User
+    createdBy: PublicProfile!
+    receiver: PublicProfile
+    provider: PublicProfile
     organization: Organization
     title: String!
     description: String
@@ -1204,7 +1238,7 @@ input RemoveOrganizationDomainInput {
 
 type Thread {
     id: ID!
-    participants: [User!]!
+    participants: [PublicProfile!]!
     messages: [Message!]!
     postID: String!
     post: Post!
@@ -1216,7 +1250,7 @@ type Thread {
 
 type Message {
     id: ID!
-    sender: User!
+    sender: PublicProfile!
     content: String!
     thread: Thread!
     createdAt: Time!
@@ -1979,10 +2013,10 @@ func (ec *executionContext) _Message_sender(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*models.User)
+	res := resTmp.(*PublicProfile)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalNPublicProfile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Message_content(ctx context.Context, field graphql.CollectedField, obj *models.Message) (ret graphql.Marshaler) {
@@ -2971,10 +3005,10 @@ func (ec *executionContext) _Post_createdBy(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*models.User)
+	res := resTmp.(*PublicProfile)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalNPublicProfile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Post_receiver(ctx context.Context, field graphql.CollectedField, obj *models.Post) (ret graphql.Marshaler) {
@@ -3005,10 +3039,10 @@ func (ec *executionContext) _Post_receiver(ctx context.Context, field graphql.Co
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*models.User)
+	res := resTmp.(*PublicProfile)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalOPublicProfile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Post_provider(ctx context.Context, field graphql.CollectedField, obj *models.Post) (ret graphql.Marshaler) {
@@ -3039,10 +3073,10 @@ func (ec *executionContext) _Post_provider(ctx context.Context, field graphql.Co
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*models.User)
+	res := resTmp.(*PublicProfile)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalOPublicProfile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Post_organization(ctx context.Context, field graphql.CollectedField, obj *models.Post) (ret graphql.Marshaler) {
@@ -3687,6 +3721,108 @@ func (ec *executionContext) _Post_isEditable(ctx context.Context, field graphql.
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _PublicProfile_id(ctx context.Context, field graphql.CollectedField, obj *PublicProfile) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "PublicProfile",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PublicProfile_nickname(ctx context.Context, field graphql.CollectedField, obj *PublicProfile) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "PublicProfile",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Nickname, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PublicProfile_avatarURL(ctx context.Context, field graphql.CollectedField, obj *PublicProfile) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "PublicProfile",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AvatarURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Query_users(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -4104,10 +4240,10 @@ func (ec *executionContext) _Thread_participants(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]models.User)
+	res := resTmp.([]PublicProfile)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+	return ec.marshalNPublicProfile2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Thread_messages(ctx context.Context, field graphql.CollectedField, obj *models.Thread) (ret graphql.Marshaler) {
@@ -7202,6 +7338,34 @@ func (ec *executionContext) _Post(ctx context.Context, sel ast.SelectionSet, obj
 	return out
 }
 
+var publicProfileImplementors = []string{"PublicProfile"}
+
+func (ec *executionContext) _PublicProfile(ctx context.Context, sel ast.SelectionSet, obj *PublicProfile) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, publicProfileImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PublicProfile")
+		case "id":
+			out.Values[i] = ec._PublicProfile_id(ctx, field, obj)
+		case "nickname":
+			out.Values[i] = ec._PublicProfile_nickname(ctx, field, obj)
+		case "avatarURL":
+			out.Values[i] = ec._PublicProfile_avatarURL(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var queryImplementors = []string{"Query"}
 
 func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
@@ -8275,6 +8439,57 @@ func (ec *executionContext) marshalNPostType2ᚖgithubᚗcomᚋsilinternational�
 	return v
 }
 
+func (ec *executionContext) marshalNPublicProfile2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx context.Context, sel ast.SelectionSet, v PublicProfile) graphql.Marshaler {
+	return ec._PublicProfile(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPublicProfile2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx context.Context, sel ast.SelectionSet, v []PublicProfile) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPublicProfile2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalNPublicProfile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx context.Context, sel ast.SelectionSet, v *PublicProfile) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._PublicProfile(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNRemoveOrganizationDomainInput2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐRemoveOrganizationDomainInput(ctx context.Context, v interface{}) (RemoveOrganizationDomainInput, error) {
 	return ec.unmarshalInputRemoveOrganizationDomainInput(ctx, v)
 }
@@ -8886,6 +9101,17 @@ func (ec *executionContext) marshalOPreferredWeightUnit2ᚖgithubᚗcomᚋsilint
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) marshalOPublicProfile2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx context.Context, sel ast.SelectionSet, v PublicProfile) graphql.Marshaler {
+	return ec._PublicProfile(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOPublicProfile2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx context.Context, sel ast.SelectionSet, v *PublicProfile) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._PublicProfile(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOString2string(ctx context.Context, v interface{}) (string, error) {

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -1161,8 +1161,8 @@ input UpdateUserPreferencesInput {
 
 "User fields that can safely be visible to any user in the system"
 type PublicProfile {
-    id: ID
-    nickname: String
+    id: ID!
+    nickname: String!
     avatarURL: String
 }
 
@@ -3747,12 +3747,15 @@ func (ec *executionContext) _PublicProfile_id(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PublicProfile_nickname(ctx context.Context, field graphql.CollectedField, obj *PublicProfile) (ret graphql.Marshaler) {
@@ -3781,12 +3784,15 @@ func (ec *executionContext) _PublicProfile_nickname(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PublicProfile_avatarURL(ctx context.Context, field graphql.CollectedField, obj *PublicProfile) (ret graphql.Marshaler) {
@@ -7351,8 +7357,14 @@ func (ec *executionContext) _PublicProfile(ctx context.Context, sel ast.Selectio
 			out.Values[i] = graphql.MarshalString("PublicProfile")
 		case "id":
 			out.Values[i] = ec._PublicProfile_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "nickname":
 			out.Values[i] = ec._PublicProfile_nickname(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "avatarURL":
 			out.Values[i] = ec._PublicProfile_avatarURL(ctx, field, obj)
 		default:

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -160,13 +160,13 @@ type ComplexityRoot struct {
 
 	User struct {
 		AdminRole          func(childComplexity int) int
+		AvatarURL          func(childComplexity int) int
 		CreatedAt          func(childComplexity int) int
 		Email              func(childComplexity int) int
 		ID                 func(childComplexity int) int
 		Location           func(childComplexity int) int
 		Nickname           func(childComplexity int) int
 		Organizations      func(childComplexity int) int
-		PhotoURL           func(childComplexity int) int
 		Posts              func(childComplexity int, role PostRole) int
 		Preferences        func(childComplexity int) int
 		UnreadMessageCount func(childComplexity int) int
@@ -263,7 +263,7 @@ type UserResolver interface {
 
 	Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error)
 	Posts(ctx context.Context, obj *models.User, role PostRole) ([]models.Post, error)
-	PhotoURL(ctx context.Context, obj *models.User) (*string, error)
+	AvatarURL(ctx context.Context, obj *models.User) (*string, error)
 	Preferences(ctx context.Context, obj *models.User) (*models.StandardPreferences, error)
 	Location(ctx context.Context, obj *models.User) (*models.Location, error)
 	UnreadMessageCount(ctx context.Context, obj *models.User) (int, error)
@@ -888,6 +888,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.AdminRole(childComplexity), true
 
+	case "User.avatarURL":
+		if e.complexity.User.AvatarURL == nil {
+			break
+		}
+
+		return e.complexity.User.AvatarURL(childComplexity), true
+
 	case "User.createdAt":
 		if e.complexity.User.CreatedAt == nil {
 			break
@@ -929,13 +936,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.Organizations(childComplexity), true
-
-	case "User.photoURL":
-		if e.complexity.User.PhotoURL == nil {
-			break
-		}
-
-		return e.complexity.User.PhotoURL(childComplexity), true
 
 	case "User.posts":
 		if e.complexity.User.Posts == nil {
@@ -1119,7 +1119,7 @@ type User {
     adminRole: UserAdminRole
     organizations: [Organization!]!
     posts(role: PostRole!): [Post!]!
-    photoURL: String
+    avatarURL: String
     preferences: UserPreferences
     location: Location
     unreadMessageCount: Int!
@@ -4811,7 +4811,7 @@ func (ec *executionContext) _User_posts(ctx context.Context, field graphql.Colle
 	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _User_photoURL(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
+func (ec *executionContext) _User_avatarURL(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -4830,7 +4830,7 @@ func (ec *executionContext) _User_photoURL(ctx context.Context, field graphql.Co
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.User().PhotoURL(rctx, obj)
+		return ec.resolvers.User().AvatarURL(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -7705,7 +7705,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 				}
 				return res
 			})
-		case "photoURL":
+		case "avatarURL":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
 				defer func() {
@@ -7713,7 +7713,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._User_photoURL(ctx, field, obj)
+				res = ec._User_avatarURL(ctx, field, obj)
 				return res
 			})
 		case "preferences":

--- a/application/gqlgen/gqlgenutils.go
+++ b/application/gqlgen/gqlgenutils.go
@@ -71,7 +71,8 @@ func convertUserPreferencesToStandardPreferences(input *UpdateUserPreferencesInp
 	return stPrefs, nil
 }
 
-// getFunctionName provides the filename, line number, and function name of the 2nd caller.
+// getFunctionName provides the filename, line number, and function name of the caller, skipping the top `skip`
+// functions on the stack.
 func getFunctionName(skip int) string {
 	pc, file, line, ok := runtime.Caller(skip)
 	if !ok {

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -32,12 +32,7 @@ func (r *messageResolver) Sender(ctx context.Context, obj *models.Message) (*Pub
 		return nil, reportError(ctx, err, "GetMessageSender")
 	}
 
-	profile, err := getPublicProfile(user)
-	if err != nil {
-		return nil, reportError(ctx, err, "GetMessageSender.GetPublicProfile")
-	}
-
-	return profile, nil
+	return getPublicProfile(ctx, user), nil
 }
 
 // Thread resolves the `thread` property of the message query

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -23,7 +23,7 @@ func (r *messageResolver) ID(ctx context.Context, obj *models.Message) (string, 
 }
 
 // Sender resolves the `sender` property of the message query
-func (r *messageResolver) Sender(ctx context.Context, obj *models.Message) (*models.User, error) {
+func (r *messageResolver) Sender(ctx context.Context, obj *models.Message) (*PublicProfile, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -32,7 +32,12 @@ func (r *messageResolver) Sender(ctx context.Context, obj *models.Message) (*mod
 		return nil, reportError(ctx, err, "GetMessageSender")
 	}
 
-	return user, nil
+	profile, err := getPublicProfile(user)
+	if err != nil {
+		return nil, reportError(ctx, err, "GetMessageSender.GetPublicProfile")
+	}
+
+	return profile, nil
 }
 
 // Thread resolves the `thread` property of the message query

--- a/application/gqlgen/message_test.go
+++ b/application/gqlgen/message_test.go
@@ -6,11 +6,7 @@ type messageResponse struct {
 		Content string `json:"content"`
 		Sender  struct {
 			ID       string `json:"id"`
-			Email    string `json:"email"`
 			Nickname string `json:"nickname"`
-			Location struct {
-				Description string `json:"description"`
-			} `json:"location"`
 		} `json:"sender"`
 		Thread struct {
 			ID           string `json:"id"`
@@ -27,7 +23,7 @@ func (gs *GqlgenSuite) TestMessageQuery() {
 	c := getGqlClient()
 
 	query := `{ message(id: "` + f.Messages[0].Uuid.String() + `")
-		{ id content sender { location { description }} thread {id participants {nickname}}}}`
+		{ id content sender { nickname } thread {id participants {nickname}}}}`
 
 	var resp messageResponse
 
@@ -44,8 +40,7 @@ func (gs *GqlgenSuite) TestMessageQuery() {
 
 	gs.Equal(f.Messages[0].Uuid.String(), resp.Message.ID)
 	gs.Equal(f.Messages[0].Content, resp.Message.Content)
-	gs.Equal(f.Messages[0].SentBy.Nickname, resp.Message.Sender.Nickname)
-	gs.Equal(f.Messages[0].SentBy.Location.Description, resp.Message.Sender.Location.Description)
+	gs.Equal(f.Users[1].Nickname, resp.Message.Sender.Nickname)
 	gs.Equal(thread.Uuid.String(), resp.Message.Thread.ID)
 	gs.Equal(participants[0].Nickname, resp.Message.Thread.Participants[0].Nickname)
 	gs.Equal(participants[1].Nickname, resp.Message.Thread.Participants[1].Nickname)

--- a/application/gqlgen/models_gen.go
+++ b/application/gqlgen/models_gen.go
@@ -38,8 +38,8 @@ type LocationInput struct {
 
 // User fields that can safely be visible to any user in the system
 type PublicProfile struct {
-	ID        *string `json:"id"`
-	Nickname  *string `json:"nickname"`
+	ID        string  `json:"id"`
+	Nickname  string  `json:"nickname"`
 	AvatarURL *string `json:"avatarURL"`
 }
 

--- a/application/gqlgen/models_gen.go
+++ b/application/gqlgen/models_gen.go
@@ -36,6 +36,13 @@ type LocationInput struct {
 	Longitude   *float64 `json:"longitude"`
 }
 
+// User fields that can safely be visible to any user in the system
+type PublicProfile struct {
+	ID        *string `json:"id"`
+	Nickname  *string `json:"nickname"`
+	AvatarURL *string `json:"avatarURL"`
+}
+
 type RemoveOrganizationDomainInput struct {
 	Domain         string `json:"domain"`
 	OrganizationID string `json:"organizationID"`

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -38,7 +38,7 @@ func (r *postResolver) Status(ctx context.Context, obj *models.Post) (string, er
 }
 
 // CreatedBy resolves the `createdBy` property of the post query. It retrieves the related record from the database.
-func (r *postResolver) CreatedBy(ctx context.Context, obj *models.Post) (*models.User, error) {
+func (r *postResolver) CreatedBy(ctx context.Context, obj *models.Post) (*PublicProfile, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -48,11 +48,15 @@ func (r *postResolver) CreatedBy(ctx context.Context, obj *models.Post) (*models
 		return nil, reportError(ctx, err, "GetPostCreator")
 	}
 
-	return creator, nil
+	profile, err := getPublicProfile(creator)
+	if err != nil {
+		return nil, reportError(ctx, err, "GetPostCreator.GetPublicProfile")
+	}
+	return profile, nil
 }
 
 // Receiver resolves the `receiver` property of the post query. It retrieves the related record from the database.
-func (r *postResolver) Receiver(ctx context.Context, obj *models.Post) (*models.User, error) {
+func (r *postResolver) Receiver(ctx context.Context, obj *models.Post) (*PublicProfile, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -62,11 +66,16 @@ func (r *postResolver) Receiver(ctx context.Context, obj *models.Post) (*models.
 		return nil, reportError(ctx, err, "GetPostReceiver")
 	}
 
-	return receiver, nil
+	profile, err := getPublicProfile(receiver)
+	if err != nil {
+		return nil, reportError(ctx, err, "GetPostReceiver.GetPublicProfile")
+	}
+
+	return profile, nil
 }
 
 // Provider resolves the `provider` property of the post query. It retrieves the related record from the database.
-func (r *postResolver) Provider(ctx context.Context, obj *models.Post) (*models.User, error) {
+func (r *postResolver) Provider(ctx context.Context, obj *models.Post) (*PublicProfile, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -76,7 +85,12 @@ func (r *postResolver) Provider(ctx context.Context, obj *models.Post) (*models.
 		return nil, reportError(ctx, err, "GetPostProvider")
 	}
 
-	return provider, nil
+	profile, err := getPublicProfile(provider)
+	if err != nil {
+		return nil, reportError(ctx, err, "GetPostProvider.GetPublicProfile")
+	}
+
+	return profile, nil
 }
 
 // Organization resolves the `organization` property of the post query. It retrieves the related record from the

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -48,11 +48,7 @@ func (r *postResolver) CreatedBy(ctx context.Context, obj *models.Post) (*Public
 		return nil, reportError(ctx, err, "GetPostCreator")
 	}
 
-	profile, err := getPublicProfile(creator)
-	if err != nil {
-		return nil, reportError(ctx, err, "GetPostCreator.GetPublicProfile")
-	}
-	return profile, nil
+	return getPublicProfile(ctx, creator), nil
 }
 
 // Receiver resolves the `receiver` property of the post query. It retrieves the related record from the database.
@@ -66,12 +62,7 @@ func (r *postResolver) Receiver(ctx context.Context, obj *models.Post) (*PublicP
 		return nil, reportError(ctx, err, "GetPostReceiver")
 	}
 
-	profile, err := getPublicProfile(receiver)
-	if err != nil {
-		return nil, reportError(ctx, err, "GetPostReceiver.GetPublicProfile")
-	}
-
-	return profile, nil
+	return getPublicProfile(ctx, receiver), nil
 }
 
 // Provider resolves the `provider` property of the post query. It retrieves the related record from the database.
@@ -85,12 +76,7 @@ func (r *postResolver) Provider(ctx context.Context, obj *models.Post) (*PublicP
 		return nil, reportError(ctx, err, "GetPostProvider")
 	}
 
-	profile, err := getPublicProfile(provider)
-	if err != nil {
-		return nil, reportError(ctx, err, "GetPostProvider.GetPublicProfile")
-	}
-
-	return profile, nil
+	return getPublicProfile(ctx, provider), nil
 }
 
 // Organization resolves the `organization` property of the post query. It retrieves the related record from the

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -64,7 +64,7 @@ type User {
     adminRole: UserAdminRole
     organizations: [Organization!]!
     posts(role: PostRole!): [Post!]!
-    photoURL: String
+    avatarURL: String
     preferences: UserPreferences
     location: Location
     unreadMessageCount: Int!

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -104,6 +104,13 @@ input UpdateUserPreferencesInput {
     weightUnit: PreferredWeightUnit
 }
 
+"User fields that can safely be visible to any user in the system"
+type PublicProfile {
+    id: ID!
+    nickname: String!
+    avatarURL: String
+}
+
 enum PostType {
     REQUEST
     OFFER
@@ -112,9 +119,9 @@ enum PostType {
 type Post {
     id: ID!
     type: PostType!
-    createdBy: User!
-    receiver: User
-    provider: User
+    createdBy: PublicProfile!
+    receiver: PublicProfile
+    provider: PublicProfile
     organization: Organization
     title: String!
     description: String
@@ -176,7 +183,7 @@ input RemoveOrganizationDomainInput {
 
 type Thread {
     id: ID!
-    participants: [User!]!
+    participants: [PublicProfile!]!
     messages: [Message!]!
     postID: String!
     post: Post!
@@ -188,7 +195,7 @@ type Thread {
 
 type Message {
     id: ID!
-    sender: User!
+    sender: PublicProfile!
     content: String!
     thread: Thread!
     createdAt: Time!

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -28,15 +28,7 @@ func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) (
 		return nil, reportError(ctx, err, "GetThreadParticipants")
 	}
 
-	profiles := make([]PublicProfile, len(participants))
-	for i, p := range participants {
-		prof, err := getPublicProfile(&p)
-		if err != nil {
-			return nil, reportError(ctx, err, "GetThreadParticipants.GetPublicProfile")
-		}
-		profiles[i] = *prof
-	}
-	return profiles, nil
+	return getPublicProfiles(ctx, participants), nil
 }
 
 // ID resolves the `ID` property of the thread query. It provides the UUID instead of the autoincrement ID.

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -18,7 +18,7 @@ type threadResolver struct{ *Resolver }
 
 // Participants resolves the `participants` property of the thread query, retrieving the related records from the
 // database.
-func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) ([]models.User, error) {
+func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) ([]PublicProfile, error) {
 	if obj == nil {
 		return nil, nil
 	}
@@ -28,7 +28,15 @@ func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) (
 		return nil, reportError(ctx, err, "GetThreadParticipants")
 	}
 
-	return participants, nil
+	profiles := make([]PublicProfile, len(participants))
+	for i, p := range participants {
+		prof, err := getPublicProfile(&p)
+		if err != nil {
+			return nil, reportError(ctx, err, "GetThreadParticipants.GetPublicProfile")
+		}
+		profiles[i] = *prof
+	}
+	return profiles, nil
 }
 
 // ID resolves the `ID` property of the thread query. It provides the UUID instead of the autoincrement ID.

--- a/application/gqlgen/thread_test.go
+++ b/application/gqlgen/thread_test.go
@@ -12,11 +12,7 @@ type threadsResponse struct {
 			Content string `json:"content"`
 			Sender  struct {
 				ID       string `json:"id"`
-				Email    string `json:"email"`
 				Nickname string `json:"nickname"`
-				Location struct {
-					Description string `json:"description"`
-				} `json:"location"`
 			} `json:"sender"`
 		} `json:"messages"`
 		Post struct {
@@ -30,7 +26,7 @@ func (gs *GqlgenSuite) TestThreadsQuery() {
 	c := getGqlClient()
 
 	query := `{ threads
-		{ id post { id } participants {nickname} messages {id content sender { location { description }}}}  }`
+		{ id post { id } participants {nickname} messages {id content sender { nickname }}}  }`
 
 	var resp threadsResponse
 
@@ -43,8 +39,7 @@ func (gs *GqlgenSuite) TestThreadsQuery() {
 	gs.Equal(f.Posts[0].Uuid.String(), resp.Threads[0].Post.ID)
 	gs.Equal(f.Messages[0].Uuid.String(), resp.Threads[0].Messages[0].ID)
 	gs.Equal(f.Messages[0].Content, resp.Threads[0].Messages[0].Content)
-	gs.Equal(f.Messages[0].SentBy.Nickname, resp.Threads[0].Messages[0].Sender.Nickname)
-	gs.Equal(f.Messages[0].SentBy.Location.Description, resp.Threads[0].Messages[0].Sender.Location.Description)
+	gs.Equal(f.Users[1].Nickname, resp.Threads[0].Messages[0].Sender.Nickname)
 
 	thread := f.Threads[0]
 	err = thread.Load("Participants")
@@ -85,7 +80,7 @@ func (gs *GqlgenSuite) TestMyThreadsQuery() {
 	c := getGqlClient()
 
 	query := `{ myThreads
-		{ id participants {nickname} messages {id content sender { location { description }}}}  }`
+		{ id participants {nickname} messages {id content sender { nickname }}}  }`
 
 	var resp myThreadsResponse
 
@@ -97,8 +92,7 @@ func (gs *GqlgenSuite) TestMyThreadsQuery() {
 	gs.Equal(f.Threads[0].Uuid.String(), resp.MyThreads[0].ID)
 	gs.Equal(f.Messages[0].Uuid.String(), resp.MyThreads[0].Messages[0].ID)
 	gs.Equal(f.Messages[0].Content, resp.MyThreads[0].Messages[0].Content)
-	gs.Equal(f.Messages[0].SentBy.Nickname, resp.MyThreads[0].Messages[0].Sender.Nickname)
-	gs.Equal(f.Messages[0].SentBy.Location.Description, resp.MyThreads[0].Messages[0].Sender.Location.Description)
+	gs.Equal(f.Users[1].Nickname, resp.MyThreads[0].Messages[0].Sender.Nickname)
 
 	thread := f.Threads[0]
 	err = thread.Load("Participants")

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -62,8 +62,8 @@ func (r *userResolver) Posts(ctx context.Context, obj *models.User, role PostRol
 	return posts, nil
 }
 
-// PhotoURL retrieves a URL for the user profile photo or avatar.
-func (r *userResolver) PhotoURL(ctx context.Context, obj *models.User) (*string, error) {
+// AvatarURL retrieves a URL for the user profile photo or avatar.
+func (r *userResolver) AvatarURL(ctx context.Context, obj *models.User) (*string, error) {
 	if obj == nil {
 		return nil, nil
 	}

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -234,3 +234,17 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 
 	return &standardPrefs, nil
 }
+
+func getPublicProfile(user *models.User) (*PublicProfile, error) {
+	id := user.Uuid.String()
+	nickname := user.Nickname
+	url, err := user.GetPhotoURL()
+	if err != nil {
+		return nil, err
+	}
+	return &PublicProfile{
+		ID:        &id,
+		Nickname:  &nickname,
+		AvatarURL: url,
+	}, nil
+}

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -235,15 +235,26 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 	return &standardPrefs, nil
 }
 
+// getPublicProfiles converts a list of models.User to PublicProfile, hiding private profile information
+func getPublicProfiles(ctx context.Context, users []models.User) []PublicProfile {
+	profiles := make([]PublicProfile, len(users))
+	for i, p := range users {
+		prof := getPublicProfile(ctx, &p)
+		profiles[i] = *prof
+	}
+	return profiles
+}
+
 // getPublicProfile converts a models.User to a PublicProfile, which hides private profile information
-func getPublicProfile(user *models.User) (*PublicProfile, error) {
+func getPublicProfile(ctx context.Context, user *models.User) *PublicProfile {
 	url, err := user.GetPhotoURL()
 	if err != nil {
-		return nil, err
+		_ = reportError(ctx, err, "", map[string]interface{}{"user": user.Uuid})
+		return nil
 	}
 	return &PublicProfile{
 		ID:        user.Uuid.String(),
 		Nickname:  user.Nickname,
 		AvatarURL: url,
-	}, nil
+	}
 }

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -247,11 +247,16 @@ func getPublicProfiles(ctx context.Context, users []models.User) []PublicProfile
 
 // getPublicProfile converts a models.User to a PublicProfile, which hides private profile information
 func getPublicProfile(ctx context.Context, user *models.User) *PublicProfile {
+	if user == nil {
+		return nil
+	}
+
 	url, err := user.GetPhotoURL()
 	if err != nil {
 		_ = reportError(ctx, err, "", map[string]interface{}{"user": user.Uuid})
 		return nil
 	}
+
 	return &PublicProfile{
 		ID:        user.Uuid.String(),
 		Nickname:  user.Nickname,

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -235,6 +235,7 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 	return &standardPrefs, nil
 }
 
+// getPublicProfile converts a models.User to a PublicProfile, which hides private profile information
 func getPublicProfile(user *models.User) (*PublicProfile, error) {
 	url, err := user.GetPhotoURL()
 	if err != nil {

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -236,15 +236,13 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 }
 
 func getPublicProfile(user *models.User) (*PublicProfile, error) {
-	id := user.Uuid.String()
-	nickname := user.Nickname
 	url, err := user.GetPhotoURL()
 	if err != nil {
 		return nil, err
 	}
 	return &PublicProfile{
-		ID:        &id,
-		Nickname:  &nickname,
+		ID:        user.Uuid.String(),
+		Nickname:  user.Nickname,
 		AvatarURL: url,
 	}, nil
 }

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -31,8 +31,8 @@ type UserResponse struct {
 			TimeZone   *string `json:"timeZone"`
 			WeightUnit *string `json:"weightUnit"`
 		}
-		PhotoURL string `json:"photoURL"`
-		Location struct {
+		AvatarURL string `json:"avatarURL"`
+		Location  struct {
 			Description string  `json:"description"`
 			Country     string  `json:"country"`
 			Lat         float64 `json:"latitude"`
@@ -183,7 +183,7 @@ func (gs *GqlgenSuite) TestUserQuery() {
 
 	var resp UserResponse
 
-	allFields := `{ id email nickname adminRole photoURL preferences {language timeZone weightUnit}  
+	allFields := `{ id email nickname adminRole avatarURL preferences {language timeZone weightUnit}  
 		posts (role: CREATEDBY) {id} organizations {id}
 		location {description country latitude longitude} }`
 	testCases := []testCase{
@@ -199,8 +199,8 @@ func (gs *GqlgenSuite) TestUserQuery() {
 				gs.Equal(f.Users[1].Email, resp.User.Email, "incorrect Email")
 				gs.Equal(f.Users[1].Nickname, resp.User.Nickname, "incorrect Nickname")
 				gs.Equal(f.Users[1].AdminRole, resp.User.AdminRole, "incorrect AdminRole")
-				gs.Equal(f.Users[1].PhotoFile.URL, resp.User.PhotoURL, "incorrect PhotoURL")
-				gs.Regexp("^https?", resp.User.PhotoURL, "invalid PhotoURL")
+				gs.Equal(f.Users[1].PhotoFile.URL, resp.User.AvatarURL, "incorrect AvatarURL")
+				gs.Regexp("^https?", resp.User.AvatarURL, "invalid AvatarURL")
 				gs.Equal(1, len(resp.User.Posts), "wrong number of posts")
 				gs.Equal(f.Posts[0].Uuid.String(), resp.User.Posts[0].ID, "incorrect Post ID")
 				gs.Equal(1, len(resp.User.Organizations), "wrong number of Organizations")
@@ -271,7 +271,7 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 
 	preferences := fmt.Sprintf(`{weightUnit: %s}`, strings.ToUpper(domain.UserPreferenceWeightUnitKGs))
 
-	requestedFields := `{id nickname photoURL preferences {language, timeZone, weightUnit} location {description, country}}`
+	requestedFields := `{id nickname avatarURL preferences {language, timeZone, weightUnit} location {description, country}}`
 
 	update := fmt.Sprintf(`mutation { user: updateUser(input:{id: "%s", nickname: "%s", location: %s, preferences: %s}) %s }`,
 		userID, newNickname, location, preferences, requestedFields)
@@ -286,8 +286,8 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 					t.Errorf("failed to load user fixture, %s", err)
 				}
 				gs.Equal(newNickname, resp.User.Nickname, "incorrect Nickname")
-				gs.Equal(f.Users[1].PhotoFile.URL, resp.User.PhotoURL, "incorrect PhotoURL")
-				gs.Regexp("^https?", resp.User.PhotoURL, "invalid PhotoURL")
+				gs.Equal(f.Users[1].PhotoFile.URL, resp.User.AvatarURL, "incorrect AvatarURL")
+				gs.Regexp("^https?", resp.User.AvatarURL, "invalid AvatarURL")
 				gs.Equal("Paris, France", resp.User.Location.Description, "incorrect location")
 				gs.Equal("FR", resp.User.Location.Country, "incorrect country")
 

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/nulls"
 	"github.com/silinternational/wecarry-api/aws"
 	"github.com/silinternational/wecarry-api/domain"
@@ -320,5 +321,56 @@ func (gs *GqlgenSuite) TestUpdateUser() {
 			gs.NoError(err)
 		}
 		t.Run(test.Name, test.Test)
+	}
+}
+
+func createFixturesForGetPublicProfile()UserQueryFixtures {
+	unique := domain.GetUuid().String()
+	user :=  models.User{
+		Uuid: domain.GetUuid(),
+		Nickname:     "user0" + unique,
+		AuthPhotoURL: nulls.NewString("https://example.com/userphoto/1"),
+	}
+	return UserQueryFixtures{Users: models.Users{user}}
+}
+
+func (gs *GqlgenSuite) Test_getPublicProfile() {
+	t := gs.T()
+	f := createFixturesForGetPublicProfile()
+	tests := []struct {
+		name string
+		user *models.User
+		want PublicProfile
+		wantNil bool
+	}{
+		{
+			name: "fully-specified User",
+			user: &f.Users[0],
+			want: PublicProfile{
+				ID:        f.Users[0].Uuid.String(),
+				Nickname:  f.Users[0].Nickname,
+				AvatarURL: &f.Users[0].AuthPhotoURL.String,
+			},
+		},
+		{
+			name: "nil user",
+			user: 	nil,
+			wantNil: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var ctx *buffalo.DefaultContext
+			profile := getPublicProfile(ctx, test.user)
+
+			if test.wantNil {
+				gs.Nil(profile)
+				return
+			}
+			gs.NotNil(profile)
+			gs.Equal(test.want.ID, profile.ID, "ID doesn't match")
+			gs.Equal(test.want.Nickname, profile.Nickname, "Nickname doesn't match")
+			gs.Equal(*test.want.AvatarURL, *profile.AvatarURL, "AvatarURL doesn't match")
+		})
 	}
 }

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -1,5 +1,7 @@
 - id: GetMessageSender
   translation: We had a problem finding the message sender information.
+- id: GetMessageSender.GetPublicProfile
+  translation: We had a problem finding the message sender's profile.
 - id: GetMessageThread
   translation: We had a problem finding the message conversation information.
 - id: GetMessage
@@ -40,10 +42,16 @@
   translation: We had a problem finding the list of domains for the organization.
 - id: GetPostCreator
   translation: We had a problem finding the creator of that request or offer.
+- id: GetPostCreator.GetPublicProfile
+  translation: We had a problem finding the profile of the creator of that request or offer.
 - id: GetPostReceiver
   translation: We had a problem finding the receiver for that request or offer.
+- id: GetPostReceivr.GetPublicProfile
+  translation: We had a problem finding the profile of the receiver of that request or offer.
 - id: GetPostProvider
   translation: We had a problem finding the provider for that request or offer.
+- id: GetPostProvider.GetPublicProfile
+  translation: We had a problem finding the profile of the provider of that request or offer.
 - id: GetPostOrganization
   translation: We had a problem finding the organization for that request or offer.
 - id: GetPostDestination
@@ -88,6 +96,8 @@
   translation: You are not authorized to change the status of that post.
 - id: GetThreadParticipants
   translation: We had a problem getting a list of participants in that conversation.
+- id: GetThreadParticipants.GetPublicProfile
+  translation: We had a problem getting the profiles of the participants in that conversation.
 - id: GetThreadLastViewedAt
   translation: We had a problem finding the time you last viewed that conversation.
 - id: GetThreadMessages

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -1,7 +1,5 @@
 - id: GetMessageSender
   translation: We had a problem finding the message sender information.
-- id: GetMessageSender.GetPublicProfile
-  translation: We had a problem finding the message sender's profile.
 - id: GetMessageThread
   translation: We had a problem finding the message conversation information.
 - id: GetMessage
@@ -42,16 +40,10 @@
   translation: We had a problem finding the list of domains for the organization.
 - id: GetPostCreator
   translation: We had a problem finding the creator of that request or offer.
-- id: GetPostCreator.GetPublicProfile
-  translation: We had a problem finding the profile of the creator of that request or offer.
 - id: GetPostReceiver
   translation: We had a problem finding the receiver for that request or offer.
-- id: GetPostReceivr.GetPublicProfile
-  translation: We had a problem finding the profile of the receiver of that request or offer.
 - id: GetPostProvider
   translation: We had a problem finding the provider for that request or offer.
-- id: GetPostProvider.GetPublicProfile
-  translation: We had a problem finding the profile of the provider of that request or offer.
 - id: GetPostOrganization
   translation: We had a problem finding the organization for that request or offer.
 - id: GetPostDestination
@@ -96,8 +88,6 @@
   translation: You are not authorized to change the status of that post.
 - id: GetThreadParticipants
   translation: We had a problem getting a list of participants in that conversation.
-- id: GetThreadParticipants.GetPublicProfile
-  translation: We had a problem getting the profiles of the participants in that conversation.
 - id: GetThreadLastViewedAt
   translation: We had a problem finding the time you last viewed that conversation.
 - id: GetThreadMessages

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	"crypto/md5"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/events"
@@ -372,7 +374,10 @@ func (u *User) GetPhotoURL() (*string, error) {
 		if u.AuthPhotoURL.Valid {
 			return &u.AuthPhotoURL.String, nil
 		}
-		return nil, nil
+		// ref: https://en.gravatar.com/site/implement/images/
+		hash := md5.Sum([]byte(strings.ToLower(strings.TrimSpace(u.Email))))
+		url := fmt.Sprintf("https://www.gravatar.com/avatar/%x.jpg?s=200&d=mp", hash)
+		return &url, nil
 	}
 
 	if err := u.PhotoFile.RefreshURL(); err != nil {

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -1,8 +1,10 @@
 package models
 
 import (
+	"crypto/md5"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -751,17 +753,19 @@ func (ms *ModelSuite) TestUser_GetPhoto() {
 	t := ms.T()
 	f := createFixturesForTestUserGetPhoto(ms)
 
+	hash := md5.Sum([]byte(strings.ToLower(strings.TrimSpace(f.Users[0].Email))))
+	gravatarURL := fmt.Sprintf("https://www.gravatar.com/avatar/%x.jpg?s=200&d=mp", hash)
+
 	tests := []struct {
 		name    string
 		user    User
 		wantURL string
-		wantNil bool
 		wantErr string
 	}{
 		{
 			name:    "no AuthPhoto, no photo attachment",
 			user:    f.Users[0],
-			wantNil: true,
+			wantURL: gravatarURL,
 		},
 		{
 			name:    "AuthPhoto, and no photo attachment",
@@ -790,10 +794,6 @@ func (ms *ModelSuite) TestUser_GetPhoto() {
 			}
 			ms.NoError(err)
 
-			if test.wantNil {
-				ms.Nil(url)
-				return
-			}
 			ms.NotNil(url)
 			ms.Equal(test.wantURL, *url)
 		})


### PR DESCRIPTION
Change GraphQL schema to only return a full user profile from the `user` and `users` queries and `updateUser` mutation, which have restricted access. This is a breaking change to the API.

This requires that the Gravatar URL generation be moved back into the API.