### PR TITLE
refactor getters and setters

### DIFF
--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -126,7 +126,11 @@ func getAuthInviteResponse(c buffalo.Context) (authInviteResponse, error) {
 		Name: meeting.Name,
 	}
 	if meeting.ImageFileID.Valid {
-		resp.ImageURL = meeting.ImageFile.URL
+		f, err := meeting.ImageFile()
+		if err != nil {
+			domain.ErrLogger.Printf("error loading meeting image file: " + err.Error())
+		}
+		resp.ImageURL = f.URL
 	}
 	return resp, nil
 }

--- a/application/actions/meeting_test.go
+++ b/application/actions/meeting_test.go
@@ -120,7 +120,7 @@ func (as *ActionSuite) Test_MeetingQuery() {
 	as.Equal(testMtg.EndDate.Format(domain.DateFormat), gotMtg.EndDate,
 		"incorrect meeting EndDate")
 
-	image, err := testMtg.GetImage()
+	image, err := testMtg.ImageFile()
 	as.NoError(err, "unexpected error getting ImageFile")
 	wantUUID := ""
 	if image != nil {
@@ -175,7 +175,7 @@ func (as *ActionSuite) Test_MeetingsQuery() {
 		as.Equal(wantMtg.EndDate.Format(domain.DateFormat), gotMtg.EndDate,
 			"incorrect meeting EndDate")
 
-		image, err := wantMtg.GetImage()
+		image, err := wantMtg.ImageFile()
 		as.NoError(err, "unexpected error getting ImageFile")
 		wantUUID := ""
 		if image != nil {
@@ -274,9 +274,6 @@ func (as *ActionSuite) Test_UpdateMeeting() {
 
 	as.NoError(as.testGqlQuery(query, f.Users[0].Nickname, &resp))
 
-	err := as.DB.Load(&(f.Meetings[0]), "ImageFile")
-	as.NoError(err, "failed to load meeting fixture, %s")
-
 	gotMtg := resp.Meeting
 
 	as.Equal(f.Meetings[0].UUID.String(), gotMtg.ID)
@@ -291,7 +288,7 @@ func (as *ActionSuite) Test_UpdateMeeting() {
 	as.Equal("dc", gotMtg.Location.Country, "incorrect meeting Location.Country")
 
 	// Not authorized
-	err = as.testGqlQuery(query, f.Users[1].Nickname, &resp)
+	err := as.testGqlQuery(query, f.Users[1].Nickname, &resp)
 	as.Error(err, "expected an authorization error but did not get one")
 
 	as.Contains(err.Error(), "You are not allowed to edit the information for that meeting.", "incorrect authorization error message")

--- a/application/actions/message_test.go
+++ b/application/actions/message_test.go
@@ -62,7 +62,7 @@ func (as *ActionSuite) TestCreateMessage() {
 	thread, err := f.Messages[0].GetThread()
 	as.NoError(err)
 
-	messages, err := thread.GetMessages()
+	messages, err := thread.Messages()
 	as.NoError(err)
 	as.Equal(3, len(messages), "incorrect number of thread messages")
 

--- a/application/actions/organization_test.go
+++ b/application/actions/organization_test.go
@@ -264,7 +264,7 @@ func (as *ActionSuite) Test_OrganizationViewAndList() {
 
 	userFixtures := test.CreateUserFixtures(as.DB, 4)
 	for i, _ := range userFixtures.Users {
-		_ = as.DB.Load(&userFixtures.Users[i], "UserOrganizations", "AccessTokens")
+		as.NoError(as.DB.Load(&userFixtures.Users[i], "UserOrganizations"))
 	}
 
 	// user 0 will be a super admin, user 1 will be a sales admin, and user 2 will be an org admin for org1, user 3 will be a user

--- a/application/actions/organization_test.go
+++ b/application/actions/organization_test.go
@@ -69,7 +69,7 @@ func (as *ActionSuite) Test_CreateOrganization() {
 	as.Equal(f.Organizations[1].AuthType, orgs[0].AuthType, "AuthType doesn't match")
 	as.Equal(f.Organizations[1].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
 
-	domains, _ := orgs[0].GetDomains()
+	domains, _ := orgs[0].Domains()
 	as.Equal(0, len(domains), "new organization has unexpected domains")
 
 	as.Equal(resp.Organization.ID, orgs[0].UUID.String(), "UUID doesn't match")
@@ -454,7 +454,7 @@ func (as *ActionSuite) Test_UpdateOrganization() {
 	as.Equal(f.Organizations[0].Url, orgs[0].Url, "URL doesn't match")
 	as.Equal(f.Organizations[0].AuthType, orgs[0].AuthType, "AuthType doesn't match")
 	as.Equal(f.Organizations[0].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
-	dbDomains, _ := orgs[0].GetDomains()
+	dbDomains, _ := orgs[0].Domains()
 	as.Equal(2, len(dbDomains), "updated organization has unexpected domains")
 	as.Equal(resp.Organization.ID, orgs[0].UUID.String(), "UUID from query doesn't match database")
 }

--- a/application/actions/organizationdomain_test.go
+++ b/application/actions/organizationdomain_test.go
@@ -37,12 +37,14 @@ func (as *ActionSuite) Test_CreateUpdateOrganizationDomain() {
 	as.Equal(f.Organizations[0].UUID.String(), resp.OrganizationDomain[0].OrganizationID, "received wrong org ID")
 
 	var orgs models.Organizations
-	err = as.DB.Eager().Where("name = ?", f.Organizations[0].Name).All(&orgs)
+	err = as.DB.Where("name = ?", f.Organizations[0].Name).All(&orgs)
 	as.NoError(err)
 
 	as.GreaterOrEqual(1, len(orgs), "no Organization found")
-	as.Equal(1, len(orgs[0].OrganizationDomains), "wrong number of domains in DB")
-	as.Equal(testDomain, orgs[0].OrganizationDomains[0].Domain, "wrong domain in DB")
+	domains, err := orgs[0].Domains()
+	as.NoError(err)
+	as.Equal(1, len(domains), "wrong number of domains in DB")
+	as.Equal(testDomain, domains[0].Domain, "wrong domain in DB")
 
 	// Test updating orgdomains
 	validUpdateInput := fmt.Sprintf(`organizationID:"%s" domain:"%s" authType:"saml", authConfig:"{}"`,

--- a/application/gqlgen/meeting.go
+++ b/application/gqlgen/meeting.go
@@ -107,7 +107,7 @@ func (r *meetingResolver) Posts(ctx context.Context, obj *models.Meeting) ([]mod
 	if obj == nil {
 		return nil, nil
 	}
-	posts, err := obj.GetPosts()
+	posts, err := obj.Posts()
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "Meeting.Posts")
 	}

--- a/application/gqlgen/meeting.go
+++ b/application/gqlgen/meeting.go
@@ -95,7 +95,7 @@ func (r *meetingResolver) ImageFile(ctx context.Context, obj *models.Meeting) (*
 		return nil, nil
 	}
 
-	image, err := obj.GetImage()
+	image, err := obj.ImageFile()
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetMeetingImage")
 	}
@@ -230,10 +230,8 @@ func convertGqlMeetingInputToDBMeeting(ctx context.Context, input meetingInput, 
 	}
 
 	if input.ImageFileID != nil {
-		if file, err := meeting.AttachImage(*input.ImageFileID); err != nil {
+		if _, err := meeting.SetImageFile(*input.ImageFileID); err != nil {
 			graphql.AddError(ctx, gqlerror.Errorf("Error attaching image file to Meeting, %s", err.Error()))
-		} else {
-			meeting.ImageFile = file
 		}
 	}
 

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -105,7 +105,7 @@ func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input C
 		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain", extras)
 	}
 
-	domains, err2 := org.GetDomains()
+	domains, err2 := org.Domains()
 	if err2 != nil {
 		// don't return an error since the AddDomain operation succeeded
 		_ = domain.ReportError(ctx, err2, "", extras)
@@ -142,7 +142,7 @@ func (r *mutationResolver) UpdateOrganizationDomain(ctx context.Context, input C
 		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.SaveError", extras)
 	}
 
-	domains, err2 := org.GetDomains()
+	domains, err2 := org.Domains()
 	if err2 != nil {
 		// don't return an error since the operation succeeded
 		_ = domain.ReportError(ctx, err2, "", extras)
@@ -172,7 +172,7 @@ func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input R
 		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain", extras)
 	}
 
-	domains, err2 := org.GetDomains()
+	domains, err2 := org.Domains()
 	if err2 != nil {
 		// don't return an error since the RemoveDomain operation succeeded
 		_ = domain.ReportError(ctx, err2, "", extras)

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -72,7 +72,7 @@ func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organiza
 		return nil, nil
 	}
 
-	domains, err := obj.GetDomains()
+	domains, err := obj.Domains()
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationDomains")
 	}

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -64,7 +64,7 @@ func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]mo
 		return nil, nil
 	}
 
-	messages, err := obj.GetMessages()
+	messages, err := obj.Messages()
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreadMessages")
 	}

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -51,7 +51,7 @@ func (r *userResolver) Posts(ctx context.Context, obj *models.User, role PostRol
 		return nil, nil
 	}
 
-	posts, err := obj.GetPosts(postRoleMap[role])
+	posts, err := obj.Posts(postRoleMap[role])
 	if err != nil {
 		extras := map[string]interface{}{
 			"role": role,

--- a/application/listeners/posthelpers_fixtures_test.go
+++ b/application/listeners/posthelpers_fixtures_test.go
@@ -155,7 +155,7 @@ func CreateFixtures_sendNotificationRequestFromStatus(ms *ModelSuite, t *testing
 			t.Errorf("could not create test post ... %v", err)
 			t.FailNow()
 		}
-		if err := models.DB.Load(&posts[i], "CreatedBy", "Provider", "Receiver", "Organization"); err != nil {
+		if err := models.DB.Load(&posts[i], "CreatedBy", "Provider", "Organization"); err != nil {
 			t.Errorf("Error loading post associations: %s", err)
 			t.FailNow()
 		}

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -221,7 +221,8 @@ func (m *Meeting) ImageFile() (*File, error) {
 	if err := (*m.ImgFile).refreshURL(); err != nil {
 		return nil, err
 	}
-	return m.ImgFile, nil
+	f := *m.ImgFile
+	return &f, nil
 }
 
 func (m *Meeting) GetCreator() (*User, error) {

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -32,7 +32,6 @@ type Meeting struct {
 	ImageFileID nulls.Int    `json:"image_file_id" db:"image_file_id"`
 	LocationID  int          `json:"location_id" db:"location_id"`
 
-	CreatedBy User     `belongs_to:"users"`
 	ImageFile File     `belongs_to:"files"`
 	Location  Location `belongs_to:"locations"`
 }
@@ -103,7 +102,7 @@ func (m *Meeting) FindByUUID(uuid string) error {
 		return errors.New("error finding meeting: uuid must not be blank")
 	}
 
-	if err := DB.Eager("CreatedBy").Where("uuid = ?", uuid).First(m); err != nil {
+	if err := DB.Where("uuid = ?", uuid).First(m); err != nil {
 		return fmt.Errorf("error finding meeting by uuid: %s", err.Error())
 	}
 
@@ -120,7 +119,7 @@ func (m *Meetings) FindOnDate(timeInFocus time.Time) error {
 	date := timeInFocus.Format(domain.DateTimeFormat)
 	where := "start_date <= ? and end_date >= ?"
 
-	if err := getOrdered(m, DB.Eager("CreatedBy").Where(where, date, date)); err != nil {
+	if err := getOrdered(m, DB.Where(where, date, date)); err != nil {
 		return fmt.Errorf("error finding meeting with start_date and end_date straddling %s ... %s",
 			date, err.Error())
 	}
@@ -133,7 +132,7 @@ func (m *Meetings) FindOnOrAfterDate(timeInFocus time.Time) error {
 
 	date := timeInFocus.Format(domain.DateTimeFormat)
 
-	if err := getOrdered(m, DB.Eager("CreatedBy").Where("end_date >= ?", date)); err != nil {
+	if err := getOrdered(m, DB.Where("end_date >= ?", date)); err != nil {
 		return fmt.Errorf("error finding meeting with end_date before %s ... %s", date, err.Error())
 	}
 
@@ -144,7 +143,7 @@ func (m *Meetings) FindOnOrAfterDate(timeInFocus time.Time) error {
 func (m *Meetings) FindAfterDate(timeInFocus time.Time) error {
 	date := timeInFocus.Format(domain.DateTimeFormat)
 
-	if err := getOrdered(m, DB.Eager("CreatedBy").Where("start_date > ?", date)); err != nil {
+	if err := getOrdered(m, DB.Where("start_date > ?", date)); err != nil {
 		return fmt.Errorf("error finding meeting with start_date after %s ... %s", date, err.Error())
 	}
 
@@ -158,7 +157,7 @@ func (m *Meetings) FindRecent(timeInFocus time.Time) error {
 	recentDate := timeInFocus.Add(-domain.RecentMeetingDelay)
 	where := "end_date between ? and ?"
 
-	if err := getOrdered(m, DB.Eager("CreatedBy").Where(where, recentDate, yesterday)); err != nil {
+	if err := getOrdered(m, DB.Where(where, recentDate, yesterday)); err != nil {
 		return fmt.Errorf("error finding meeting with end_date between %s and %s ... %s",
 			recentDate, yesterday, err.Error())
 	}

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -35,7 +35,6 @@ type Meeting struct {
 	CreatedBy User     `belongs_to:"users"`
 	ImageFile File     `belongs_to:"files"`
 	Location  Location `belongs_to:"locations"`
-	Posts     Posts    `has_many:"posts" fk_id:"meeting_id" order_by:"updated_at desc"`
 }
 
 // String is not required by pop and may be deleted
@@ -281,13 +280,14 @@ func (m *Meeting) CanUpdate(user User) bool {
 	return user.ID == m.CreatedByID
 }
 
-// GetPosts return all associated Posts
-func (m *Meeting) GetPosts() ([]Post, error) {
-	if err := DB.Load(m, "Posts"); err != nil {
+// Posts return all associated Posts
+func (m *Meeting) Posts() (Posts, error) {
+	var posts Posts
+	if err := DB.Where("meeting_id = ?", m.ID).Order("updated_at desc").All(&posts); err != nil {
 		return nil, fmt.Errorf("error getting posts for meeting id %v ... %v", m.ID, err)
 	}
 
-	return m.Posts, nil
+	return posts, nil
 }
 
 // Invites returns all of the MeetingInvites for this Meeting. Only the meeting creator and organizers are authorized.

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -345,7 +345,7 @@ func (ms *ModelSuite) TestMeeting_FindByInviteCode() {
 	}
 }
 
-func (ms *ModelSuite) TestMeeting_AttachImage() {
+func (ms *ModelSuite) TestMeeting_SetImageFile() {
 	meetings := createMeetingFixtures(ms.DB, 3).Meetings
 	files := createFileFixtures(3)
 	meetings[1].ImageFileID = nulls.NewInt(files[0].ID)
@@ -381,7 +381,7 @@ func (ms *ModelSuite) TestMeeting_AttachImage() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.AttachImage(tt.newImage)
+			got, err := tt.meeting.SetImageFile(tt.newImage)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -397,7 +397,7 @@ func (ms *ModelSuite) TestMeeting_AttachImage() {
 	}
 }
 
-func (ms *ModelSuite) TestMeeting_GetImage() {
+func (ms *ModelSuite) TestMeeting_ImageFile() {
 	user := User{}
 	createFixture(ms, &user)
 
@@ -414,14 +414,18 @@ func (ms *ModelSuite) TestMeeting_GetImage() {
 	}
 	createFixture(ms, &meeting)
 
+	f, err := meeting.ImageFile()
+	ms.NoError(err, "unexpected error from Meeting.ImageFile()")
+	ms.Nil(f, "expected nil returned from Meeting.ImageFile()")
+
 	var imageFixture File
 	const filename = "photo.gif"
 	ms.Nil(imageFixture.Store(filename, []byte("GIF89a")), "failed to create file fixture")
 
-	attachedFile, err := meeting.AttachImage(imageFixture.UUID.String())
+	attachedFile, err := meeting.SetImageFile(imageFixture.UUID.String())
 	ms.NoError(err)
 
-	if got, err := meeting.GetImage(); err == nil {
+	if got, err := meeting.ImageFile(); err == nil {
 		ms.Equal(attachedFile.UUID.String(), got.UUID.String())
 		ms.True(got.URLExpiration.After(time.Now().Add(time.Minute)))
 		ms.Equal(filename, got.Name)

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -526,7 +526,7 @@ func (ms *ModelSuite) TestMeeting_GetPosts() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.GetPosts()
+			got, err := tt.meeting.Posts()
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -30,17 +30,16 @@ const AuthTypeSaml = "saml"
 const AuthTypeTwitter = "twitter"
 
 type Organization struct {
-	ID                  int                  `json:"id" db:"id"`
-	CreatedAt           time.Time            `json:"created_at" db:"created_at"`
-	UpdatedAt           time.Time            `json:"updated_at" db:"updated_at"`
-	Name                string               `json:"name" db:"name"`
-	Url                 nulls.String         `json:"url" db:"url"`
-	AuthType            string               `json:"auth_type" db:"auth_type"`
-	AuthConfig          string               `json:"auth_config" db:"auth_config"`
-	UUID                uuid.UUID            `json:"uuid" db:"uuid"`
-	LogoFileID          nulls.Int            `json:"logo_file_id" db:"logo_file_id"`
-	Users               Users                `many_to_many:"user_organizations" order_by:"nickname"`
-	OrganizationDomains []OrganizationDomain `has_many:"organization_domains" order_by:"domain asc"`
+	ID         int          `json:"id" db:"id"`
+	CreatedAt  time.Time    `json:"created_at" db:"created_at"`
+	UpdatedAt  time.Time    `json:"updated_at" db:"updated_at"`
+	Name       string       `json:"name" db:"name"`
+	Url        nulls.String `json:"url" db:"url"`
+	AuthType   string       `json:"auth_type" db:"auth_type"`
+	AuthConfig string       `json:"auth_config" db:"auth_config"`
+	UUID       uuid.UUID    `json:"uuid" db:"uuid"`
+	LogoFileID nulls.Int    `json:"logo_file_id" db:"logo_file_id"`
+	Users      Users        `many_to_many:"user_organizations" order_by:"nickname"`
 }
 
 // String is used to serialize error extras
@@ -180,11 +179,12 @@ func (orgs *Organizations) AllWhereUserIsOrgAdmin(cUser User) error {
 
 // Domains finds and returns all related OrganizationDomain rows.
 func (o *Organization) Domains() ([]OrganizationDomain, error) {
-	if err := DB.Load(o, "OrganizationDomains"); err != nil {
+	var domains OrganizationDomains
+	if err := DB.Where("organization_id=?", o.ID).Order("domain asc").All(&domains); err != nil {
 		return nil, err
 	}
 
-	return o.OrganizationDomains, nil
+	return domains, nil
 }
 
 // GetUsers finds and returns all related Users.

--- a/application/models/organization.go
+++ b/application/models/organization.go
@@ -178,8 +178,8 @@ func (orgs *Organizations) AllWhereUserIsOrgAdmin(cUser User) error {
 		All(orgs)
 }
 
-// GetDomains finds and returns all related OrganizationDomain rows.
-func (o *Organization) GetDomains() ([]OrganizationDomain, error) {
+// Domains finds and returns all related OrganizationDomain rows.
+func (o *Organization) Domains() ([]OrganizationDomain, error) {
 	if err := DB.Load(o, "OrganizationDomains"); err != nil {
 		return nil, err
 	}

--- a/application/models/organization_test.go
+++ b/application/models/organization_test.go
@@ -270,17 +270,12 @@ func (ms *ModelSuite) TestOrganization_AddRemoveDomain() {
 	err = orgFixtures[1].AddDomain("second.com", "", "")
 	ms.Error(err, "was able to add existing domain (second.com) to Org2 but should have gotten error")
 	domains, _ = orgFixtures[0].Domains()
-	if len(domains) != 2 {
-		t.Errorf("after reloading org domains we did not get what we expected (%v), got: %v", 2, len(orgFixtures[0].OrganizationDomains))
-	}
+	ms.Equal(2, len(domains), "after reloading org domains we did not get what we expected")
 
 	err = orgFixtures[0].RemoveDomain("first.com")
 	ms.NoError(err, "unable to remove domain: %s", err)
 	domains, _ = orgFixtures[0].Domains()
-	if len(domains) != 1 {
-		t.Errorf("org domains count after removing domain is not correct, expected %v, got: %v", 1, len(orgFixtures[0].OrganizationDomains))
-	}
-
+	ms.Equal(1, len(domains), "org domains count after removing domain is not correct")
 }
 
 func (ms *ModelSuite) TestOrganization_Save() {

--- a/application/models/organization_test.go
+++ b/application/models/organization_test.go
@@ -255,28 +255,28 @@ func (ms *ModelSuite) TestOrganization_AddRemoveDomain() {
 
 	err := orgFixtures[0].AddDomain("first.com", "", "")
 	ms.NoError(err, "unable to add first domain to Org1: %s", err)
-	domains, _ := orgFixtures[0].GetDomains()
+	domains, _ := orgFixtures[0].Domains()
 	if len(domains) != 1 {
 		t.Errorf("did not get error, but failed to add first domain to Org1")
 	}
 
 	err = orgFixtures[0].AddDomain("second.com", "", "")
 	ms.NoError(err, "unable to add second domain to Org1: %s", err)
-	domains, _ = orgFixtures[0].GetDomains()
+	domains, _ = orgFixtures[0].Domains()
 	if len(domains) != 2 {
 		t.Errorf("did not get error, but failed to add second domain to Org1")
 	}
 
 	err = orgFixtures[1].AddDomain("second.com", "", "")
 	ms.Error(err, "was able to add existing domain (second.com) to Org2 but should have gotten error")
-	domains, _ = orgFixtures[0].GetDomains()
+	domains, _ = orgFixtures[0].Domains()
 	if len(domains) != 2 {
 		t.Errorf("after reloading org domains we did not get what we expected (%v), got: %v", 2, len(orgFixtures[0].OrganizationDomains))
 	}
 
 	err = orgFixtures[0].RemoveDomain("first.com")
 	ms.NoError(err, "unable to remove domain: %s", err)
-	domains, _ = orgFixtures[0].GetDomains()
+	domains, _ = orgFixtures[0].Domains()
 	if len(domains) != 1 {
 		t.Errorf("org domains count after removing domain is not correct, expected %v, got: %v", 1, len(orgFixtures[0].OrganizationDomains))
 	}
@@ -347,7 +347,7 @@ func (ms *ModelSuite) TestOrganization_All() {
 func (ms *ModelSuite) TestOrganization_GetDomains() {
 	f := CreateFixturesForOrganizationGetDomains(ms)
 
-	orgDomains, err := f.Organizations[0].GetDomains()
+	orgDomains, err := f.Organizations[0].Domains()
 	ms.NoError(err)
 
 	domains := make([]string, len(orgDomains))

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -247,7 +247,6 @@ type Post struct {
 
 	CreatedBy    User         `belongs_to:"users"`
 	Organization Organization `belongs_to:"organizations"`
-	Receiver     User         `belongs_to:"users"`
 	Provider     User         `belongs_to:"users"`
 
 	Files       PostFiles `has_many:"post_files"`

--- a/application/models/post.go
+++ b/application/models/post.go
@@ -250,11 +250,10 @@ type Post struct {
 	Receiver     User         `belongs_to:"users"`
 	Provider     User         `belongs_to:"users"`
 
-	Files       PostFiles     `has_many:"post_files"`
-	Histories   PostHistories `has_many:"post_histories"`
-	PhotoFile   File          `belongs_to:"files"`
-	Destination Location      `belongs_to:"locations"`
-	Origin      Location      `belongs_to:"locations"`
+	Files       PostFiles `has_many:"post_files"`
+	PhotoFile   File      `belongs_to:"files"`
+	Destination Location  `belongs_to:"locations"`
+	Origin      Location  `belongs_to:"locations"`
 }
 
 // PostCreatedEventData holds data needed by the New Post event listener

--- a/application/models/postfile.go
+++ b/application/models/postfile.go
@@ -13,7 +13,6 @@ type PostFile struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 	PostID    int       `json:"post_id" db:"post_id"`
-	Post      Post      `belongs_to:"posts"`
 	FileID    int       `json:"file_id" db:"file_id"`
 	File      File      `belongs_to:"files"`
 }

--- a/application/models/posthistory.go
+++ b/application/models/posthistory.go
@@ -19,9 +19,7 @@ type PostHistory struct {
 	PostID     int        `json:"post_id" db:"post_id"`
 	ReceiverID nulls.Int  `json:"receiver_id" db:"receiver_id"`
 	ProviderID nulls.Int  `json:"provider_id" db:"provider_id"`
-	Post       Post       `belongs_to:"posts"`
 	Receiver   User       `belongs_to:"users"`
-	Provider   User       `belongs_to:"users"`
 }
 
 // String can be helpful for serializing the model

--- a/application/models/potentialprovider.go
+++ b/application/models/potentialprovider.go
@@ -20,7 +20,6 @@ type PotentialProvider struct {
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 	PostID    int       `json:"post_id" db:"post_id"`
 	UserID    int       `json:"user_id" db:"user_id"`
-	Post      Post      `belongs_to:"posts"`
 	User      User      `belongs_to:"users"`
 }
 

--- a/application/models/testutils_test.go
+++ b/application/models/testutils_test.go
@@ -302,7 +302,7 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 		meetings[i].StartDate = time.Now()
 		meetings[i].EndDate = time.Now().Add(time.Hour * 24)
 		meetings[i].InviteCode = nulls.NewUUID(domain.GetUUID())
-		if _, err := meetings[i].AttachImage(files[i].UUID.String()); err != nil {
+		if _, err := meetings[i].SetImageFile(files[i].UUID.String()); err != nil {
 			panic("error attaching image to meeting fixture, " + err.Error())
 		}
 		mustCreate(tx, &meetings[i])

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -20,7 +20,6 @@ type Thread struct {
 	UUID         uuid.UUID `json:"uuid" db:"uuid"`
 	PostID       int       `json:"post_id" db:"post_id"`
 	Post         Post      `belongs_to:"posts"`
-	Messages     Messages  `has_many:"messages"`
 	Participants Users     `many_to_many:"thread_participants"`
 }
 
@@ -89,7 +88,7 @@ func (t *Thread) GetPost() (*Post, error) {
 	return &post, nil
 }
 
-func (t *Thread) GetMessages() ([]Message, error) {
+func (t *Thread) Messages() ([]Message, error) {
 	var messages []Message
 	if err := DB.Where("thread_id = ?", t.ID).All(&messages); err != nil {
 		return messages, fmt.Errorf("error getting messages for thread id %v ... %v", t.ID, err)
@@ -212,7 +211,7 @@ func (t *Thread) UnreadMessageCount(userID int, lastViewedAt time.Time) (int, er
 		return count, fmt.Errorf("error in UnreadMessageCount, invalid id %v", userID)
 	}
 
-	msgs, err := t.GetMessages()
+	msgs, err := t.Messages()
 	if err != nil {
 		return count, err
 	}

--- a/application/models/thread_test.go
+++ b/application/models/thread_test.go
@@ -165,21 +165,21 @@ func (ms *ModelSuite) TestThread_GetMessages() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.thread.GetMessages()
+			got, err := test.thread.Messages()
 			if test.wantErr {
 				if (err != nil) != test.wantErr {
-					t.Errorf("GetMessages() did not return expected error")
+					t.Errorf("Messages() did not return expected error")
 				}
 			} else {
 				if err != nil {
-					t.Errorf("GetMessages() error = %v", err)
+					t.Errorf("Messages() error = %v", err)
 				} else {
 					ids := make([]uuid.UUID, len(got))
 					for i := range got {
 						ids[i] = got[i].UUID
 					}
 					if !reflect.DeepEqual(ids, test.want) {
-						t.Errorf("GetMessages() got = %s, want %s", ids, test.want)
+						t.Errorf("Messages() got = %s, want %s", ids, test.want)
 					}
 				}
 			}

--- a/application/models/threadparticipant.go
+++ b/application/models/threadparticipant.go
@@ -19,7 +19,6 @@ type ThreadParticipant struct {
 	LastViewedAt   time.Time `json:"last_viewed_at" db:"last_viewed_at"`
 	LastNotifiedAt time.Time `json:"last_notified_at" db:"last_notified_at"`
 	Thread         Thread    `belongs_to:"threads"`
-	User           User      `belongs_to:"users"`
 }
 
 // String can be helpful for serializing the model

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -63,7 +63,6 @@ type User struct {
 	PhotoFileID       nulls.Int         `json:"photo_file_id" db:"photo_file_id"`
 	AuthPhotoURL      nulls.String      `json:"auth_photo_url" db:"auth_photo_url"`
 	LocationID        nulls.Int         `json:"location_id" db:"location_id"`
-	AccessTokens      []UserAccessToken `has_many:"user_access_tokens" json:"-"`
 	Organizations     Organizations     `many_to_many:"user_organizations" order_by:"name asc" json:"-"`
 	UserOrganizations UserOrganizations `has_many:"user_organizations" json:"-"`
 	UserPreferences   UserPreferences   `has_many:"user_preferences" json:"-"`

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -66,9 +66,6 @@ type User struct {
 	Organizations     Organizations     `many_to_many:"user_organizations" order_by:"name asc" json:"-"`
 	UserOrganizations UserOrganizations `has_many:"user_organizations" json:"-"`
 	UserPreferences   UserPreferences   `has_many:"user_preferences" json:"-"`
-	PostsCreated      Posts             `has_many:"posts" fk_id:"created_by_id" order_by:"updated_at desc"`
-	PostsProviding    Posts             `has_many:"posts" fk_id:"provider_id" order_by:"updated_at desc"`
-	PostsReceiving    Posts             `has_many:"posts" fk_id:"receiver_id" order_by:"updated_at desc"`
 	PhotoFile         File              `belongs_to:"files"`
 	Location          Location          `belongs_to:"locations"`
 }
@@ -416,23 +413,16 @@ func (u *User) FindUserOrganization(org Organization) (UserOrganization, error) 
 	return userOrg, nil
 }
 
-func (u *User) GetPosts(postRole string) ([]Post, error) {
-	if err := DB.Load(u, postRole); err != nil {
+func (u *User) Posts(postRole string) ([]Post, error) {
+	fk := map[string]string{
+		PostsCreated:   "created_by_id=?",
+		PostsReceiving: "receiver_id=?",
+		PostsProviding: "provider_id=?",
+	}
+	var posts Posts
+	if err := DB.Where(fk[postRole], u.ID).Order("updated_at desc").All(&posts); err != nil {
 		return nil, fmt.Errorf("error getting posts for user id %v ... %v", u.ID, err)
 	}
-
-	var posts Posts
-	switch postRole {
-	case PostsCreated:
-		posts = u.PostsCreated
-
-	case PostsReceiving:
-		posts = u.PostsReceiving
-
-	case PostsProviding:
-		posts = u.PostsProviding
-	}
-
 	return posts, nil
 }
 

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -478,9 +478,9 @@ func (ms *ModelSuite) TestUser_GetPosts() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.args.user.GetPosts(test.args.postRole)
+			got, err := test.args.user.Posts(test.args.postRole)
 			if err != nil {
-				t.Errorf("GetPosts() returned error: %s", err)
+				t.Errorf("Posts() returned error: %s", err)
 			}
 
 			ids := make([]uuid.UUID, len(got))

--- a/application/models/userpreference.go
+++ b/application/models/userpreference.go
@@ -33,7 +33,6 @@ type UserPreference struct {
 	UserID    int       `json:"user_id" db:"user_id"`
 	Key       string    `json:"key" db:"key"`
 	Value     string    `json:"value" db:"value"`
-	User      User      `belongs_to:"users"`
 }
 
 // String can be helpful for serializing the model


### PR DESCRIPTION
This is mostly just renames, with a couple noteworthy exceptions:
- In `Meeting` the image getter method handles hydration of the file object so calling code need not manage that. To accomplish that, the struct field `ImgFile` has been changed to a pointer to indicate whether it has been hydrated. (It could be non-existent as well, but I don't have a good answer for that at this point.) On a somewhat anecdotal note, "Effective Go" says that a field hidden by getter/setter methods should be lower-cased to avoid collision with the getter name. That doesn't work here because Pop needs access to the field.
- `Meeting.Posts()` is similar, but has no corresponding struct member. No setter is needed.
- same with `Organization.Domains()`
- same with `User.Posts()`

__Question:__ is the `Meeting.ImgFile` struct member necessary? Acts as a sort of "cache" but maybe has negligible benefit. I did this as a sort of trial, before doing the same thing elsewhere.