### PR TITLE
protect image transparency

### DIFF
--- a/application/models/file.go
+++ b/application/models/file.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
-	"image/color"
-	"image/draw"
-	_ "image/gif" // enable decoding of GIF images
-	"image/jpeg"  // decode/encode JPEG images
-	_ "image/png" // enable decoding of PNG images
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"mime"
 	"net/http"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -101,19 +102,8 @@ func (f *File) Store(name string, content []byte) *FileUploadError {
 		return &e
 	}
 
-	// If possible, strip EXIF metadata by re-encoding the image. Also sets background to white.
-	img, _, err := image.Decode(bytes.NewReader(content))
-	if err == nil {
-		dst := image.NewRGBA(img.Bounds())
-		draw.Draw(dst, dst.Bounds(), image.NewUniform(color.White), image.Point{}, draw.Src)
-		draw.Draw(dst, dst.Bounds(), img, img.Bounds().Min, draw.Over)
-		buf := new(bytes.Buffer)
-		if err := jpeg.Encode(buf, dst, nil); err == nil {
-			content = buf.Bytes()
-			contentType = "image/jpg"
-			name = name + ".jpeg"
-		}
-	}
+	removeMetadata(&contentType, &content)
+	changeFileExtension(&name, contentType)
 
 	url, err := aws.StoreFile(fileUUID.String(), contentType, content)
 	if err != nil {
@@ -144,6 +134,45 @@ func (f *File) Store(name string, content []byte) *FileUploadError {
 
 	*f = file
 	return nil
+}
+
+// removeMetadata removes, if possible, all EXIF metadata by re-encoding the image. If the encoding type changes,
+// `contentType` will be modified accordingly.
+func removeMetadata(contentType *string, content *[]byte) {
+	img, _, err := image.Decode(bytes.NewReader(*content))
+	if err != nil {
+		return
+	}
+	buf := new(bytes.Buffer)
+	switch *contentType {
+	case "image/jpg":
+		if err := jpeg.Encode(buf, img, nil); err == nil {
+			*content = buf.Bytes()
+		}
+	case "image/gif":
+		if err := gif.Encode(buf, img, nil); err == nil {
+			*content = buf.Bytes()
+		}
+	case "image/png":
+		if err := png.Encode(buf, img); err == nil {
+			*content = buf.Bytes()
+		}
+	case "image/webp":
+		if err := png.Encode(buf, img); err == nil {
+			*content = buf.Bytes()
+			*contentType = "image/png"
+		}
+	}
+}
+
+// changeFileExtension attempts to make the file extension match the given content type
+func changeFileExtension(name *string, contentType string) {
+	ext, err := mime.ExtensionsByType(contentType)
+	if err != nil || len(ext) < 1 {
+		return
+	}
+	*name = strings.TrimSuffix(*name, filepath.Ext(*name)) + ext[0]
+
 }
 
 // FindByUUID locates an file by UUID and returns the result, including a valid URL.

--- a/application/models/file.go
+++ b/application/models/file.go
@@ -92,7 +92,7 @@ func (f *File) Store(name string, content []byte) *FileUploadError {
 		return &e
 	}
 
-	contentType, err := detectContentType(content)
+	contentType, err := validateContentType(content)
 	if err != nil {
 		e := FileUploadError{
 			HttpStatus: http.StatusBadRequest,
@@ -209,7 +209,7 @@ func (f *File) refreshURL() error {
 	return nil
 }
 
-func detectContentType(content []byte) (string, error) {
+func validateContentType(content []byte) (string, error) {
 	allowedTypes := []string{
 		"image/bmp",
 		"image/gif",

--- a/application/models/file_test.go
+++ b/application/models/file_test.go
@@ -311,3 +311,38 @@ func (ms *ModelSuite) TestFiles_DeleteUnlinked() {
 	n, _ := DB.Count(&f)
 	ms.Equal(nPosts*2+nMeetings+nOrganizations+nUsers, n, "wrong number of files remain")
 }
+
+func (ms *ModelSuite) Test_changeFileExtension() {
+	tests := []struct {
+		name        string
+		filename    string
+		contentType string
+		want        string
+	}{
+		{
+			name:        "png to gif",
+			filename:    "file.png",
+			contentType: "image/gif",
+			want:        "file.gif",
+		},
+		{
+			name:        "webp to png",
+			filename:    "file.webp",
+			contentType: "image/png",
+			want:        "file.png",
+		},
+		{
+			name:        "bad type",
+			filename:    "file.webp",
+			contentType: "file/xyz",
+			want:        "file.webp",
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			n := tt.filename
+			changeFileExtension(&n, tt.contentType)
+			ms.Equal(tt.want, n)
+		})
+	}
+}

--- a/application/models/file_test.go
+++ b/application/models/file_test.go
@@ -264,13 +264,13 @@ func (ms *ModelSuite) Test_detectContentType() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := detectContentType(tt.content)
+			got, err := validateContentType(tt.content)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("detectContentType() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("validateContentType() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("detectContentType() got = %v, want %v", got, tt.want)
+				t.Errorf("validateContentType() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Rather than replace image transparency with a solid white background, keep the alpha layer by re-encoding back to the same format. Note that the Go standard library doesn't support webp encoding, so these files will be encoded as png.