### PR TITLE
fix max file size

### DIFF
--- a/application/actions/upload_test.go
+++ b/application/actions/upload_test.go
@@ -131,7 +131,7 @@ func (as *ActionSuite) Test_Upload() {
 
 	// File too big
 	readerBytes := []byte("GIF87a")
-	massive := make([]byte, 2099999)
+	massive := make([]byte, 10485760+1) // ten megabytes plus one
 	readerBytes = append(readerBytes, massive...)
 
 	f.Reader = bytes.NewReader(readerBytes)

--- a/application/actions/upload_test.go
+++ b/application/actions/upload_test.go
@@ -131,7 +131,7 @@ func (as *ActionSuite) Test_Upload() {
 
 	// File too big
 	readerBytes := []byte("GIF87a")
-	massive := make([]byte, 10485760+1) // ten megabytes plus one
+	massive := make([]byte, domain.Megabyte*10+1) // ten megabytes plus one
 	readerBytes = append(readerBytes, massive...)
 
 	f.Reader = bytes.NewReader(readerBytes)

--- a/application/actions/upload_test.go
+++ b/application/actions/upload_test.go
@@ -131,7 +131,7 @@ func (as *ActionSuite) Test_Upload() {
 
 	// File too big
 	readerBytes := []byte("GIF87a")
-	massive := make([]byte, domain.Megabyte*10+1) // ten megabytes plus one
+	massive := make([]byte, domain.Megabyte*10) // ten megabytes
 	readerBytes = append(readerBytes, massive...)
 
 	f.Reader = bytes.NewReader(readerBytes)

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	DateFormat                  = "2006-01-02"
-	MaxFileSize                 = 1 << 21 // 10 Mebibytes
+	MaxFileSize                 = 1024 * 1024 * 10 // 10 Megabytes
 	AccessTokenLifetimeSeconds  = 3600
 	DateTimeFormat              = "2006-01-02 15:04:05"
 	NewMessageNotificationDelay = 1 * time.Minute

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	Megabyte                    = 1048576
 	DateFormat                  = "2006-01-02"
 	MaxFileSize                 = 1024 * 1024 * 10 // 10 Megabytes
 	AccessTokenLifetimeSeconds  = 3600

--- a/application/models/file_test.go
+++ b/application/models/file_test.go
@@ -59,7 +59,7 @@ func (ms *ModelSuite) TestFile_Store() {
 		t.FailNow()
 	}
 
-	maxFileSize := 10485760 // ten megabytes
+	maxFileSize := domain.Megabyte * 10
 	biggishGifFile := make([]byte, maxFileSize)
 	tooBigFile := make([]byte, maxFileSize+1)
 	for i, b := range []byte("GIF87a") {


### PR DESCRIPTION
This is based on the idea that the max file size was intended to be 10 megabytes.  (It looks like that when we increased from 1 megabyte, we landed at a 2 megabyte limit accidentally)