### PR TITLE
provide a list of user's meetings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ return nil, domain.ReportError(ctx, err, "UpdatePostStatus.Unauthorized", extras
 Errors within a query, such as an authorization failure on a request field, should
 not present an error to the API client. The requested data field should be returned
 as `null`. The cause of the error should be logged to `stderr` and Rollbar using
-`domain.ReportError` if context is available, or `domain.ErrLogger.printf` if no
+`domain.ReportError` if context is available, or `domain.ErrLogger.Printf` if no
 context is available.
 
 #### REST API responses
@@ -120,7 +120,7 @@ err := domain.AppError{
 return c.Render(httpStatus, render.JSON(err))
 ```
 
-In addition, the error should be logged using `Error` or `ErrLogger.printf`
+In addition, the error should be logged using `Error` or `ErrLogger.Printf`
 
 #### Internal error logging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,8 @@ err := domain.AppError{
 return c.Render(httpStatus, render.JSON(err))
 ```
 
-In addition, the error should be logged using `Error` or `ErrLogger.Printf`
+In addition, the error should be logged using `Error` or `ErrLogger.Printf`. For 
+auth-related errors, the helper `actions.authRequestError` is available.
 
 #### Internal error logging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ logged and a new user-focused and localized message should be returned from
 the resolver function. Translation of error messages is handled by the Buffalo
 `Translate` function. Translation keys consist of an initial identifier related to 
 a model, query or mutation name, optionally followed by a short description of the 
-point of failure. You may use the helper function `reportError` which handles all of 
+point of failure. You may use the helper function `ReportError` which handles all of 
 these steps. Translation text is stored in the `locales` folder.
  
 For example:
@@ -85,7 +85,7 @@ For example:
 	extras := map[string]interface{}{
 		"user": cUser.Uuid,
 	}
-    return nil, reportError(ctx, err, "CreatePost.SetDestination", extras)
+    return nil, domain.ReportError(ctx, err, "CreatePost.SetDestination", extras)
 ``` 
 
 ## gqlgen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ situations. For example:
 #### GraphQL error responses
 
 Errors occurring at the top level of a query or mutation, such as an authorization
-failure of an entire query, should present to the API client with an http OK (200)
+failure of an entire query, should present to the API client an http OK (200)
 response with an `errors` object in the response body. Internally, this is handled
 by the helper function `domain.ReportError`, which takes an `error` and a translation
 key like `"UpdateUser.NotFound"`. The `error` is logged to `stderr` and to Rollbar,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ by the helper function `domain.ReportError`, which takes an `error` and a transl
 key like `"UpdateUser.NotFound"`. The `error` is logged to `stderr` and to Rollbar,
 and the translation key is localized by Buffalo's `Translate` function and returned
 from the resolver to be processed by `gqlgen`. Translation text is stored in the
-`locales` folder.
+`application/locales` folder.
 
 For example:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,24 +70,64 @@ situations. For example:
      
 ### Error handling and presentation
 
-Internal handling of errors consists mostly of the built-in `errors` type. When
-an error propagates up to the `gqlgen` package, the internal error should be
-logged and a new user-focused and localized message should be returned from 
-the resolver function. Translation of error messages is handled by the Buffalo
-`Translate` function. Translation keys consist of an initial identifier related to 
-a model, query or mutation name, optionally followed by a short description of the 
-point of failure. You may use the helper function `ReportError` which handles all of 
-these steps. Translation text is stored in the `locales` folder.
- 
+#### GraphQL error responses
+
+Errors occurring at the top level of a query or mutation, such as an authorization
+failure of an entire query, should present to the API client with an http OK (200)
+response with an `errors` object in the response body. Internally, this is handled
+by the helper function `domain.ReportError`, which takes an `error` and a translation
+key like `"UpdateUser.NotFound"`. The `error` is logged to `stderr` and to Rollbar,
+and the translation key is localized by Buffalo's `Translate` function and returned
+from the resolver to be processed by `gqlgen`. Translation text is stored in the
+`locales` folder.
+
 For example:
 
 ```go
-	extras := map[string]interface{}{
-		"user": cUser.Uuid,
-	}
-    return nil, domain.ReportError(ctx, err, "CreatePost.SetDestination", extras)
+extras := map[string]interface{}{
+    "oldStatus": post.Status,
+    "newStatus": input.Status,
+}    
+return nil, domain.ReportError(ctx, err, "UpdatePostStatus.Unauthorized", extras)
 ``` 
 
+Errors within a query, such as an authorization failure on a request field, should
+not present an error to the API client. The requested data field should be returned
+as `null`. The cause of the error should be logged to `stderr` and Rollbar using
+`domain.ReportError` if context is available, or `domain.ErrLogger.printf` if no
+context is available.
+
+#### REST API responses
+
+Errors occurring in the processing of REST API requests should result in a 400-
+or 500-level http response with a json body containing a `code` and a `key`:
+
+```json
+{
+  "code": 400,
+  "key": "ErrorMissingClientID"
+}
+``` 
+
+This can be generated as follows:
+
+```go
+err := domain.AppError{
+    Code: httpStatus,
+    Key:  errorCode,
+}
+
+return c.Render(httpStatus, render.JSON(err))
+```
+
+In addition, the error should be logged using `Error` or `ErrLogger.printf`
+
+#### Internal error logging
+
+Errors that do not justify an error being passed to the API client may be logged
+to `stderr` and Rollbar using `domain.Error` if context is available, or
+`domain.ErrLogger.printf` if no context is available.
+ 
 ## gqlgen
 
 gqlgen generates code to handle GraphQL queries. The primary input is the 

--- a/application/actions/user_test.go
+++ b/application/actions/user_test.go
@@ -54,7 +54,7 @@ const allUserFields = `id email nickname createdAt updatedAt adminRole avatarURL
 	location {description country latitude longitude}
 	organizations {id}
 	posts (role: CREATEDBY) {id}
-	meetings {id}
+	meetingsAsParticipant {id}
 	`
 
 // TestUserQuery tests the User GraphQL query

--- a/application/actions/user_test.go
+++ b/application/actions/user_test.go
@@ -44,9 +44,9 @@ type User struct {
 	Posts []struct {
 		ID string `json:"id"`
 	} `json:"posts"`
-	Meetings []struct {
+	MeetingsAsParticipant []struct {
 		ID string `json:"id"`
-	} `json:"meetings"`
+	} `json:"meetingsAsParticipant"`
 }
 
 const allUserFields = `id email nickname createdAt updatedAt adminRole avatarURL photoID
@@ -108,8 +108,8 @@ func (as *ActionSuite) TestUserQuery() {
 				as.Equal(1, len(resp.User.Posts), "wrong number of posts")
 				as.Equal(f.Posts[0].UUID.String(), resp.User.Posts[0].ID, "incorrect Post ID")
 
-				as.Equal(1, len(resp.User.Meetings), "wrong number of meetings")
-				as.Equal(f.Meetings[0].UUID.String(), resp.User.Meetings[0].ID, "incorrect Meeting ID")
+				as.Equal(1, len(resp.User.MeetingsAsParticipant), "wrong number of meetings")
+				as.Equal(f.Meetings[0].UUID.String(), resp.User.MeetingsAsParticipant[0].ID, "incorrect Meeting ID")
 			},
 		},
 		{

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -223,20 +223,20 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		AdminRole          func(childComplexity int) int
-		AvatarURL          func(childComplexity int) int
-		CreatedAt          func(childComplexity int) int
-		Email              func(childComplexity int) int
-		ID                 func(childComplexity int) int
-		Location           func(childComplexity int) int
-		Meetings           func(childComplexity int) int
-		Nickname           func(childComplexity int) int
-		Organizations      func(childComplexity int) int
-		PhotoID            func(childComplexity int) int
-		Posts              func(childComplexity int, role PostRole) int
-		Preferences        func(childComplexity int) int
-		UnreadMessageCount func(childComplexity int) int
-		UpdatedAt          func(childComplexity int) int
+		AdminRole             func(childComplexity int) int
+		AvatarURL             func(childComplexity int) int
+		CreatedAt             func(childComplexity int) int
+		Email                 func(childComplexity int) int
+		ID                    func(childComplexity int) int
+		Location              func(childComplexity int) int
+		MeetingsAsParticipant func(childComplexity int) int
+		Nickname              func(childComplexity int) int
+		Organizations         func(childComplexity int) int
+		PhotoID               func(childComplexity int) int
+		Posts                 func(childComplexity int, role PostRole) int
+		Preferences           func(childComplexity int) int
+		UnreadMessageCount    func(childComplexity int) int
+		UpdatedAt             func(childComplexity int) int
 	}
 
 	UserPreferences struct {
@@ -1499,12 +1499,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Location(childComplexity), true
 
-	case "User.meetings":
-		if e.complexity.User.Meetings == nil {
+	case "User.meetingsAsParticipant":
+		if e.complexity.User.MeetingsAsParticipant == nil {
 			break
 		}
 
-		return e.complexity.User.Meetings(childComplexity), true
+		return e.complexity.User.MeetingsAsParticipant(childComplexity), true
 
 	case "User.nickname":
 		if e.complexity.User.Nickname == nil {
@@ -1852,7 +1852,7 @@ type User {
     organizations: [Organization!]!
     posts(role: PostRole!): [Post!]!
     "meetings in which the user is a participant"
-    meetings: [Meeting!]!
+    meetingsAsParticipant: [Meeting!]!
 }
 
 type UserPreferences {
@@ -8220,7 +8220,7 @@ func (ec *executionContext) _User_posts(ctx context.Context, field graphql.Colle
 	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _User_meetings(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
+func (ec *executionContext) _User_meetingsAsParticipant(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -8239,7 +8239,7 @@ func (ec *executionContext) _User_meetings(ctx context.Context, field graphql.Co
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Meetings(ctx)
+		return obj.MeetingsAsParticipant(ctx)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -12087,7 +12087,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 				}
 				return res
 			})
-		case "meetings":
+		case "meetingsAsParticipant":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
 				defer func() {
@@ -12095,7 +12095,7 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._User_meetings(ctx, field, obj)
+				res = ec._User_meetingsAsParticipant(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -229,6 +229,7 @@ type ComplexityRoot struct {
 		Email              func(childComplexity int) int
 		ID                 func(childComplexity int) int
 		Location           func(childComplexity int) int
+		Meetings           func(childComplexity int) int
 		Nickname           func(childComplexity int) int
 		Organizations      func(childComplexity int) int
 		PhotoID            func(childComplexity int) int
@@ -383,13 +384,13 @@ type ThreadResolver interface {
 type UserResolver interface {
 	ID(ctx context.Context, obj *models.User) (string, error)
 
-	Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error)
-	Posts(ctx context.Context, obj *models.User, role PostRole) ([]models.Post, error)
 	AvatarURL(ctx context.Context, obj *models.User) (*string, error)
 	PhotoID(ctx context.Context, obj *models.User) (*string, error)
 	Preferences(ctx context.Context, obj *models.User) (*models.StandardPreferences, error)
 	Location(ctx context.Context, obj *models.User) (*models.Location, error)
 	UnreadMessageCount(ctx context.Context, obj *models.User) (int, error)
+	Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error)
+	Posts(ctx context.Context, obj *models.User, role PostRole) ([]models.Post, error)
 }
 type WatchResolver interface {
 	ID(ctx context.Context, obj *models.Watch) (string, error)
@@ -1498,6 +1499,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.User.Location(childComplexity), true
 
+	case "User.meetings":
+		if e.complexity.User.Meetings == nil {
+			break
+		}
+
+		return e.complexity.User.Meetings(childComplexity), true
+
 	case "User.nickname":
 		if e.complexity.User.Nickname == nil {
 			break
@@ -1833,13 +1841,18 @@ type User {
     createdAt: Time!
     updatedAt: Time!
     adminRole: UserAdminRole
-    organizations: [Organization!]!
-    posts(role: PostRole!): [Post!]!
+    "avatarURL is generated from an attached photo if present, an external URL if present, or a Gravatar URL"
     avatarURL: String
+    "` + "`" + `File` + "`" + ` ID of the user's photo, if present"
     photoID: String
     preferences: UserPreferences
+    "user's home location"
     location: Location
     unreadMessageCount: Int!
+    organizations: [Organization!]!
+    posts(role: PostRole!): [Post!]!
+    "meetings in which the user is a participant"
+    meetings: [Meeting!]!
 }
 
 type UserPreferences {
@@ -7953,87 +7966,6 @@ func (ec *executionContext) _User_adminRole(ctx context.Context, field graphql.C
 	return ec.marshalOUserAdminRole2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUserAdminRole(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _User_organizations(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "User",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.User().Organizations(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.Organization)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _User_posts(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "User",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_User_posts_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.User().Posts(rctx, obj, args["role"].(PostRole))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.Post)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _User_avatarURL(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -8205,6 +8137,124 @@ func (ec *executionContext) _User_unreadMessageCount(ctx context.Context, field 
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _User_organizations(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "User",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.User().Organizations(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _User_posts(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "User",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_User_posts_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.User().Posts(rctx, obj, args["role"].(PostRole))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Post)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _User_meetings(ctx context.Context, field graphql.CollectedField, obj *models.User) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "User",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Meetings(ctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Meeting)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeeting2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _UserPreferences_language(ctx context.Context, field graphql.CollectedField, obj *models.StandardPreferences) (ret graphql.Marshaler) {
@@ -11951,34 +12001,6 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "adminRole":
 			out.Values[i] = ec._User_adminRole(ctx, field, obj)
-		case "organizations":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._User_organizations(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "posts":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._User_posts(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
 		case "avatarURL":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -12032,6 +12054,48 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 					}
 				}()
 				res = ec._User_unreadMessageCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "organizations":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_organizations(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "posts":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_posts(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "meetings":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_meetings(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/application/gqlgen/gqlgenutils.go
+++ b/application/gqlgen/gqlgenutils.go
@@ -1,16 +1,13 @@
 package gqlgen
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
 
-	"github.com/99designs/gqlgen/graphql"
-	"github.com/silinternational/wecarry-api/domain"
-
 	"github.com/gobuffalo/nulls"
+
+	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -87,42 +84,4 @@ func convertUserPreferencesToStandardPreferences(input *UpdateUserPreferencesInp
 	}
 
 	return stPrefs, nil
-}
-
-// getFunctionName provides the filename, line number, and function name of the caller, skipping the top `skip`
-// functions on the stack.
-func getFunctionName(skip int) string {
-	pc, file, line, ok := runtime.Caller(skip)
-	if !ok {
-		return "?"
-	}
-
-	fn := runtime.FuncForPC(pc)
-	return fmt.Sprintf("%s:%d %s", file, line, fn.Name())
-}
-
-// reportError logs an error with details, and returns a user-friendly, translated error identified by translation key
-// string `errID`.
-func reportError(ctx context.Context, err error, errID string, extras ...map[string]interface{}) error {
-	c := models.GetBuffaloContextFromGqlContext(ctx)
-	allExtras := map[string]interface{}{
-		"query":    graphql.GetRequestContext(ctx).RawQuery,
-		"function": getFunctionName(2),
-	}
-	for _, e := range extras {
-		for key, val := range e {
-			allExtras[key] = val
-		}
-	}
-
-	errStr := errID
-	if err != nil {
-		errStr = err.Error()
-	}
-	domain.Error(c, errStr, allExtras)
-
-	if domain.T == nil {
-		return errors.New(errID)
-	}
-	return errors.New(domain.T.Translate(c, errID))
 }

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -29,7 +29,7 @@ func (r *messageResolver) Sender(ctx context.Context, obj *models.Message) (*Pub
 	}
 	user, err := obj.GetSender()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetMessageSender")
+		return nil, domain.ReportError(ctx, err, "GetMessageSender")
 	}
 
 	return getPublicProfile(ctx, user), nil
@@ -43,7 +43,7 @@ func (r *messageResolver) Thread(ctx context.Context, obj *models.Message) (*mod
 
 	thread, err := obj.GetThread()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetMessageThread")
+		return nil, domain.ReportError(ctx, err, "GetMessageThread")
 	}
 
 	return thread, nil
@@ -61,7 +61,7 @@ func (r *queryResolver) Message(ctx context.Context, id *string) (*models.Messag
 		extras := map[string]interface{}{
 			"user": currentUser.UUID.String(),
 		}
-		return nil, reportError(ctx, err, "GetMessage", extras)
+		return nil, domain.ReportError(ctx, err, "GetMessage", extras)
 	}
 
 	return &message, nil
@@ -103,11 +103,11 @@ func (r *mutationResolver) CreateMessage(ctx context.Context, input CreateMessag
 	}
 	message, err := convertGqlCreateMessageInputToDBMessage(input, cUser)
 	if err != nil {
-		return nil, reportError(ctx, err, "CreateMessage.ParseInput", extras)
+		return nil, domain.ReportError(ctx, err, "CreateMessage.ParseInput", extras)
 	}
 
 	if err2 := message.Create(); err2 != nil {
-		return nil, reportError(ctx, err2, "CreateMessage", extras)
+		return nil, domain.ReportError(ctx, err2, "CreateMessage", extras)
 	}
 
 	return &message, nil

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -24,7 +24,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input CreateO
 	if !cUser.CanCreateOrganization() {
 		extras["user.admin_role"] = cUser.AdminRole
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "CreateOrganization.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganization.Unauthorized", extras)
 	}
 
 	org := models.Organization{
@@ -36,12 +36,12 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input CreateO
 
 	if input.LogoFileID != nil {
 		if _, err := org.AttachLogo(*input.LogoFileID); err != nil {
-			return nil, reportError(ctx, err, "CreateOrganization.LogoFileNotFound")
+			return nil, domain.ReportError(ctx, err, "CreateOrganization.LogoFileNotFound")
 		}
 	}
 
 	if err := org.Save(); err != nil {
-		return nil, reportError(ctx, err, "CreateOrganization")
+		return nil, domain.ReportError(ctx, err, "CreateOrganization")
 	}
 
 	return &org, nil
@@ -56,12 +56,12 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 
 	var org models.Organization
 	if err := org.FindByUUID(input.ID); err != nil {
-		return nil, reportError(ctx, err, "UpdateOrganization.NotFound", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganization.NotFound", extras)
 	}
 
 	if !cUser.CanEditOrganization(org.ID) {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "UpdateOrganization.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganization.Unauthorized", extras)
 	}
 
 	if input.URL != nil {
@@ -70,7 +70,7 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 
 	if input.LogoFileID != nil {
 		if _, err := org.AttachLogo(*input.LogoFileID); err != nil {
-			return nil, reportError(ctx, err, "UpdateOrganization.LogoFileNotFound")
+			return nil, domain.ReportError(ctx, err, "UpdateOrganization.LogoFileNotFound")
 		}
 	}
 
@@ -78,7 +78,7 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 	org.AuthType = input.AuthType
 	org.AuthConfig = input.AuthConfig
 	if err := org.Save(); err != nil {
-		return nil, reportError(ctx, err, "UpdateOrganization", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganization", extras)
 	}
 
 	return &org, nil
@@ -93,22 +93,22 @@ func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input C
 
 	var org models.Organization
 	if err := org.FindByUUID(input.OrganizationID); err != nil {
-		return nil, reportError(ctx, err, "CreateOrganizationDomain.NotFound", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain.NotFound", extras)
 	}
 
 	if !cUser.CanEditOrganization(org.ID) {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "CreateOrganizationDomain.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain.Unauthorized", extras)
 	}
 
 	if err := org.AddDomain(input.Domain, domain.ConvertStrPtrToString(input.AuthType), domain.ConvertStrPtrToString(input.AuthConfig)); err != nil {
-		return nil, reportError(ctx, err, "CreateOrganizationDomain", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain", extras)
 	}
 
 	domains, err2 := org.GetDomains()
 	if err2 != nil {
 		// don't return an error since the AddDomain operation succeeded
-		_ = reportError(ctx, err2, "", extras)
+		_ = domain.ReportError(ctx, err2, "", extras)
 	}
 
 	return domains, nil
@@ -123,29 +123,29 @@ func (r *mutationResolver) UpdateOrganizationDomain(ctx context.Context, input C
 
 	var org models.Organization
 	if err := org.FindByUUID(input.OrganizationID); err != nil {
-		return nil, reportError(ctx, err, "UpdateOrganizationDomain.NotFound", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.NotFound", extras)
 	}
 
 	if !cUser.CanEditOrganization(org.ID) {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "UpdateOrganizationDomain.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.Unauthorized", extras)
 	}
 
 	var orgDomain models.OrganizationDomain
 	if err := orgDomain.FindByDomain(input.Domain); err != nil {
-		return nil, reportError(ctx, err, "UpdateOrganizationDomain.NotFound", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.NotFound", extras)
 	}
 
 	orgDomain.AuthType = domain.ConvertStrPtrToString(input.AuthType)
 	orgDomain.AuthConfig = domain.ConvertStrPtrToString(input.AuthConfig)
 	if err := orgDomain.Save(); err != nil {
-		return nil, reportError(ctx, err, "UpdateOrganizationDomain.SaveError", extras)
+		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.SaveError", extras)
 	}
 
 	domains, err2 := org.GetDomains()
 	if err2 != nil {
 		// don't return an error since the operation succeeded
-		_ = reportError(ctx, err2, "", extras)
+		_ = domain.ReportError(ctx, err2, "", extras)
 	}
 
 	return domains, nil
@@ -160,22 +160,22 @@ func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input R
 
 	var org models.Organization
 	if err := org.FindByUUID(input.OrganizationID); err != nil {
-		return nil, reportError(ctx, err, "RemoveOrganizationDomain.NotFound", extras)
+		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain.NotFound", extras)
 	}
 
 	if !cUser.CanEditOrganization(org.ID) {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "RemoveOrganizationDomain.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain.Unauthorized", extras)
 	}
 
 	if err := org.RemoveDomain(input.Domain); err != nil {
-		return nil, reportError(ctx, err, "RemoveOrganizationDomain", extras)
+		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain", extras)
 	}
 
 	domains, err2 := org.GetDomains()
 	if err2 != nil {
 		// don't return an error since the RemoveDomain operation succeeded
-		_ = reportError(ctx, err2, "", extras)
+		_ = domain.ReportError(ctx, err2, "", extras)
 	}
 
 	return domains, nil
@@ -190,11 +190,11 @@ func (r *mutationResolver) SetThreadLastViewedAt(ctx context.Context, input SetT
 
 	var thread models.Thread
 	if err := thread.FindByUUID(input.ThreadID); err != nil {
-		return nil, reportError(ctx, err, "SetThreadLastViewedAt.NotFound", extras)
+		return nil, domain.ReportError(ctx, err, "SetThreadLastViewedAt.NotFound", extras)
 	}
 
 	if err := thread.UpdateLastViewedAt(cUser.ID, input.Time); err != nil {
-		return nil, reportError(ctx, err, "SetThreadLastViewedAt", extras)
+		return nil, domain.ReportError(ctx, err, "SetThreadLastViewedAt", extras)
 	}
 
 	return &thread, nil
@@ -209,16 +209,16 @@ func (r *mutationResolver) CreateOrganizationTrust(ctx context.Context, input Cr
 
 	var organization models.Organization
 	if err := organization.FindByUUID(input.PrimaryID); err != nil {
-		return nil, reportError(ctx, err, "CreateOrganizationTrust.FindPrimaryOrganization", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganizationTrust.FindPrimaryOrganization", extras)
 	}
 
 	if !cUser.CanCreateOrganizationTrust() {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "CreateOrganizationTrust.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganizationTrust.Unauthorized", extras)
 	}
 
 	if err := organization.CreateTrust(input.SecondaryID); err != nil {
-		return nil, reportError(ctx, err, "CreateOrganizationTrust", extras)
+		return nil, domain.ReportError(ctx, err, "CreateOrganizationTrust", extras)
 	}
 
 	return &organization, nil
@@ -233,16 +233,16 @@ func (r *mutationResolver) RemoveOrganizationTrust(ctx context.Context, input Re
 
 	var organization models.Organization
 	if err := organization.FindByUUID(input.PrimaryID); err != nil {
-		return nil, reportError(ctx, err, "RemoveOrganizationTrust.FindPrimaryOrganization", extras)
+		return nil, domain.ReportError(ctx, err, "RemoveOrganizationTrust.FindPrimaryOrganization", extras)
 	}
 
 	if !cUser.CanRemoveOrganizationTrust(organization.ID) {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "RemoveOrganizationTrust.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "RemoveOrganizationTrust.Unauthorized", extras)
 	}
 
 	if err := organization.RemoveTrust(input.SecondaryID); err != nil {
-		return nil, reportError(ctx, err, "RemoveOrganizationTrust", extras)
+		return nil, domain.ReportError(ctx, err, "RemoveOrganizationTrust", extras)
 	}
 
 	return &organization, nil
@@ -259,7 +259,7 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 
 	var m models.Meeting
 	if err := m.FindByUUID(input.MeetingID); err != nil {
-		return nil, reportError(ctx, err, "CreateMeetingInvite.FindMeeting", extras)
+		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.FindMeeting", extras)
 	}
 
 	inv := models.MeetingInvite{
@@ -280,9 +280,9 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 		graphql.AddError(ctx, gqlerror.Errorf("problem creating invite for %v", emailList))
 	}
 
-	invites, err := m.Invites(models.GetBuffaloContextFromGqlContext(ctx))
+	invites, err := m.Invites(domain.GetBuffaloContextFromGqlContext(ctx))
 	if err != nil {
-		return nil, reportError(ctx, err, "CreateMeetingInvite.ListInvites", extras)
+		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.ListInvites", extras)
 	}
 	return invites, nil
 }

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -23,7 +24,7 @@ func (r *queryResolver) Organizations(ctx context.Context) ([]models.Organizatio
 	// get list of orgs that cUser is allowed to see
 	orgs := models.Organizations{}
 	if err := orgs.AllWhereUserIsOrgAdmin(cUser); err != nil {
-		return orgs, reportError(ctx, err, "ListOrganizations.Error", extras)
+		return orgs, domain.ReportError(ctx, err, "ListOrganizations.Error", extras)
 	}
 
 	return orgs, nil
@@ -38,14 +39,14 @@ func (r *queryResolver) Organization(ctx context.Context, id *string) (*models.O
 
 	org := &models.Organization{}
 	if err := org.FindByUUID(*id); err != nil {
-		return org, reportError(ctx, err, "ViewOrganization.Error", extras)
+		return org, domain.ReportError(ctx, err, "ViewOrganization.Error", extras)
 	}
 
 	if org.ID != 0 && cUser.CanViewOrganization(org.ID) {
 		return org, nil
 	}
 
-	return &models.Organization{}, reportError(ctx, errors.New("user not allowed to view organization"),
+	return &models.Organization{}, domain.ReportError(ctx, errors.New("user not allowed to view organization"),
 		"ViewOrganization.NotFound", extras)
 }
 
@@ -73,7 +74,7 @@ func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organiza
 
 	domains, err := obj.GetDomains()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetOrganizationDomains")
+		return nil, domain.ReportError(ctx, err, "GetOrganizationDomains")
 	}
 
 	return domains, nil
@@ -87,7 +88,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *models.Organiza
 
 	logoURL, err := obj.LogoURL()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetOrganizationLogoURL")
+		return nil, domain.ReportError(ctx, err, "GetOrganizationLogoURL")
 	}
 
 	return logoURL, nil
@@ -101,7 +102,7 @@ func (r *organizationResolver) TrustedOrganizations(ctx context.Context, obj *mo
 
 	organizations, err := obj.TrustedOrganizations()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetOrganizationTrustedOrganizations")
+		return nil, domain.ReportError(ctx, err, "GetOrganizationTrustedOrganizations")
 	}
 
 	return organizations, nil

--- a/application/gqlgen/organizationdomain.go
+++ b/application/gqlgen/organizationdomain.go
@@ -3,6 +3,7 @@ package gqlgen
 import (
 	"context"
 
+	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -21,7 +22,7 @@ func (r *organizationDomainResolver) OrganizationID(ctx context.Context, obj *mo
 
 	id, err := obj.GetOrganizationUUID()
 	if err != nil {
-		return "", reportError(ctx, err, "GetOrganizationDomainOrganizationID")
+		return "", domain.ReportError(ctx, err, "GetOrganizationDomainOrganizationID")
 	}
 
 	return id, nil

--- a/application/gqlgen/post.go
+++ b/application/gqlgen/post.go
@@ -34,7 +34,7 @@ func (r *postResolver) CreatedBy(ctx context.Context, obj *models.Post) (*Public
 
 	creator, err := obj.GetCreator()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostCreator")
+		return nil, domain.ReportError(ctx, err, "GetPostCreator")
 	}
 
 	return getPublicProfile(ctx, creator), nil
@@ -48,7 +48,7 @@ func (r *postResolver) Receiver(ctx context.Context, obj *models.Post) (*PublicP
 
 	receiver, err := obj.GetReceiver()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostReceiver")
+		return nil, domain.ReportError(ctx, err, "GetPostReceiver")
 	}
 
 	return getPublicProfile(ctx, receiver), nil
@@ -62,7 +62,7 @@ func (r *postResolver) Provider(ctx context.Context, obj *models.Post) (*PublicP
 
 	provider, err := obj.GetProvider()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostProvider")
+		return nil, domain.ReportError(ctx, err, "GetPostProvider")
 	}
 
 	return getPublicProfile(ctx, provider), nil
@@ -77,7 +77,7 @@ func (r *postResolver) PotentialProviders(ctx context.Context, obj *models.Post)
 
 	providers, err := obj.GetPotentialProviders()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPotentialProviders")
+		return nil, domain.ReportError(ctx, err, "GetPotentialProviders")
 	}
 
 	profiles := getPublicProfiles(ctx, providers)
@@ -93,7 +93,7 @@ func (r *postResolver) Organization(ctx context.Context, obj *models.Post) (*mod
 
 	organization, err := obj.GetOrganization()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostOrganization")
+		return nil, domain.ReportError(ctx, err, "GetPostOrganization")
 	}
 
 	return organization, nil
@@ -133,7 +133,7 @@ func (r *postResolver) Destination(ctx context.Context, obj *models.Post) (*mode
 
 	destination, err := obj.GetDestination()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostDestination")
+		return nil, domain.ReportError(ctx, err, "GetPostDestination")
 	}
 
 	return destination, nil
@@ -147,7 +147,7 @@ func (r *postResolver) Origin(ctx context.Context, obj *models.Post) (*models.Lo
 
 	origin, err := obj.GetOrigin()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostOrigin")
+		return nil, domain.ReportError(ctx, err, "GetPostOrigin")
 	}
 
 	return origin, nil
@@ -165,7 +165,7 @@ func (r *postResolver) Threads(ctx context.Context, obj *models.Post) ([]models.
 		extras := map[string]interface{}{
 			"user": user.UUID,
 		}
-		return nil, reportError(ctx, err, "GetPostThreads", extras)
+		return nil, domain.ReportError(ctx, err, "GetPostThreads", extras)
 	}
 
 	return threads, nil
@@ -199,7 +199,7 @@ func (r *postResolver) Photo(ctx context.Context, obj *models.Post) (*models.Fil
 
 	photo, err := obj.GetPhoto()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostPhoto")
+		return nil, domain.ReportError(ctx, err, "GetPostPhoto")
 	}
 
 	return photo, nil
@@ -217,7 +217,7 @@ func (r *postResolver) PhotoID(ctx context.Context, obj *models.Post) (*string, 
 
 	photoID, err := obj.GetPhotoID()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetUserPhotoID")
+		return nil, domain.ReportError(ctx, err, "GetUserPhotoID")
 	}
 
 	return photoID, nil
@@ -230,7 +230,7 @@ func (r *postResolver) Files(ctx context.Context, obj *models.Post) ([]models.Fi
 	}
 	files, err := obj.GetFiles()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostFiles")
+		return nil, domain.ReportError(ctx, err, "GetPostFiles")
 	}
 
 	return files, nil
@@ -244,7 +244,7 @@ func (r *postResolver) Meeting(ctx context.Context, obj *models.Post) (*models.M
 
 	meeting, err := obj.Meeting()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetPostMeeting")
+		return nil, domain.ReportError(ctx, err, "GetPostMeeting")
 	}
 
 	return meeting, nil
@@ -272,7 +272,7 @@ func (r *queryResolver) Posts(ctx context.Context, destination, origin *Location
 		extras := map[string]interface{}{
 			"user": cUser.UUID,
 		}
-		return nil, reportError(ctx, err, "GetPosts", extras)
+		return nil, domain.ReportError(ctx, err, "GetPosts", extras)
 	}
 
 	return posts, nil
@@ -289,7 +289,7 @@ func (r *queryResolver) Post(ctx context.Context, id *string) (*models.Post, err
 		extras := map[string]interface{}{
 			"user": cUser.UUID,
 		}
-		return nil, reportError(ctx, err, "GetPost", extras)
+		return nil, domain.ReportError(ctx, err, "GetPost", extras)
 	}
 
 	return &post, nil
@@ -399,24 +399,24 @@ func (r *mutationResolver) CreatePost(ctx context.Context, input postInput) (*mo
 
 	post, err := convertGqlPostInputToDBPost(ctx, input, cUser)
 	if err != nil {
-		return nil, reportError(ctx, err, "CreatePost.ProcessInput", extras)
+		return nil, domain.ReportError(ctx, err, "CreatePost.ProcessInput", extras)
 	}
 
 	if !post.MeetingID.Valid {
 		dest := convertLocation(*input.Destination)
 		if err = dest.Create(); err != nil {
-			return nil, reportError(ctx, err, "CreatePost.SetDestination", extras)
+			return nil, domain.ReportError(ctx, err, "CreatePost.SetDestination", extras)
 		}
 		post.DestinationID = dest.ID
 	}
 
 	if err = post.Create(); err != nil {
-		return nil, reportError(ctx, err, "CreatePost", extras)
+		return nil, domain.ReportError(ctx, err, "CreatePost", extras)
 	}
 
 	if input.Origin != nil {
 		if err = post.SetOrigin(convertLocation(*input.Origin)); err != nil {
-			return nil, reportError(ctx, err, "CreatePost.SetOrigin", extras)
+			return nil, domain.ReportError(ctx, err, "CreatePost.SetOrigin", extras)
 		}
 	}
 
@@ -432,35 +432,35 @@ func (r *mutationResolver) UpdatePost(ctx context.Context, input postInput) (*mo
 
 	post, err := convertGqlPostInputToDBPost(ctx, input, cUser)
 	if err != nil {
-		return nil, reportError(ctx, err, "UpdatePost.ProcessInput", extras)
+		return nil, domain.ReportError(ctx, err, "UpdatePost.ProcessInput", extras)
 	}
 
 	var dbPost models.Post
 	_ = dbPost.FindByID(post.ID)
 	if editable, err := dbPost.IsEditable(cUser); err != nil {
-		return nil, reportError(ctx, err, "UpdatePost.GetEditable", extras)
+		return nil, domain.ReportError(ctx, err, "UpdatePost.GetEditable", extras)
 	} else if !editable {
-		return nil, reportError(ctx, errors.New("attempt to update a non-editable post"),
+		return nil, domain.ReportError(ctx, errors.New("attempt to update a non-editable post"),
 			"UpdatePost.NotEditable", extras)
 	}
 
 	if err := post.Update(); err != nil {
-		return nil, reportError(ctx, err, "UpdatePost", extras)
+		return nil, domain.ReportError(ctx, err, "UpdatePost", extras)
 	}
 
 	if input.Destination != nil {
 		if err := post.SetDestination(convertLocation(*input.Destination)); err != nil {
-			return nil, reportError(ctx, err, "UpdatePost.SetDestination", extras)
+			return nil, domain.ReportError(ctx, err, "UpdatePost.SetDestination", extras)
 		}
 	}
 
 	if input.Origin == nil {
 		if err := post.RemoveOrigin(); err != nil {
-			return nil, reportError(ctx, err, "UpdatePost.RemoveOrigin", extras)
+			return nil, domain.ReportError(ctx, err, "UpdatePost.RemoveOrigin", extras)
 		}
 	} else {
 		if err := post.SetOrigin(convertLocation(*input.Origin)); err != nil {
-			return nil, reportError(ctx, err, "UpdatePost.SetOrigin", extras)
+			return nil, domain.ReportError(ctx, err, "UpdatePost.SetOrigin", extras)
 		}
 	}
 
@@ -471,7 +471,7 @@ func (r *mutationResolver) UpdatePost(ctx context.Context, input postInput) (*mo
 func (r *mutationResolver) UpdatePostStatus(ctx context.Context, input UpdatePostStatusInput) (*models.Post, error) {
 	var post models.Post
 	if err := post.FindByUUID(input.ID); err != nil {
-		return nil, reportError(ctx, err, "UpdatePostStatus.FindPost")
+		return nil, domain.ReportError(ctx, err, "UpdatePostStatus.FindPost")
 	}
 
 	cUser := models.GetCurrentUserFromGqlContext(ctx)
@@ -482,21 +482,21 @@ func (r *mutationResolver) UpdatePostStatus(ctx context.Context, input UpdatePos
 	}
 
 	if !cUser.CanUpdatePostStatus(post, input.Status) {
-		return nil, reportError(ctx, errors.New("not allowed to change post status"),
+		return nil, domain.ReportError(ctx, errors.New("not allowed to change post status"),
 			"UpdatePostStatus.Unauthorized", extras)
 	}
 
 	if err := post.SetProviderWithStatus(input.Status, input.ProviderUserID); err != nil {
-		return nil, reportError(ctx, errors.New("error setting provider with status: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("error setting provider with status: "+err.Error()),
 			"UpdatePostStatus.SetProvider", extras)
 	}
 
 	if err := post.Update(); err != nil {
-		return nil, reportError(ctx, err, "UpdatePostStatus", extras)
+		return nil, domain.ReportError(ctx, err, "UpdatePostStatus", extras)
 	}
 
 	if err := post.DestroyPotentialProviders(input.Status, cUser); err != nil {
-		return nil, reportError(ctx, errors.New("error destroying post's potential providers: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("error destroying post's potential providers: "+err.Error()),
 			"UpdatePostStatus.DestroyPotentialProviders", extras)
 	}
 
@@ -508,23 +508,23 @@ func (r *mutationResolver) AddMeAsPotentialProvider(ctx context.Context, postID 
 
 	var post models.Post
 	if err := post.FindByUUIDForCurrentUser(postID, cUser); err != nil {
-		return nil, reportError(ctx, err, "AddMeAsPotentialProvider.FindPost")
+		return nil, domain.ReportError(ctx, err, "AddMeAsPotentialProvider.FindPost")
 	}
 
 	if post.Status != models.PostStatusOpen {
-		return nil, reportError(ctx, errors.New(
+		return nil, domain.ReportError(ctx, errors.New(
 			"Can only create PotentialProvider for a Post that has Status=Open. Got "+post.Status.String()),
 			"AddMeAsPotentialProvider.BadPostStatus")
 	}
 
 	var provider models.PotentialProvider
 	if err := provider.NewWithPostUUID(postID, cUser.ID); err != nil {
-		return nil, reportError(ctx, errors.New("error preparing potential provider: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("error preparing potential provider: "+err.Error()),
 			"AddMeAsPotentialProvider")
 	}
 
 	if err := provider.Create(); err != nil {
-		return nil, reportError(ctx, errors.New("error creating potential provider: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("error creating potential provider: "+err.Error()),
 			"AddMeAsPotentialProvider")
 	}
 
@@ -537,13 +537,13 @@ func (r *mutationResolver) RemoveMeAsPotentialProvider(ctx context.Context, post
 	var provider models.PotentialProvider
 
 	if err := provider.FindWithPostUUIDAndUserUUID(postID, cUser.UUID.String(), cUser); err != nil {
-		return nil, reportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
 			"RemoveMeAsPotentialProvider")
 	}
 
 	var post models.Post
 	if err := post.FindByUUID(postID); err != nil {
-		return nil, reportError(ctx, err, "RemoveMeAsPotentialProvider.FindPost")
+		return nil, domain.ReportError(ctx, err, "RemoveMeAsPotentialProvider.FindPost")
 	}
 
 	extras := map[string]interface{}{
@@ -552,17 +552,17 @@ func (r *mutationResolver) RemoveMeAsPotentialProvider(ctx context.Context, post
 	}
 
 	if !provider.CanUserAccessPotentialProvider(post, cUser) {
-		return nil, reportError(ctx, errors.New("user not allowed to access PotentialProvider"),
+		return nil, domain.ReportError(ctx, errors.New("user not allowed to access PotentialProvider"),
 			"RemoveMeAsPotentialProvider.NotAuthorized", extras)
 	}
 
 	if err := provider.Destroy(); err != nil {
-		return nil, reportError(ctx, errors.New("error removing potential provider: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("error removing potential provider: "+err.Error()),
 			"RemoveMeAsPotentialProvider", extras)
 	}
 
 	if err := post.FindByUUID(postID); err != nil {
-		return nil, reportError(ctx, err, "RemoveMeAsPotentialProvider.FindPost")
+		return nil, domain.ReportError(ctx, err, "RemoveMeAsPotentialProvider.FindPost")
 	}
 
 	return &post, nil
@@ -574,13 +574,13 @@ func (r *mutationResolver) RemovePotentialProvider(ctx context.Context, postID, 
 	var provider models.PotentialProvider
 
 	if err := provider.FindWithPostUUIDAndUserUUID(postID, cUser.UUID.String(), cUser); err != nil {
-		return nil, reportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
 			"RemovePotentialProvider")
 	}
 
 	var post models.Post
 	if err := post.FindByUUID(postID); err != nil {
-		return nil, reportError(ctx, err, "RemovePotentialProvider.FindPost")
+		return nil, domain.ReportError(ctx, err, "RemovePotentialProvider.FindPost")
 	}
 
 	extras := map[string]interface{}{
@@ -589,17 +589,17 @@ func (r *mutationResolver) RemovePotentialProvider(ctx context.Context, postID, 
 	}
 
 	if !provider.CanUserAccessPotentialProvider(post, cUser) {
-		return nil, reportError(ctx, errors.New("user not allowed to access PotentialProvider"),
+		return nil, domain.ReportError(ctx, errors.New("user not allowed to access PotentialProvider"),
 			"RemovePotentialProvider.NotAuthorized", extras)
 	}
 
 	if err := provider.Destroy(); err != nil {
-		return nil, reportError(ctx, errors.New("error removing potential provider: "+err.Error()),
+		return nil, domain.ReportError(ctx, errors.New("error removing potential provider: "+err.Error()),
 			"RemovePotentialProvider", extras)
 	}
 
 	if err := post.FindByUUID(postID); err != nil {
-		return nil, reportError(ctx, err, "RemovePotentialProvider.FindPost")
+		return nil, domain.ReportError(ctx, err, "RemovePotentialProvider.FindPost")
 	}
 
 	return &post, nil

--- a/application/gqlgen/resolver.go
+++ b/application/gqlgen/resolver.go
@@ -5,6 +5,7 @@ package gqlgen
 import (
 	"context"
 
+	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -44,7 +45,7 @@ func (m *meetingInviteResolver) Meeting(ctx context.Context, obj *models.Meeting
 
 	mtg, err := obj.Meeting()
 	if err != nil {
-		return nil, reportError(ctx, err, "MeetingInvite.Meeting")
+		return nil, domain.ReportError(ctx, err, "MeetingInvite.Meeting")
 	}
 	return &mtg, nil
 }
@@ -56,7 +57,7 @@ func (m *meetingInviteResolver) Inviter(ctx context.Context, obj *models.Meeting
 
 	inviter, err := obj.Inviter()
 	if err != nil {
-		return nil, reportError(ctx, err, "MeetingInvite.Inviter")
+		return nil, domain.ReportError(ctx, err, "MeetingInvite.Inviter")
 	}
 
 	return getPublicProfile(ctx, &inviter), nil
@@ -77,7 +78,7 @@ func (m *meetingParticipantResolver) Meeting(ctx context.Context, obj *models.Me
 
 	mtg, err := obj.Meeting()
 	if err != nil {
-		return nil, reportError(ctx, err, "MeetingParticipant.Meeting")
+		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Meeting")
 	}
 	return &mtg, err
 }
@@ -89,7 +90,7 @@ func (m *meetingParticipantResolver) User(ctx context.Context, obj *models.Meeti
 
 	user, err := obj.User()
 	if err != nil {
-		return nil, reportError(ctx, err, "MeetingParticipant.User")
+		return nil, domain.ReportError(ctx, err, "MeetingParticipant.User")
 	}
 
 	return &user, nil
@@ -104,7 +105,7 @@ func (m *meetingParticipantResolver) Invite(ctx context.Context, obj *models.Mee
 
 	inv, err := obj.Invite()
 	if err != nil {
-		return nil, reportError(ctx, err, "MeetingParticipant.Invite")
+		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Invite")
 	}
 
 	return inv, nil

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -186,7 +186,7 @@ type User {
     organizations: [Organization!]!
     posts(role: PostRole!): [Post!]!
     "meetings in which the user is a participant"
-    meetings: [Meeting!]!
+    meetingsAsParticipant: [Meeting!]!
 }
 
 type UserPreferences {

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -175,13 +175,18 @@ type User {
     createdAt: Time!
     updatedAt: Time!
     adminRole: UserAdminRole
-    organizations: [Organization!]!
-    posts(role: PostRole!): [Post!]!
+    "avatarURL is generated from an attached photo if present, an external URL if present, or a Gravatar URL"
     avatarURL: String
+    "`File` ID of the user's photo, if present"
     photoID: String
     preferences: UserPreferences
+    "user's home location"
     location: Location
     unreadMessageCount: Int!
+    organizations: [Organization!]!
+    posts(role: PostRole!): [Post!]!
+    "meetings in which the user is a participant"
+    meetings: [Meeting!]!
 }
 
 type UserPreferences {

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -25,7 +25,7 @@ func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) (
 
 	participants, err := obj.GetParticipants()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetThreadParticipants")
+		return nil, domain.ReportError(ctx, err, "GetThreadParticipants")
 	}
 
 	return getPublicProfiles(ctx, participants), nil
@@ -51,7 +51,7 @@ func (r *threadResolver) LastViewedAt(ctx context.Context, obj *models.Thread) (
 		extras := map[string]interface{}{
 			"user": currentUser.UUID,
 		}
-		return nil, reportError(ctx, err, "GetThreadLastViewedAt", extras)
+		return nil, domain.ReportError(ctx, err, "GetThreadLastViewedAt", extras)
 	}
 
 	return lastViewedAt, nil
@@ -66,7 +66,7 @@ func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]mo
 
 	messages, err := obj.GetMessages()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetThreadMessages")
+		return nil, domain.ReportError(ctx, err, "GetThreadMessages")
 	}
 
 	return messages, nil
@@ -80,7 +80,7 @@ func (r *threadResolver) PostID(ctx context.Context, obj *models.Thread) (string
 
 	post, err := obj.GetPost()
 	if err != nil {
-		return "", reportError(ctx, err, "GetThreadPostID")
+		return "", domain.ReportError(ctx, err, "GetThreadPostID")
 	}
 
 	return post.UUID.String(), nil
@@ -94,7 +94,7 @@ func (r *threadResolver) Post(ctx context.Context, obj *models.Thread) (*models.
 
 	post, err := obj.GetPost()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetThreadPost")
+		return nil, domain.ReportError(ctx, err, "GetThreadPost")
 	}
 
 	return post, nil
@@ -109,19 +109,19 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 
 	lastViewedAt, err := obj.GetLastViewedAt(user)
 	if err != nil {
-		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err.Error())
+		domain.Warn(domain.GetBuffaloContextFromGqlContext(ctx), err.Error())
 		return 0, nil
 	}
 
 	if lastViewedAt == nil {
-		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx),
+		domain.Warn(domain.GetBuffaloContextFromGqlContext(ctx),
 			fmt.Sprintf("lastViewedAt nil for user %v on thread %v", user.ID, obj.ID))
 		return 0, nil
 	}
 
 	count, err2 := obj.UnreadMessageCount(user.ID, *lastViewedAt)
 	if err2 != nil {
-		domain.Warn(models.GetBuffaloContextFromGqlContext(ctx), err2.Error())
+		domain.Warn(domain.GetBuffaloContextFromGqlContext(ctx), err2.Error())
 		return 0, nil
 	}
 	return count, nil
@@ -132,7 +132,7 @@ func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
 	threads := models.Threads{}
 
 	if err := threads.All(); err != nil {
-		return nil, reportError(ctx, err, "GetThreads")
+		return nil, domain.ReportError(ctx, err, "GetThreads")
 	}
 
 	return threads, nil
@@ -147,7 +147,7 @@ func (r *queryResolver) MyThreads(ctx context.Context) ([]models.Thread, error) 
 		extras := map[string]interface{}{
 			"user": currentUser.UUID,
 		}
-		return nil, reportError(ctx, err, "GetMyThreads", extras)
+		return nil, domain.ReportError(ctx, err, "GetMyThreads", extras)
 	}
 
 	return threads, nil

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -38,7 +39,7 @@ func (r *userResolver) Organizations(ctx context.Context, obj *models.User) ([]m
 
 	organizations, err := obj.GetOrganizations()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetUserOrganizations")
+		return nil, domain.ReportError(ctx, err, "GetUserOrganizations")
 	}
 
 	return organizations, nil
@@ -55,7 +56,7 @@ func (r *userResolver) Posts(ctx context.Context, obj *models.User, role PostRol
 		extras := map[string]interface{}{
 			"role": role,
 		}
-		return nil, reportError(ctx, err, "GetUserPosts", extras)
+		return nil, domain.ReportError(ctx, err, "GetUserPosts", extras)
 	}
 
 	return posts, nil
@@ -69,7 +70,7 @@ func (r *userResolver) AvatarURL(ctx context.Context, obj *models.User) (*string
 
 	photoURL, err := obj.GetPhotoURL()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetUserPhotoURL")
+		return nil, domain.ReportError(ctx, err, "GetUserPhotoURL")
 	}
 
 	return photoURL, nil
@@ -87,7 +88,7 @@ func (r *userResolver) PhotoID(ctx context.Context, obj *models.User) (*string, 
 
 	photoID, err := obj.GetPhotoID()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetUserPhotoID")
+		return nil, domain.ReportError(ctx, err, "GetUserPhotoID")
 	}
 
 	return photoID, nil
@@ -101,7 +102,7 @@ func (r *userResolver) Location(ctx context.Context, obj *models.User) (*models.
 
 	location, err := obj.GetLocation()
 	if err != nil {
-		return nil, reportError(ctx, err, "GetUserLocation")
+		return nil, domain.ReportError(ctx, err, "GetUserLocation")
 	}
 
 	return location, nil
@@ -115,7 +116,7 @@ func (r *userResolver) UnreadMessageCount(ctx context.Context, obj *models.User)
 	mCounts, err := obj.UnreadMessageCount()
 
 	if err != nil {
-		return 0, reportError(ctx, err, "GetUserUnreadMessageCount")
+		return 0, domain.ReportError(ctx, err, "GetUserUnreadMessageCount")
 	}
 	total := 0
 	for _, c := range mCounts {
@@ -135,12 +136,12 @@ func (r *queryResolver) Users(ctx context.Context) ([]models.User, error) {
 		extras := map[string]interface{}{
 			"role": role,
 		}
-		return nil, reportError(ctx, err, "GetUsers.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "GetUsers.Unauthorized", extras)
 	}
 
 	users := models.Users{}
 	if err := users.All(); err != nil {
-		return nil, reportError(ctx, err, "GetUsers")
+		return nil, domain.ReportError(ctx, err, "GetUsers")
 	}
 
 	return users, nil
@@ -160,12 +161,12 @@ func (r *queryResolver) User(ctx context.Context, id *string) (*models.User, err
 		extras := map[string]interface{}{
 			"role": role,
 		}
-		return nil, reportError(ctx, err, "GetUser.Unauthorized", extras)
+		return nil, domain.ReportError(ctx, err, "GetUser.Unauthorized", extras)
 	}
 
 	dbUser := models.User{}
 	if err := dbUser.FindByUUID(*id); err != nil {
-		return nil, reportError(ctx, err, "GetUser")
+		return nil, domain.ReportError(ctx, err, "GetUser")
 	}
 
 	return &dbUser, nil
@@ -180,7 +181,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 
 	if input.ID != nil {
 		if err := user.FindByUUID(*(input.ID)); err != nil {
-			return nil, reportError(ctx, err, "UpdateUser.NotFound")
+			return nil, domain.ReportError(ctx, err, "UpdateUser.NotFound")
 		}
 	} else {
 		user = cUser
@@ -188,7 +189,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 
 	if cUser.AdminRole != models.UserAdminRoleSuperAdmin && cUser.ID != user.ID {
 		err := errors.New("insufficient permissions")
-		return nil, reportError(ctx, err, "UpdateUser.Unauthorized")
+		return nil, domain.ReportError(ctx, err, "UpdateUser.Unauthorized")
 	}
 
 	if input.Nickname != nil {
@@ -202,7 +203,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 		_, err = user.AttachPhoto(*input.PhotoID)
 	}
 	if err != nil {
-		return nil, reportError(ctx, err, "UpdateUser.UpdatePhoto")
+		return nil, domain.ReportError(ctx, err, "UpdateUser.UpdatePhoto")
 	}
 
 	if input.Location == nil {
@@ -211,7 +212,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 		err = user.SetLocation(convertLocation(*input.Location))
 	}
 	if err != nil {
-		return nil, reportError(ctx, err, "UpdateUser.SetLocationError")
+		return nil, domain.ReportError(ctx, err, "UpdateUser.SetLocationError")
 	}
 
 	// No deleting of preferences supported at this time
@@ -219,16 +220,16 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 		standardPrefs, err := convertUserPreferencesToStandardPreferences(input.Preferences)
 
 		if err != nil {
-			return nil, reportError(ctx, err, "UpdateUser.PreferencesInput")
+			return nil, domain.ReportError(ctx, err, "UpdateUser.PreferencesInput")
 		}
 
 		if _, err = user.UpdateStandardPreferences(standardPrefs); err != nil {
-			return nil, reportError(ctx, err, "UpdateUser.Preferences")
+			return nil, domain.ReportError(ctx, err, "UpdateUser.Preferences")
 		}
 	}
 
 	if err = user.Save(); err != nil {
-		return nil, reportError(ctx, err, "UpdateUser")
+		return nil, domain.ReportError(ctx, err, "UpdateUser")
 	}
 
 	return &user, nil
@@ -247,7 +248,7 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 		extras := map[string]interface{}{
 			"user": user.UUID,
 		}
-		return nil, reportError(ctx, err, "GetUserPreferences", extras)
+		return nil, domain.ReportError(ctx, err, "GetUserPreferences", extras)
 	}
 
 	// These have particular acceptable values, unlike TimeZone
@@ -275,7 +276,7 @@ func getPublicProfile(ctx context.Context, user *models.User) *PublicProfile {
 
 	url, err := user.GetPhotoURL()
 	if err != nil {
-		_ = reportError(ctx, err, "", map[string]interface{}{"user": user.UUID})
+		_ = domain.ReportError(ctx, err, "", map[string]interface{}{"user": user.UUID})
 		return nil
 	}
 

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -195,6 +195,10 @@
   translation: We had a problem finding the list of conversations.
 - id: GetMyThreads
   translation: We had a problem finding a list of your conversations.
+
+# User
+- id: User.Meetings
+  translation: We had a problem getting a list of meetings for you.
 - id: GetUserOrganizations
   translation: We had a problem finding the list of organizations for the user profile.
 - id: GetUserPosts

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -197,7 +197,7 @@
   translation: We had a problem finding a list of your conversations.
 
 # User
-- id: User.Meetings
+- id: User.MeetingsAsParticipant
   translation: We had a problem getting a list of meetings for you.
 - id: GetUserOrganizations
   translation: We had a problem finding the list of organizations for the user profile.

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -117,18 +117,6 @@ func GetCurrentUserFromGqlContext(ctx context.Context) User {
 	return GetCurrentUser(bc)
 }
 
-type EmptyContext struct {
-	buffalo.Context
-}
-
-func GetBuffaloContextFromGqlContext(c context.Context) buffalo.Context {
-	bc, ok := c.Value("BuffaloContext").(buffalo.Context)
-	if ok {
-		return bc
-	}
-	return EmptyContext{}
-}
-
 func GetCurrentUser(c buffalo.Context) User {
 	user := c.Value("current_user")
 

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -787,4 +788,17 @@ func (u *User) isMeetingOrganizer(ctx buffalo.Context, meeting Meeting) bool {
 
 func (u *User) isSuperAdmin() bool {
 	return u.AdminRole == UserAdminRoleSuperAdmin
+}
+
+// Meetings returns all meetings in which the user is a participant
+func (u *User) Meetings(ctx context.Context) ([]Meeting, error) {
+	m := Meetings{}
+	if err := DB.
+		Where("meeting_participants.user_id=?", u.ID).
+		Join("meeting_participants", "meeting_participants.meeting_id=meetings.id").
+		All(&m); err != nil {
+
+		return m, domain.ReportError(ctx, err, "User.Meetings", map[string]interface{}{"user": u.UUID})
+	}
+	return m, nil
 }

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -790,15 +790,15 @@ func (u *User) isSuperAdmin() bool {
 	return u.AdminRole == UserAdminRoleSuperAdmin
 }
 
-// Meetings returns all meetings in which the user is a participant
-func (u *User) Meetings(ctx context.Context) ([]Meeting, error) {
+// MeetingsAsParticipant returns all meetings in which the user is a participant
+func (u *User) MeetingsAsParticipant(ctx context.Context) ([]Meeting, error) {
 	m := Meetings{}
 	if err := DB.
 		Where("meeting_participants.user_id=?", u.ID).
 		Join("meeting_participants", "meeting_participants.meeting_id=meetings.id").
 		All(&m); err != nil {
 
-		return m, domain.ReportError(ctx, err, "User.Meetings", map[string]interface{}{"user": u.UUID})
+		return m, domain.ReportError(ctx, err, "User.MeetingsAsParticipant", map[string]interface{}{"user": u.UUID})
 	}
 	return m, nil
 }

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -1571,7 +1571,7 @@ func (ms *ModelSuite) TestUser_isMeetingOrganizer() {
 	}
 }
 
-func (ms *ModelSuite) TestUser_Meetings() {
+func (ms *ModelSuite) TestUser_MeetingsAsParticipant() {
 	f := createMeetingFixtures(ms.DB, 2)
 
 	tests := []struct {

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -1615,7 +1615,7 @@ func (ms *ModelSuite) TestUser_Meetings() {
 			ctx.Set("current_user", tt.user)
 
 			// exercise
-			got, err := tt.user.Meetings(ctx)
+			got, err := tt.user.MeetingsAsParticipant(ctx)
 
 			// verify
 			if tt.wantErr != "" {


### PR DESCRIPTION
Also, I moved some helper functions so `models` code can use them -- specifically, so `models.User.MeetingsAsParticipant` can be used as a GraphQL resolver rather than adding a separate method in `gqlgen.userResolver`. Unfortunately I had to touch many files to do this, but I think it will pay off over time. Since `reportError` is being moved and renamed, is it still named well? Maybe `translateError`?