### PR TITLE
fix neededBefore validation

### DIFF
--- a/application/models/post_test.go
+++ b/application/models/post_test.go
@@ -260,6 +260,34 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 			},
 			wantErr: true,
 		},
+		{
+			name: "bad neededBefore (today)",
+			post: Post{
+				CreatedByID:    1,
+				Type:           PostTypeRequest,
+				OrganizationID: 1,
+				Title:          "A Request",
+				NeededBefore:   nulls.NewTime(time.Now()),
+				Size:           PostSizeMedium,
+				Status:         PostStatusOpen,
+				UUID:           domain.GetUUID(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "good neededBefore (tommorrow)",
+			post: Post{
+				CreatedByID:    1,
+				Type:           PostTypeRequest,
+				OrganizationID: 1,
+				Title:          "A Request",
+				NeededBefore:   nulls.NewTime(time.Now().Add(domain.DurationDay)),
+				Size:           PostSizeMedium,
+				Status:         PostStatusOpen,
+				UUID:           domain.GetUUID(),
+			},
+			wantErr: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/application/models/post_test.go
+++ b/application/models/post_test.go
@@ -177,10 +177,11 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 	t := ms.T()
 
 	tests := []struct {
-		name    string
-		post    Post
-		want    *validate.Errors
-		wantErr bool
+		name     string
+		post     Post
+		want     *validate.Errors
+		wantErr  bool
+		errField string
 	}{
 		{
 			name: "good - open",
@@ -206,7 +207,8 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 				Status:         PostStatusAccepted,
 				UUID:           domain.GetUUID(),
 			},
-			wantErr: true,
+			wantErr:  true,
+			errField: "create_status",
 		},
 		{
 			name: "bad status - delivered",
@@ -219,7 +221,8 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 				Status:         PostStatusDelivered,
 				UUID:           domain.GetUUID(),
 			},
-			wantErr: true,
+			wantErr:  true,
+			errField: "create_status",
 		},
 		{
 			name: "bad status - received",
@@ -232,7 +235,8 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 				Status:         PostStatusReceived,
 				UUID:           domain.GetUUID(),
 			},
-			wantErr: true,
+			wantErr:  true,
+			errField: "create_status",
 		},
 		{
 			name: "bad status - completed",
@@ -245,7 +249,8 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 				Status:         PostStatusCompleted,
 				UUID:           domain.GetUUID(),
 			},
-			wantErr: true,
+			wantErr:  true,
+			errField: "create_status",
 		},
 		{
 			name: "bad status - removed",
@@ -258,7 +263,8 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 				Status:         PostStatusRemoved,
 				UUID:           domain.GetUUID(),
 			},
-			wantErr: true,
+			wantErr:  true,
+			errField: "create_status",
 		},
 		{
 			name: "bad neededBefore (today)",
@@ -272,7 +278,8 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 				Status:         PostStatusOpen,
 				UUID:           domain.GetUUID(),
 			},
-			wantErr: true,
+			wantErr:  true,
+			errField: "needed_before",
 		},
 		{
 			name: "good neededBefore (tommorrow)",
@@ -291,14 +298,12 @@ func (ms *ModelSuite) TestPost_ValidateCreate() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			errField := "create_status"
-
 			vErr, _ := test.post.ValidateCreate(DB)
 			if test.wantErr {
 				if vErr.Count() == 0 {
 					t.Errorf("Expected an error, but did not get one")
-				} else if len(vErr.Get(errField)) == 0 {
-					t.Errorf("Expected an error on field %v, but got none (errors: %v)", errField, vErr.Errors)
+				} else if len(vErr.Get(test.errField)) == 0 {
+					t.Errorf("Expected an error on %v, but got none (errors: %v)", test.errField, vErr.Errors)
 				}
 			} else if (test.wantErr == false) && (vErr.HasAny()) {
 				t.Errorf("Unexpected error: %v", vErr)

--- a/application/models/post_test.go
+++ b/application/models/post_test.go
@@ -127,35 +127,6 @@ func (ms *ModelSuite) TestPost_Validate() {
 			wantErr:  true,
 			errField: "uuid",
 		},
-		{
-			name: "bad neededBefore (today)",
-			post: Post{
-				CreatedByID:    1,
-				Type:           PostTypeRequest,
-				OrganizationID: 1,
-				Title:          "A Request",
-				NeededBefore:   nulls.NewTime(time.Now()),
-				Size:           PostSizeMedium,
-				Status:         PostStatusOpen,
-				UUID:           domain.GetUUID(),
-			},
-			wantErr:  true,
-			errField: "needed_before",
-		},
-		{
-			name: "good neededBefore (tommorrow)",
-			post: Post{
-				CreatedByID:    1,
-				Type:           PostTypeRequest,
-				OrganizationID: 1,
-				Title:          "A Request",
-				NeededBefore:   nulls.NewTime(time.Now().Add(domain.DurationDay)),
-				Size:           PostSizeMedium,
-				Status:         PostStatusOpen,
-				UUID:           domain.GetUUID(),
-			},
-			wantErr: false,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This is a (possibly temporary) fix for the card "Unable to delete a post that is past it's neededBefore date". It moves the `neededBefore` validation to the `ValidateCreate` method so updates like setting `status` to `REMOVED` won't fail.