### PR TITLE
Before reading file contents, check size from file header

### DIFF
--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -39,11 +39,9 @@ func uploadHandler(c buffalo.Context) error {
 
 	if f.Size > int64(domain.MaxFileSize) {
 		domain.ErrLogger.Printf("file upload size (%v) greater than max file size (%v)", f.Size, domain.MaxFileSize)
-		return c.Render(http.StatusInternalServerError, render.JSON(UploadResponse{
-			Error: &domain.AppError{
-				Code: http.StatusBadRequest,
-				Key:  domain.ErrorStoreFileTooLarge,
-			},
+		return c.Render(http.StatusBadRequest, render.JSON(domain.AppError{
+			Code: http.StatusBadRequest,
+			Key:  domain.ErrorStoreFileTooLarge,
 		}))
 	}
 

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -37,6 +37,16 @@ func uploadHandler(c buffalo.Context) error {
 		}))
 	}
 
+	if f.Size > int64(domain.MaxFileSize) {
+		domain.ErrLogger.Printf("file upload size (%v) greater than max file size (%v)", f.Size, domain.MaxFileSize)
+		return c.Render(http.StatusInternalServerError, render.JSON(UploadResponse{
+			Error: &domain.AppError{
+				Code: http.StatusBadRequest,
+				Key:  domain.ErrorStoreFileTooLarge,
+			},
+		}))
+	}
+
 	content, err := ioutil.ReadAll(f)
 	if err != nil {
 		domain.ErrLogger.Printf("error reading uploaded file ... %v", err)


### PR DESCRIPTION
I noticed we were checking file size after reading it into a `[]byte` before storing in S3. Since the size is available as part of the `binding.File` I'm adding an earlier check here as well. 