### PR TITLE
remove /site/status requests from log output

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -60,6 +60,7 @@ func App() *buffalo.App {
 		app.Use(domain.T.Middleware())
 
 		app.GET("/site/status", statusHandler)
+		app.Middleware.Skip(buffalo.RequestLogger, statusHandler)
 
 		app.POST("/gql/", gqlHandler)
 


### PR DESCRIPTION
server logs are filled with messages like 
> level=info time="2019-12-18T16:56:01Z" msg=/site/status/ duration="159.665µs"

I don't think we need them. Do we?