### PR TITLE
rename test database from scrutinizer back to wecarry

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,6 +17,7 @@ build:
       GOOGLE_KEY: test
       GOOGLE_SECRET: test
       SERVICE_INTEGRATION_TOKEN: abc123test
+      TEST_DATABASE_URL: postgres://scrutinizer:scrutinizer@testdb:5432/scrutinizer?sslmode=disable
   nodes:
     analysis:
       project_setup:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,7 +17,7 @@ build:
       GOOGLE_KEY: test
       GOOGLE_SECRET: test
       SERVICE_INTEGRATION_TOKEN: abc123test
-      TEST_DATABASE_URL: postgres://scrutinizer:scrutinizer@testdb:5432/scrutinizer?sslmode=disable
+      TEST_DATABASE_URL: postgres://scrutinizer:scrutinizer@localhost:5432/scrutinizer?sslmode=disable
   nodes:
     analysis:
       project_setup:

--- a/application/database.yml
+++ b/application/database.yml
@@ -6,15 +6,11 @@ development:
   host: db
   pool: 5
 
+test:
+  url: {{envOr "TEST_DATABASE_URL" "postgres://wecarry:wecarry@testdb:5432/wecarry_test?sslmode=disable"}}
+
 staging:
   url: {{envOr "DATABASE_URL" "postgres://wecarry:wecarry@127.0.0.1:5432/wecarry_staging?sslmode=disable"}}
 
 prod:
   url: {{envOr "DATABASE_URL" "postgres://wecarry:wecarry@127.0.0.1:5432/wecarry_production?sslmode=disable"}}
-
-test:
-  dialect: postgres
-  database: scrutinizer
-  user: scrutinizer
-  password: scrutinizer
-  host: {{envOr "DOCKER_IP" "localhost"}}

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -34,9 +34,9 @@ app:
 testdb:
   image: postgres:11.6
   environment:
-    POSTGRES_USER: scrutinizer
-    POSTGRES_PASSWORD: scrutinizer
-    POSTGRES_DB: scrutinizer
+    POSTGRES_USER: wecarry
+    POSTGRES_PASSWORD: wecarry
+    POSTGRES_DB: wecarry_test
 
 binary:
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,9 @@ services:
   testdb:
     image: postgres:11.6
     environment:
-      POSTGRES_USER: scrutinizer
-      POSTGRES_PASSWORD: scrutinizer
-      POSTGRES_DB: scrutinizer
+      POSTGRES_USER: wecarry
+      POSTGRES_PASSWORD: wecarry
+      POSTGRES_DB: wecarry_test
 
   # http://localhost:8080/?pgsql=db&username=wecarry&db=wecarry&ns=public
   adminer:


### PR DESCRIPTION
Was able to use the `TEST_DATABASE_URL` variable to change the database parameters only for Scrutinizer.