### PR TITLE
run go as non-root user -- avoids local files being owned by root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ migratetestdb: testdb
 	docker-compose run --rm test whenavail testdb 5432 10 buffalo-pop pop migrate up
 
 gqlgen:
-	docker-compose run --rm buffalo /bin/bash -c "go generate ./gqlgen ; chown 1000.1000 gqlgen/generated.go gqlgen/models_gen.go"
+	docker-compose run --rm buffalo /bin/bash -c "go generate ./gqlgen"
 
 adminer:
 	docker-compose up -d adminer

--- a/application/Dockerfile-dev
+++ b/application/Dockerfile-dev
@@ -1,5 +1,7 @@
 FROM gobuffalo/buffalo:v0.14.6
 
+RUN chmod -R o=,g=rwX $GOPATH/pkg
+
 RUN apt-get update && apt-get install -y \
     nano \
     curl \
@@ -12,11 +14,14 @@ RUN curl -o /usr/local/bin/whenavail https://bitbucket.org/silintl/docker-whenav
 RUN mkdir -p /wecarry
 WORKDIR /wecarry
 
-
 RUN echo 'alias ll="ls -al"' >> ~/.bashrc
 
 ADD . .
+RUN chmod 660 /wecarry/go.* && chmod 770 /wecarry
 ENV GO111MODULE=on
+
+RUN useradd user && usermod -a -G root user && mkdir /home/user && chown user.user /home/user
+USER user
 RUN go get ./...
 RUN go get github.com/gobuffalo/suite
 RUN go get github.com/gobuffalo/httptest


### PR DESCRIPTION
Got tired of the build process changing the ownership on go.mod, messing up Goland and Gitkraken. Also opened an issue on buffalo: https://github.com/gobuffalo/buffalo/issues/1862.