### PR TITLE
Use post visibility to show posts from trusted organizations

### DIFF
--- a/application/actions/post_test.go
+++ b/application/actions/post_test.go
@@ -45,6 +45,7 @@ type Post struct {
 	Kilograms  float64           `json:"kilograms"`
 	IsEditable bool              `json:"isEditable"`
 	Url        string            `json:"url"`
+	Visibility string            `json:"visibility"`
 	CreatedBy  struct {
 		ID        string `json:"id"`
 		Nickname  string `json:"nickname"`
@@ -92,6 +93,7 @@ func (as *ActionSuite) Test_PostQuery() {
 			kilograms
 			isEditable
 			url
+			visibility
 			createdBy { id nickname avatarURL }
 			receiver { id nickname avatarURL }
 			provider { id nickname avatarURL }
@@ -128,6 +130,7 @@ func (as *ActionSuite) Test_PostQuery() {
 	as.Equal(f.Posts[0].UpdatedAt.Format(time.RFC3339), resp.Post.UpdatedAt)
 	as.Equal(f.Posts[0].Kilograms, resp.Post.Kilograms)
 	as.Equal(f.Posts[0].URL.String, resp.Post.Url)
+	as.Equal(f.Posts[0].Visibility.String(), resp.Post.Visibility)
 	as.Equal(false, resp.Post.IsEditable)
 	as.Equal(f.Users[0].UUID.String(), resp.Post.CreatedBy.ID, "creator ID doesn't match")
 	as.Equal(f.Users[0].Nickname, resp.Post.CreatedBy.Nickname, "creator nickname doesn't match")
@@ -178,11 +181,12 @@ func (as *ActionSuite) Test_UpdatePost() {
 			size: TINY
 			url: "example.com"
 			kilograms: 22.22
+			visibility: ALL
 		`
 	query := `mutation { post: updatePost(input: {` + input + `}) { id photo { id } description
 			destination { description country latitude longitude}
 			origin { description country latitude longitude}
-			size url kilograms isEditable}}`
+			size url kilograms visibility isEditable}}`
 
 	as.NoError(as.testGqlQuery(query, f.Users[0].Nickname, &postsResp))
 
@@ -205,6 +209,7 @@ func (as *ActionSuite) Test_UpdatePost() {
 	as.Equal(models.PostSizeTiny, postsResp.Post.Size)
 	as.Equal("example.com", postsResp.Post.Url)
 	as.Equal(22.22, postsResp.Post.Kilograms)
+	as.Equal("ALL", postsResp.Post.Visibility)
 	as.Equal(true, postsResp.Post.IsEditable)
 
 	// Attempt to edit a locked post
@@ -228,11 +233,12 @@ func (as *ActionSuite) Test_CreatePost() {
 			destination: {description:"dest" country:"dc" latitude:1.1 longitude:2.2}
 			size: TINY
 			url: "example.com"
+			visibility: ALL
 		`
 	query := `mutation { post: createPost(input: {` + input + `}) { organization { id } photo { id } type title
 			description destination { description country latitude longitude }
 			origin { description country latitude longitude }
-			size url kilograms }}`
+			size url kilograms visibility }}`
 
 	as.NoError(as.testGqlQuery(query, f.Users[0].Nickname, &postsResp))
 
@@ -253,6 +259,7 @@ func (as *ActionSuite) Test_CreatePost() {
 	as.Equal(models.PostSizeTiny, postsResp.Post.Size)
 	as.Equal("example.com", postsResp.Post.Url)
 	as.Equal(0.0, postsResp.Post.Kilograms)
+	as.Equal("ALL", postsResp.Post.Visibility)
 
 	// meeting-based request
 	input = `orgID: "` + f.Organization.UUID.String() + `"` +

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -151,6 +151,7 @@ type ComplexityRoot struct {
 		Type         func(childComplexity int) int
 		URL          func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
+		Visibility   func(childComplexity int) int
 	}
 
 	PublicProfile struct {
@@ -961,6 +962,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.UpdatedAt(childComplexity), true
 
+	case "Post.visibility":
+		if e.complexity.Post.Visibility == nil {
+			break
+		}
+
+		return e.complexity.Post.Visibility(childComplexity), true
+
 	case "PublicProfile.avatarURL":
 		if e.complexity.PublicProfile.AvatarURL == nil {
 			break
@@ -1437,6 +1445,13 @@ enum PostSize {
     XLARGE
 }
 
+# Visibility for Posts, ALL organizations, TRUSTED organizations, or SAME organization only
+enum PostVisibility {
+    ALL
+    TRUSTED
+    SAME
+}
+
 type User {
     id: ID!
     email: String!
@@ -1520,6 +1535,7 @@ type Post {
     files: [File!]!
     meeting: Meeting
     isEditable: Boolean!
+    visibility: PostVisibility!
 }
 
 type Meeting {
@@ -1612,6 +1628,7 @@ input CreatePostInput {
     kilograms: Float
     photoID: ID
     meetingID: ID
+    visibility: PostVisibility
 }
 
 input UpdatePostInput {
@@ -1624,6 +1641,7 @@ input UpdatePostInput {
     url: String
     kilograms: Float
     photoID: ID
+    visibility: PostVisibility
 }
 
 input CreateMeetingInput {
@@ -4955,6 +4973,43 @@ func (ec *executionContext) _Post_isEditable(ctx context.Context, field graphql.
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Post_visibility(ctx context.Context, field graphql.CollectedField, obj *models.Post) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Post",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Visibility, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.PostVisibility)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNPostVisibility2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _PublicProfile_id(ctx context.Context, field graphql.CollectedField, obj *PublicProfile) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -8068,6 +8123,12 @@ func (ec *executionContext) unmarshalInputCreatePostInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
+		case "visibility":
+			var err error
+			it.Visibility, err = ec.unmarshalOPostVisibility2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -8383,6 +8444,12 @@ func (ec *executionContext) unmarshalInputUpdatePostInput(ctx context.Context, o
 		case "photoID":
 			var err error
 			it.PhotoID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "visibility":
+			var err error
+			it.Visibility, err = ec.unmarshalOPostVisibility2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9340,6 +9407,11 @@ func (ec *executionContext) _Post(ctx context.Context, sel ast.SelectionSet, obj
 				}
 				return res
 			})
+		case "visibility":
+			out.Values[i] = ec._Post_visibility(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10677,6 +10749,15 @@ func (ec *executionContext) marshalNPostType2ᚖgithubᚗcomᚋsilinternational�
 	return v
 }
 
+func (ec *executionContext) unmarshalNPostVisibility2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx context.Context, v interface{}) (models.PostVisibility, error) {
+	var res models.PostVisibility
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalNPostVisibility2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx context.Context, sel ast.SelectionSet, v models.PostVisibility) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) marshalNPublicProfile2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPublicProfile(ctx context.Context, sel ast.SelectionSet, v PublicProfile) graphql.Marshaler {
 	return ec._PublicProfile(ctx, sel, &v)
 }
@@ -11369,6 +11450,30 @@ func (ec *executionContext) marshalOPostSize2ᚖgithubᚗcomᚋsilinternational�
 		return graphql.Null
 	}
 	return ec.marshalOPostSize2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostSize(ctx, sel, *v)
+}
+
+func (ec *executionContext) unmarshalOPostVisibility2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx context.Context, v interface{}) (models.PostVisibility, error) {
+	var res models.PostVisibility
+	return res, res.UnmarshalGQL(v)
+}
+
+func (ec *executionContext) marshalOPostVisibility2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx context.Context, sel ast.SelectionSet, v models.PostVisibility) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalOPostVisibility2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx context.Context, v interface{}) (*models.PostVisibility, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOPostVisibility2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOPostVisibility2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPostVisibility(ctx context.Context, sel ast.SelectionSet, v *models.PostVisibility) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalOPreferredLanguage2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋgqlgenᚐPreferredLanguage(ctx context.Context, v interface{}) (PreferredLanguage, error) {

--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -119,6 +119,8 @@ models:
     model: models.PostStatus
   PostSize:
     model: models.PostSize
+  PostVisibility:
+    model: models.PostVisibility
   UserAdminRole:
     model: models.UserAdminRole
   UserPreferences:

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -288,6 +288,10 @@ func convertGqlPostInputToDBPost(ctx context.Context, input postInput, currentUs
 		post.Kilograms = *input.Kilograms
 	}
 
+	if input.Visibility != nil {
+		post.Visibility = *input.Visibility
+	}
+
 	if input.PhotoID != nil {
 		if file, err := post.AttachPhoto(*input.PhotoID); err != nil {
 			graphql.AddError(ctx, gqlerror.Errorf("Error attaching photo to Post, %s", err.Error()))
@@ -321,6 +325,7 @@ type postInput struct {
 	Kilograms   *float64
 	PhotoID     *string
 	MeetingID   *string
+	Visibility  *models.PostVisibility
 }
 
 // CreatePost resolves the `createPost` mutation.

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -26,15 +26,6 @@ func (r *postResolver) ID(ctx context.Context, obj *models.Post) (string, error)
 	return obj.UUID.String(), nil
 }
 
-// Status field resolver. This is here to satisfy the generated postResolver. It is unclear why
-// gqlgen needs it, and it seems to be used only by the mutation responses (not the post query).
-func (r *postResolver) Status(ctx context.Context, obj *models.Post) (string, error) {
-	if obj == nil {
-		return "", nil
-	}
-	return obj.Status.String(), nil
-}
-
 // CreatedBy resolves the `createdBy` property of the post query. It retrieves the related record from the database.
 func (r *postResolver) CreatedBy(ctx context.Context, obj *models.Post) (*PublicProfile, error) {
 	if obj == nil {

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -149,7 +149,7 @@ type Post {
     destination: Location!
     origin: Location
     size: PostSize!
-    status: String!
+    status: PostStatus!
     threads: [Thread!]!
     createdAt: Time!
     updatedAt: Time!

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -69,6 +69,13 @@ enum PostSize {
     XLARGE
 }
 
+# Visibility for Posts, ALL organizations, TRUSTED organizations, or SAME organization only
+enum PostVisibility {
+    ALL
+    TRUSTED
+    SAME
+}
+
 type User {
     id: ID!
     email: String!
@@ -152,6 +159,7 @@ type Post {
     files: [File!]!
     meeting: Meeting
     isEditable: Boolean!
+    visibility: PostVisibility!
 }
 
 type Meeting {
@@ -244,6 +252,7 @@ input CreatePostInput {
     kilograms: Float
     photoID: ID
     meetingID: ID
+    visibility: PostVisibility
 }
 
 input UpdatePostInput {
@@ -256,6 +265,7 @@ input UpdatePostInput {
     url: String
     kilograms: Float
     photoID: ID
+    visibility: PostVisibility
 }
 
 input CreateMeetingInput {

--- a/application/internal/test/test.go
+++ b/application/internal/test/test.go
@@ -131,6 +131,7 @@ func CreatePostFixtures(tx *pop.Connection, n int, createFiles bool) models.Post
 		posts[i].Status = models.PostStatusOpen
 		posts[i].URL = nulls.NewString("https://www.example.com/" + strconv.Itoa(i))
 		posts[i].Kilograms = float64(i) * 0.1
+		posts[i].Visibility = "SAME"
 
 		if createFiles {
 			posts[i].PhotoFileID = nulls.NewInt(files[i].ID)

--- a/application/internal/test/test.go
+++ b/application/internal/test/test.go
@@ -131,7 +131,7 @@ func CreatePostFixtures(tx *pop.Connection, n int, createFiles bool) models.Post
 		posts[i].Status = models.PostStatusOpen
 		posts[i].URL = nulls.NewString("https://www.example.com/" + strconv.Itoa(i))
 		posts[i].Kilograms = float64(i) * 0.1
-		posts[i].Visibility = "SAME"
+		posts[i].Visibility = models.PostVisibilitySame
 
 		if createFiles {
 			posts[i].PhotoFileID = nulls.NewInt(files[i].ID)

--- a/application/migrations/20200122232403_add_visibility_to_posts.down.fizz
+++ b/application/migrations/20200122232403_add_visibility_to_posts.down.fizz
@@ -1,0 +1,1 @@
+drop_column("posts", "visibility")

--- a/application/migrations/20200122232403_add_visibility_to_posts.up.fizz
+++ b/application/migrations/20200122232403_add_visibility_to_posts.up.fizz
@@ -1,0 +1,1 @@
+add_column("posts", "visibility", "string", {"default": "SAME"})

--- a/application/migrations/schema.sql
+++ b/application/migrations/schema.sql
@@ -393,7 +393,8 @@ CREATE TABLE public.posts (
     destination_id integer NOT NULL,
     origin_id integer,
     kilograms numeric(13,4) DEFAULT '0'::numeric NOT NULL,
-    meeting_id integer
+    meeting_id integer,
+    visibility character varying(255) DEFAULT 'SAME'::character varying NOT NULL
 );
 
 

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -217,3 +217,11 @@ func save(m interface{}) error {
 	}
 	return nil
 }
+
+func convertSliceFromIntToInterface(intSlice []int) []interface{} {
+	s := make([]interface{}, len(intSlice))
+	for i, v := range intSlice {
+		s[i] = v
+	}
+	return s
+}

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -267,35 +267,3 @@ func (o *Organization) TrustedOrganizations() (Organizations, error) {
 	}
 	return trustedOrgs, nil
 }
-
-// TrustedOrganizationIDs returns the IDs of connected Organizations; returned slice may contain duplicates
-func (orgs *Organizations) TrustedOrganizationIDs() ([]int, error) {
-	var allTrustedIDs []int
-	for _, org := range *orgs {
-		orgTrustedIDs, err := org.TrustedOrganizationIDs()
-		if err != nil {
-			domain.ErrLogger.Print("error compiling list of trusted organizations, " + err.Error())
-		} else {
-			for _, i := range orgTrustedIDs {
-				allTrustedIDs = append(allTrustedIDs, i)
-			}
-		}
-	}
-	return allTrustedIDs, nil
-}
-
-// TrustedOrganizationIDs returns the IDs of connected Organizations
-func (o *Organization) TrustedOrganizationIDs() ([]int, error) {
-	trusts := OrganizationTrusts{}
-	if err := trusts.FindByOrgID(o.ID); domain.IsOtherThanNoRows(err) {
-		return nil, err
-	}
-	if len(trusts) < 1 {
-		return []int{}, nil
-	}
-	ids := make([]int, len(trusts))
-	for i := range trusts {
-		ids[i] = trusts[i].SecondaryID
-	}
-	return ids, nil
-}

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -199,11 +199,7 @@ func scopeUserAdminOrgs(cUser User) pop.ScopeFunc {
 			}
 		}
 
-		// convert []int to []interface{}
-		s := make([]interface{}, len(adminOrgIDs))
-		for i, v := range adminOrgIDs {
-			s[i] = v
-		}
+		s := convertSliceFromIntToInterface(adminOrgIDs)
 
 		if len(s) == 0 {
 			return q.Where("id = -1")

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -680,34 +680,6 @@ func scopeUserOrgs(cUser User) pop.ScopeFunc {
 	}
 }
 
-// scope query to include posts from an organization associated with the current user, and posts with
-// visibility ALL or TRUSTED and belonging to an organization trusted by one or more of the user's organizations
-func scopeTrustedOrganizations(cUser User) pop.ScopeFunc {
-	return func(q *pop.Query) *pop.Query {
-		userOrgs, err := cUser.GetOrganizations()
-		userOrgIDs := make([]interface{}, len(userOrgs))
-		for i, org := range userOrgs {
-			userOrgIDs[i] = org.ID
-		}
-
-		var trustedOrgIDs []int
-		if err != nil {
-			domain.ErrLogger.Printf("failed to get Organizations, user %s, %s", cUser.UUID.String(), err)
-		}
-		trustedOrgIDs, err = userOrgs.TrustedOrganizationIDs()
-		if err != nil {
-			domain.ErrLogger.Printf("failed to get TrustedOrganizations, user %s, %s", cUser.UUID.String(), err)
-		}
-
-		if len(trustedOrgIDs) == 0 {
-			return q.Where("organization_id = -1")
-		}
-		//return q.Where(`organization_id IN (?) AND (visibility IN ("ALL", "TRUSTED"))`, convertSliceFromIntToInterface(trustedOrgIDs)...)
-		return q.Where("visibility IN (?)", PostVisibilityAll, PostVisibilityTrusted).
-			Where("organization_id IN (?)", convertSliceFromIntToInterface(trustedOrgIDs)...)
-	}
-}
-
 // scope query to not include removed posts
 func scopeNotRemoved() pop.ScopeFunc {
 	return func(q *pop.Query) *pop.Query {
@@ -732,22 +704,31 @@ func (p *Post) FindByUserAndUUID(ctx context.Context, user User, uuid string) er
 // FindByUser finds all posts visible to the current user. NOTE: at present, the posts are not sorted correctly; need
 // to find a better way to construct the query
 func (p *Posts) FindByUser(ctx context.Context, user User) error {
-	q := DB.Scope(scopeUserOrgs(user)).Scope(scopeNotCompleted()).Order("created_at desc")
+	q := DB.RawQuery(`
+	SELECT * FROM posts WHERE
+	(
+		(
+			organization_id IN (
+				SELECT id FROM organizations WHERE id IN (
+					SELECT secondary_id FROM organization_trusts WHERE primary_id IN (
+						SELECT id FROM organizations WHERE id IN (
+							SELECT organization_id FROM user_organizations WHERE user_id = (?)
+						)
+					)
+				)
+			) AND visibility IN ('ALL', 'TRUSTED')
+		) OR (
+			organization_id IN (
+				SELECT id FROM organizations WHERE id IN (
+					SELECT organization_id FROM user_organizations WHERE user_id = (?)
+				)
+			)
+		)
+	)
+	AND status not in ('REMOVED', 'COMPLETED') ORDER BY created_at desc`, user.ID, user.ID)
 	if err := q.All(p); err != nil {
-		return errors.New("error finding posts in user organization(s), " + err.Error())
+		return fmt.Errorf("error finding posts for user %s, %s", user.UUID.String(), err)
 	}
-
-	q = DB.Scope(scopeTrustedOrganizations(user)).Scope(scopeNotCompleted()).Order("created_at desc")
-	var p2 Posts
-	if err := q.All(&p2); err != nil {
-		domain.ErrLogger.Print("error finding posts in trusted organization(s)", err.Error())
-		return nil
-	}
-
-	for i := range p2 {
-		*p = append(*p, p2[i])
-	}
-
 	return nil
 }
 

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -285,6 +285,9 @@ func (p Posts) String() string {
 
 // Create stores the Post data as a new record in the database.
 func (p *Post) Create() error {
+	if p.Visibility == "" {
+		p.Visibility = PostVisibilitySame
+	}
 	return create(p)
 }
 

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -73,6 +73,43 @@ type statusTransitionTarget struct {
 	isBackStep bool
 }
 
+type PostVisibility string
+
+const (
+	PostVisibilityAll     PostVisibility = "ALL"
+	PostVisibilityTrusted PostVisibility = "TRUSTED"
+	PostVisibilitySame    PostVisibility = "SAME"
+)
+
+func (e PostVisibility) IsValid() bool {
+	switch e {
+	case PostVisibilityAll, PostVisibilityTrusted, PostVisibilitySame:
+		return true
+	}
+	return false
+}
+
+func (e PostVisibility) String() string {
+	return string(e)
+}
+
+func (e *PostVisibility) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = PostVisibility(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid PostVisibility", str)
+	}
+	return nil
+}
+
+func (e PostVisibility) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 func getStatusTransitions() map[PostStatus][]statusTransitionTarget {
 	return map[PostStatus][]statusTransitionTarget{
 		PostStatusOpen: {
@@ -193,25 +230,26 @@ func (e PostSize) String() string {
 }
 
 type Post struct {
-	ID             int          `json:"id" db:"id"`
-	CreatedAt      time.Time    `json:"created_at" db:"created_at"`
-	UpdatedAt      time.Time    `json:"updated_at" db:"updated_at"`
-	CreatedByID    int          `json:"created_by_id" db:"created_by_id"`
-	Type           PostType     `json:"type" db:"type"`
-	OrganizationID int          `json:"organization_id" db:"organization_id"`
-	Status         PostStatus   `json:"status" db:"status"`
-	Title          string       `json:"title" db:"title"`
-	Size           PostSize     `json:"size" db:"size"`
-	UUID           uuid.UUID    `json:"uuid" db:"uuid"`
-	ReceiverID     nulls.Int    `json:"receiver_id" db:"receiver_id"`
-	ProviderID     nulls.Int    `json:"provider_id" db:"provider_id"`
-	Description    nulls.String `json:"description" db:"description"`
-	URL            nulls.String `json:"url" db:"url"`
-	Kilograms      float64      `json:"kilograms" db:"kilograms"`
-	PhotoFileID    nulls.Int    `json:"photo_file_id" db:"photo_file_id"`
-	DestinationID  int          `json:"destination_id" db:"destination_id"`
-	OriginID       nulls.Int    `json:"origin_id" db:"origin_id"`
-	MeetingID      nulls.Int    `json:"meeting_id" db:"meeting_id"`
+	ID             int            `json:"id" db:"id"`
+	CreatedAt      time.Time      `json:"created_at" db:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at" db:"updated_at"`
+	CreatedByID    int            `json:"created_by_id" db:"created_by_id"`
+	Type           PostType       `json:"type" db:"type"`
+	OrganizationID int            `json:"organization_id" db:"organization_id"`
+	Status         PostStatus     `json:"status" db:"status"`
+	Title          string         `json:"title" db:"title"`
+	Size           PostSize       `json:"size" db:"size"`
+	UUID           uuid.UUID      `json:"uuid" db:"uuid"`
+	ReceiverID     nulls.Int      `json:"receiver_id" db:"receiver_id"`
+	ProviderID     nulls.Int      `json:"provider_id" db:"provider_id"`
+	Description    nulls.String   `json:"description" db:"description"`
+	URL            nulls.String   `json:"url" db:"url"`
+	Kilograms      float64        `json:"kilograms" db:"kilograms"`
+	PhotoFileID    nulls.Int      `json:"photo_file_id" db:"photo_file_id"`
+	DestinationID  int            `json:"destination_id" db:"destination_id"`
+	OriginID       nulls.Int      `json:"origin_id" db:"origin_id"`
+	MeetingID      nulls.Int      `json:"meeting_id" db:"meeting_id"`
+	Visibility     PostVisibility `json:"visibility" db:"visibility"`
 
 	CreatedBy    User          `belongs_to:"users"`
 	Organization Organization  `belongs_to:"organizations"`

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gobuffalo/validate/validators"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/silinternational/wecarry-api/domain"
 )
 
@@ -669,17 +670,10 @@ func (p *Post) GetPhoto() (*File, error) {
 func scopeUserOrgs(cUser User) pop.ScopeFunc {
 	return func(q *pop.Query) *pop.Query {
 		orgs := cUser.GetOrgIDs()
-
-		// convert []int to []interface{}
-		s := make([]interface{}, len(orgs))
-		for i, v := range orgs {
-			s[i] = v
-		}
-
-		if len(s) == 0 {
+		if len(orgs) == 0 {
 			return q.Where("organization_id = -1")
 		}
-		return q.Where("organization_id IN (?)", s...)
+		return q.Where("organization_id IN (?)", convertSliceFromIntToInterface(orgs)...)
 	}
 }
 

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -718,9 +718,10 @@ func (p *Posts) FindByUser(ctx context.Context, user User) error {
 			SELECT id FROM organizations WHERE id IN (
 				SELECT secondary_id FROM organization_trusts WHERE primary_id IN (SELECT id FROM o)
 			)
-		) AND visibility IN ('ALL', 'TRUSTED')
+		) AND visibility IN (?, ?)
 	)
-	AND status not in ('REMOVED', 'COMPLETED') ORDER BY created_at desc`, user.ID)
+	AND status not in (?, ?) ORDER BY created_at desc`,
+		user.ID, PostVisibilityAll, PostVisibilityTrusted, PostStatusRemoved, PostStatusCompleted)
 	if err := q.All(p); err != nil {
 		return fmt.Errorf("error finding posts for user %s, %s", user.UUID.String(), err)
 	}

--- a/application/models/post_test.go
+++ b/application/models/post_test.go
@@ -1621,7 +1621,7 @@ func (ms *ModelSuite) TestPosts_FindByUser() {
 		wantErr     bool
 	}{
 		{name: "user 0", user: f.Users[0],
-			wantPostIDs: []int{f.Posts[4].ID, f.Posts[1].ID, f.Posts[0].ID, f.Posts[6].ID, f.Posts[5].ID}},
+			wantPostIDs: []int{f.Posts[6].ID, f.Posts[5].ID, f.Posts[4].ID, f.Posts[1].ID, f.Posts[0].ID}},
 		{name: "user 1", user: f.Users[1], wantPostIDs: []int{f.Posts[4].ID, f.Posts[0].ID}},
 		{name: "non-existent user", user: User{}, wantPostIDs: []int{}},
 	}

--- a/application/models/post_test.go
+++ b/application/models/post_test.go
@@ -1620,7 +1620,8 @@ func (ms *ModelSuite) TestPosts_FindByUser() {
 		wantPostIDs []int
 		wantErr     bool
 	}{
-		{name: "user 0", user: f.Users[0], wantPostIDs: []int{f.Posts[4].ID, f.Posts[1].ID, f.Posts[0].ID}},
+		{name: "user 0", user: f.Users[0],
+			wantPostIDs: []int{f.Posts[4].ID, f.Posts[1].ID, f.Posts[0].ID, f.Posts[6].ID, f.Posts[5].ID}},
 		{name: "user 1", user: f.Users[1], wantPostIDs: []int{f.Posts[4].ID, f.Posts[0].ID}},
 		{name: "non-existent user", user: User{}, wantPostIDs: []int{}},
 	}

--- a/application/models/testutils_test.go
+++ b/application/models/testutils_test.go
@@ -156,6 +156,7 @@ func createPostFixtures(tx *pop.Connection, nRequests, nOffers int, createFiles 
 		posts[i].Status = PostStatusOpen
 		posts[i].URL = nulls.NewString("https://www.example.com/" + strconv.Itoa(i))
 		posts[i].Kilograms = float64(i) * 0.1
+		posts[i].Visibility = PostVisibilitySame
 
 		if createFiles {
 			posts[i].PhotoFileID = nulls.NewInt(files[i].ID)

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -358,7 +358,7 @@ func HashClientIdAccessToken(accessToken string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(accessToken)))
 }
 
-func (u *User) GetOrganizations() ([]Organization, error) {
+func (u *User) GetOrganizations() (Organizations, error) {
 	if err := DB.Load(u, "Organizations"); err != nil {
 		return nil, fmt.Errorf("error getting organizations for user id %v ... %v", u.ID, err)
 	}


### PR DESCRIPTION
Partial implementation:
- No support for filtering posts by "only my orgs" or "my orgs and trusted orgs". `posts` query presently includes user-org posts and trusted-org posts marked with visibility `ALL` or `TRUSTED`.