### PR TITLE
createMeetingParticipant mutation

### DIFF
--- a/application/actions/meeting_fixtures_test.go
+++ b/application/actions/meeting_fixtures_test.go
@@ -15,7 +15,7 @@ import (
 //  0 Mtg Past    user 0
 //  1 Mtg Recent  user 0     invitee2            user1
 //  2 Mtg Now     user 0     invitee0, invitee1  user0, user1, user2   user1
-//  3 Mtg Future  user 0
+//  3 Mtg Future  user 0     user1
 //
 //  Inviter for all invites is user 0
 func createFixturesForMeetings(as *ActionSuite) meetingQueryFixtures {
@@ -89,6 +89,11 @@ func createFixturesForMeetings(as *ActionSuite) meetingQueryFixtures {
 			MeetingID: meetings[1].ID,
 			InviterID: user.ID,
 			Email:     "invitee2@example.com",
+		},
+		{
+			MeetingID: meetings[3].ID,
+			InviterID: user.ID,
+			Email:     uf.Users[1].Email,
 		},
 	}
 	for i := range invites {

--- a/application/actions/meeting_test.go
+++ b/application/actions/meeting_test.go
@@ -295,8 +295,8 @@ func (as *ActionSuite) Test_UpdateMeeting() {
 	err = as.testGqlQuery(query, f.Users[1].Nickname, &resp)
 	as.Error(err, "expected an authorization error but did not get one")
 
-	as.Contains(err.Error(), "You are not allowed to edit the information for that meeting.", "incorrect authorization error message")
-
+	as.Contains(err.Error(), "You are not allowed to edit the information for that event.",
+		"incorrect authorization error message")
 }
 
 func (as *ActionSuite) Test_CreateMeetingInvites() {
@@ -399,7 +399,7 @@ func (as *ActionSuite) Test_RemoveMeetingInvite() {
 			meetingID:      f.Meetings[0].UUID.String(),
 			testUser:       f.Users[0],
 			responseEmails: []string{},
-			wantErr:        "problem removing the meeting invite",
+			wantErr:        "problem removing the event invite",
 		},
 		{
 			name:           "not creator, not organizer",
@@ -538,9 +538,9 @@ func (as *ActionSuite) Test_CreateMeetingParticipant() {
 		{
 			name:      "no code",
 			invite:    models.MeetingInvite{},
-			meetingID: f.Meetings[0].UUID.String(),
-			testUser:  f.Users[0],
-			wantErr:   "yes",
+			meetingID: f.Meetings[2].UUID.String(),
+			testUser:  f.Users[2],
+			wantErr:   "not allowed",
 		},
 		{
 			name:      "good secret code",

--- a/application/actions/meeting_test.go
+++ b/application/actions/meeting_test.go
@@ -534,10 +534,9 @@ func (as *ActionSuite) Test_CreateMeetingParticipant() {
 
 	testCases := []testCase{
 		{
-			name:      "no code",
+			name:      "already a participant",
 			meetingID: f.Meetings[2].UUID.String(),
 			testUser:  f.Users[2],
-			wantErr:   "not allowed",
 		},
 		{
 			name:      "meeting creator",

--- a/application/actions/meeting_test.go
+++ b/application/actions/meeting_test.go
@@ -547,11 +547,23 @@ func (as *ActionSuite) Test_CreateMeetingParticipant() {
 			meetingID: f.Meetings[0].UUID.String(),
 			testUser:  f.Users[0],
 		},
+		{
+			name:       "regular user",
+			code:       f.MeetingInvites[3].Secret.String(),
+			meetingID:  f.Meetings[3].UUID.String(),
+			testUser:   f.Users[1],
+			wantInvite: f.MeetingInvites[3],
+		},
 	}
 
 	for _, tc := range testCases {
 		as.T().Run(tc.name, func(t *testing.T) {
-			input := fmt.Sprintf(`{ meetingID: "%s" code: "%s" }`, tc.meetingID, tc.code)
+			input := ""
+			if tc.code == "" {
+				input = fmt.Sprintf(`{ meetingID: "%s" }`, tc.meetingID)
+			} else {
+				input = fmt.Sprintf(`{ meetingID: "%s" code: "%s" }`, tc.meetingID, tc.code)
+			}
 
 			query := fmt.Sprintf(queryTemplate, input, allMeetingParticipantFields)
 			err := as.testGqlQuery(query, tc.testUser.Nickname, &resp)

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -420,7 +420,7 @@ func mergeExtras(extras []map[string]interface{}) map[string]interface{} {
 func Error(c buffalo.Context, msg string, extras ...map[string]interface{}) {
 	// Avoid panics running tests when c doesn't have the necessary nested methods
 	cType := fmt.Sprintf("%T", c)
-	if cType == "models.EmptyContext" {
+	if cType == "models.emptyContext" {
 		return
 	}
 
@@ -644,12 +644,14 @@ func (v *StringIsVisible) IsValid(errors *validate.Errors) {
 }
 
 // ReportError logs an error with details, and returns a user-friendly, translated error identified by translation key
-// string `errID`.
+// string `errID`. If called with a full GraphQL context, the query text will be logged in the extras.
 func ReportError(ctx context.Context, err error, errID string, extras ...map[string]interface{}) error {
-	c := GetBuffaloContextFromGqlContext(ctx)
+	c := GetBuffaloContext(ctx)
 	allExtras := map[string]interface{}{
-		"query":    graphql.GetRequestContext(ctx).RawQuery,
 		"function": GetFunctionName(2),
+	}
+	if r := graphql.GetRequestContext(ctx); r != nil {
+		allExtras["query"] = r.RawQuery
 	}
 	for _, e := range extras {
 		for key, val := range e {
@@ -669,15 +671,21 @@ func ReportError(ctx context.Context, err error, errID string, extras ...map[str
 	return errors.New(T.Translate(c, errID))
 }
 
-func GetBuffaloContextFromGqlContext(c context.Context) buffalo.Context {
+// GetBuffaloContext retrieves a "BuffaloContext" from a wrapped context as constructed by
+// actions.gqlHandler. If it's already a buffalo.Context, it is returned as is, type casted to buffalo.Context.
+func GetBuffaloContext(c context.Context) buffalo.Context {
 	bc, ok := c.Value(BuffaloContext).(buffalo.Context)
 	if ok {
 		return bc
 	}
-	return EmptyContext{}
+	bc, ok = c.(buffalo.Context)
+	if ok {
+		return bc
+	}
+	return emptyContext{}
 }
 
-type EmptyContext struct {
+type emptyContext struct {
 	buffalo.Context
 }
 

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -419,13 +419,13 @@ func mergeExtras(extras []map[string]interface{}) map[string]interface{} {
 // Error log error and send to Rollbar
 func Error(c buffalo.Context, msg string, extras ...map[string]interface{}) {
 	// Avoid panics running tests when c doesn't have the necessary nested methods
-	cType := fmt.Sprintf("%T", c)
-	if cType == "models.emptyContext" {
+	logger := c.Logger()
+	if logger == nil {
 		return
 	}
 
 	es := mergeExtras(extras)
-	c.Logger().Error(msg, es)
+	logger.Error(msg, es)
 	rollbarMessage(c, rollbar.ERR, msg, es)
 }
 

--- a/application/gqlgen/meeting.go
+++ b/application/gqlgen/meeting.go
@@ -118,7 +118,7 @@ func (r *meetingResolver) Invites(ctx context.Context, obj *models.Meeting) ([]m
 	if obj == nil {
 		return nil, nil
 	}
-	invites, err := obj.Invites(domain.GetBuffaloContextFromGqlContext(ctx))
+	invites, err := obj.Invites(domain.GetBuffaloContext(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "Meeting.Invites")
 	}
@@ -129,7 +129,7 @@ func (r *meetingResolver) Participants(ctx context.Context, obj *models.Meeting)
 	if obj == nil {
 		return nil, nil
 	}
-	participants, err := obj.Participants(domain.GetBuffaloContextFromGqlContext(ctx))
+	participants, err := obj.Participants(domain.GetBuffaloContext(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "Meeting.Participants")
 	}
@@ -144,7 +144,7 @@ func (r *meetingResolver) Organizers(ctx context.Context, obj *models.Meeting) (
 	if obj == nil {
 		return nil, nil
 	}
-	users, err := obj.Organizers(domain.GetBuffaloContextFromGqlContext(ctx))
+	users, err := obj.Organizers(domain.GetBuffaloContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/application/gqlgen/models_gen.go
+++ b/application/gqlgen/models_gen.go
@@ -25,9 +25,10 @@ type CreateMeetingInvitesInput struct {
 type CreateMeetingParticipantInput struct {
 	// ID of the `Meeting`
 	MeetingID string `json:"meetingID"`
-	// Confirmation code from the `MeetingInvite`. If not provided, the `Meeting` must not be `INVITE_ONLY`.
-	ConfirmationCode *string `json:"confirmationCode"`
-	// Add as a `Meeting` Organizer. Authenticated `User` must be authorized [definition TBD] to do this.
+	// Secret code from the `MeetingInvite` or invite code from the `Meeting`. If the `Meeting` is not `INVITE_ONLY`,
+	// the code may be omitted.
+	Code *string `json:"code"`
+	// NOT YET IMPLEMENTED -- Add as a `Meeting` Organizer. Authenticated `User` must be authorized [definition TBD] to do this.
 	IsOrganizer *bool `json:"isOrganizer"`
 }
 

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -324,7 +324,7 @@ func (r *mutationResolver) CreateMeetingParticipant(ctx context.Context, input C
 	}
 
 	var participant models.MeetingParticipant
-	if err := participant.Create(ctx, meeting, input.Code); err != nil {
+	if err := participant.FindOrCreate(ctx, meeting, input.Code); err != nil {
 		// MeetingParticipant.Create returns localized error messages
 		return nil, err
 	}

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -314,6 +314,23 @@ func (r *mutationResolver) RemoveMeetingInvite(ctx context.Context, input Remove
 	return invites, nil
 }
 
+// CreateMeetingParticipant implements the `createMeetingParticipant` mutation
+func (r *mutationResolver) CreateMeetingParticipant(ctx context.Context, input CreateMeetingParticipantInput) (
+	*models.MeetingParticipant, error) {
+
+	var meeting models.Meeting
+	if err := meeting.FindByUUID(input.MeetingID); err != nil {
+		return nil, domain.ReportError(ctx, err, "CreateMeetingParticipant.FindMeeting")
+	}
+
+	bc := domain.GetBuffaloContextFromGqlContext(ctx)
+	var participant models.MeetingParticipant
+	if err := participant.Create(bc, meeting, input.Code); err != nil {
+		return nil, domain.ReportError(ctx, err, "CreateMeetingParticipant")
+	}
+	return &participant, nil
+}
+
 func (r *mutationResolver) RemoveMeetingParticipant(ctx context.Context, input RemoveMeetingParticipantInput) ([]models.MeetingParticipant, error) {
 	var meeting models.Meeting
 	if err := meeting.FindByUUID(input.MeetingID); err != nil {

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -323,10 +323,10 @@ func (r *mutationResolver) CreateMeetingParticipant(ctx context.Context, input C
 		return nil, domain.ReportError(ctx, err, "CreateMeetingParticipant.FindMeeting")
 	}
 
-	bc := domain.GetBuffaloContextFromGqlContext(ctx)
 	var participant models.MeetingParticipant
-	if err := participant.Create(bc, meeting, input.Code); err != nil {
-		return nil, domain.ReportError(ctx, err, "CreateMeetingParticipant")
+	if err := participant.Create(ctx, meeting, input.Code); err != nil {
+		// MeetingParticipant.Create returns localized error messages
+		return nil, err
 	}
 	return &participant, nil
 }

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -259,7 +259,7 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.FindMeeting")
 	}
 
-	c := domain.GetBuffaloContextFromGqlContext(ctx)
+	c := domain.GetBuffaloContext(ctx)
 	if !cUser.CanCreateMeetingInvite(c, m) {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.Unauthorized")
@@ -283,7 +283,7 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 		graphql.AddError(ctx, gqlerror.Errorf("problem creating invite for %v", emailList))
 	}
 
-	invites, err := m.Invites(domain.GetBuffaloContextFromGqlContext(ctx))
+	invites, err := m.Invites(domain.GetBuffaloContext(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.ListInvites")
 	}
@@ -296,7 +296,7 @@ func (r *mutationResolver) RemoveMeetingInvite(ctx context.Context, input Remove
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingInvite.FindMeeting")
 	}
 
-	c := domain.GetBuffaloContextFromGqlContext(ctx)
+	c := domain.GetBuffaloContext(ctx)
 	cUser := models.CurrentUser(ctx)
 	if !cUser.CanRemoveMeetingInvite(c, meeting) {
 		err := errors.New("insufficient permissions")
@@ -337,7 +337,7 @@ func (r *mutationResolver) RemoveMeetingParticipant(ctx context.Context, input R
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingParticipant.FindMeeting")
 	}
 
-	c := domain.GetBuffaloContextFromGqlContext(ctx)
+	c := domain.GetBuffaloContext(ctx)
 	cUser := models.CurrentUser(ctx)
 	if !cUser.CanRemoveMeetingParticipant(c, meeting) {
 		err := errors.New("insufficient permissions")

--- a/application/gqlgen/resolver.go
+++ b/application/gqlgen/resolver.go
@@ -78,7 +78,8 @@ func (m *meetingParticipantResolver) Meeting(ctx context.Context, obj *models.Me
 
 	mtg, err := obj.Meeting()
 	if err != nil {
-		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Meeting")
+		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Meeting",
+			map[string]interface{}{"meetingParticipant": *obj})
 	}
 	return &mtg, err
 }
@@ -90,7 +91,8 @@ func (m *meetingParticipantResolver) User(ctx context.Context, obj *models.Meeti
 
 	user, err := obj.User()
 	if err != nil {
-		return nil, domain.ReportError(ctx, err, "MeetingParticipant.User")
+		return nil, domain.ReportError(ctx, err, "MeetingParticipant.User",
+			map[string]interface{}{"meetingParticipant": *obj})
 	}
 
 	return &user, nil
@@ -105,7 +107,8 @@ func (m *meetingParticipantResolver) Invite(ctx context.Context, obj *models.Mee
 
 	inv, err := obj.Invite()
 	if err != nil {
-		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Invite")
+		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Invite",
+			map[string]interface{}{"meetingParticipant": *obj})
 	}
 
 	return inv, nil

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -100,6 +100,13 @@ type Mutation {
     "Remove a `MeetingInvite` and return the remaining invites for the `Meeting`"
     removeMeetingInvite(input: RemoveMeetingInviteInput!): [MeetingInvite!]!
 
+    """
+    Create a new `MeetingParticipant` either from a `MeetingInvite`, or by self-joining a meeting. Note that this
+    mutation can only be used by a pre-existing user; new users must go through the REST API login process. If the
+    `Meeting` is not `INVITE_ONLY`, no `MeetingInvitation` is needed and the `confirmationCode` may be omitted.
+    """
+    createMeetingParticipant(input: CreateMeetingParticipantInput!): MeetingParticipant!
+
     "Remove a `MeetingParticipant` and return the remaining participants for the `Meeting`"
     removeMeetingParticipant(input: RemoveMeetingParticipantInput!): [MeetingParticipant!]!
 }
@@ -596,9 +603,12 @@ type MeetingParticipant {
 input CreateMeetingParticipantInput {
     "ID of the `Meeting`"
     meetingID: ID!
-    "Confirmation code from the `MeetingInvite`. If not provided, the `Meeting` must not be `INVITE_ONLY`."
-    confirmationCode: String
-    "Add as a `Meeting` Organizer. Authenticated `User` must be authorized [definition TBD] to do this. "
+    """
+    Secret code from the `MeetingInvite` or invite code from the `Meeting`. If the `Meeting` is not `INVITE_ONLY`,
+    the code may be omitted.
+    """
+    code: String
+    "NOT YET IMPLEMENTED -- Add as a `Meeting` Organizer. Authenticated `User` must be authorized [definition TBD] to do this. "
     isOrganizer: Boolean
 }
 

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -109,19 +109,19 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 
 	lastViewedAt, err := obj.GetLastViewedAt(user)
 	if err != nil {
-		domain.Warn(domain.GetBuffaloContextFromGqlContext(ctx), err.Error())
+		domain.Warn(domain.GetBuffaloContext(ctx), err.Error())
 		return 0, nil
 	}
 
 	if lastViewedAt == nil {
-		domain.Warn(domain.GetBuffaloContextFromGqlContext(ctx),
+		domain.Warn(domain.GetBuffaloContext(ctx),
 			fmt.Sprintf("lastViewedAt nil for user %v on thread %v", user.ID, obj.ID))
 		return 0, nil
 	}
 
 	count, err2 := obj.UnreadMessageCount(user.ID, *lastViewedAt)
 	if err2 != nil {
-		domain.Warn(domain.GetBuffaloContextFromGqlContext(ctx), err2.Error())
+		domain.Warn(domain.GetBuffaloContext(ctx), err2.Error())
 		return 0, nil
 	}
 	return count, nil

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -1,64 +1,70 @@
 # Meeting
 - id: CreateMeeting
-  translation: We had a problem creating the new meeting.
+  translation: We had a problem creating the new event.
 - id: CreateMeeting.ProcessInput
-  translation: We had a problem processing the information to create that meeting.
+  translation: We had a problem processing the information to create that event.
 - id: CreateMeeting.SetLocation
-  translation: We had a problem setting the location for that new meeting.
+  translation: We had a problem setting the location for that new event.
 - id: CreateMeeting.Unauthorized
-  translation: You are not allowed to create meetings.
+  translation: You are not allowed to create events.
 - id: GetMeeting
-  translation: We had a problem finding that meeting.
+  translation: We had a problem finding that event.
 - id: GetMeetingCreator
-  translation: We had a problem finding the creator of that meeting.
+  translation: We had a problem finding the creator of that event.
 - id: GetMeetingImage
-  translation: We had a problem finding the image for that meeting.
+  translation: We had a problem finding the image for that event.
 - id: GetMeetingLocation
-  translation: We had a problem finding the location of that meeting.
+  translation: We had a problem finding the location of that event.
 - id: GetMeetings
-  translation: We had a problem finding a list of meetings.
+  translation: We had a problem finding a list of events.
 - id: GetRecentMeetings
-  translation: We had a problem finding a list of recent meetings.
+  translation: We had a problem finding a list of recent events.
 - id: UpdateMeeting
-  translation: We had a problem updating the meeting.
+  translation: We had a problem updating the event.
 - id: UpdateMeeting.ProcessInput
-  translation: We had a problem processing the information to update that meeting.
+  translation: We had a problem processing the information to update that event.
 - id: UpdateMeeting.Unauthorized
-  translation: You are not allowed to edit the information for that meeting.
+  translation: You are not allowed to edit the information for that event.
 - id: Meeting.Posts
-  translation: We had a problem finding the posts for the meeting
+  translation: We had a problem finding the posts for the event
 - id: Meeting.Invites
-  translation: We had a problem finding the invites for the meeting
+  translation: We had a problem finding the invites for the event
 - id: Meeting.Participants
-  translation: We had a problem finding the participants for the meeting
+  translation: We had a problem finding the participants for the event
 
 # MeetingInvite
 - id: CreateMeetingInvite.FindMeeting
-  translation: We had a problem finding the meeting for the new invites
+  translation: We had a problem finding the event for the new invites
 - id: CreateMeetingInvite.Unauthorized
-  translation: You are not allowed to create invitations for that meeting
+  translation: You are not allowed to create invitations for that event
 - id: CreateMeetingInvite.ListInvites
   translation: We had a problem getting the list of invites after adding the new invites
 - id: RemoveMeetingInvite.FindMeeting
-  translation: We had a problem finding the meeting for the invite to be removed
+  translation: We had a problem finding the event for the invite to be removed
 - id: RemoveMeetingInvite.Unauthorized
-  translation: You are not allowed to remove invitations for that meeting
+  translation: You are not allowed to remove invitations for that event
 - id: RemoveMeetingInvite.ListInvites
   translation: We had a problem getting the list of invites after removing the invite
 - id: RemoveMeetingInvite
-  translation: We had a problem removing the meeting invite
+  translation: We had a problem removing the event invite
 - id: MeetingInvite.Inviter
   translation: We had a problem getting the user profile of the inviter
 - id: MeetingInvite.Meeting
-  translation: We had a problem getting the meeting data for the invite
+  translation: We had a problem getting the event data for the invite
 
 # MeetingParticipant
 - id: MeetingParticipant.Meeting
-  translation: We had a problem finding the meeting for the participant
+  translation: We had a problem finding the event for the participant
 - id: MeetingParticipant.User
   translation: We had a problem finding the user data for the participant
 - id: MeetingParticipant.Invite
   translation: We had a problem finding the invite data for the participant
+- id: CreateMeetingParticipant.FindMeeting
+  translation: We had a problem finding the event to add you as a participant
+- id: CreateMeetingParticipant.Unauthorized
+  translation: You are not allowed to add yourself as a participant in that event
+- id: CreateMeetingParticipant
+  translation: We had a problem adding you as a participant in that event
 - id: RemoveMeetingParticipant.FindMeeting
   translation: We had a problem finding the meeting for the participant to be removed
 - id: RemoveMeetingParticipant.Unauthorized
@@ -146,7 +152,7 @@
 - id: GetPostFiles
   translation: We had a problem finding the list of attachments for that request or offer.
 - id: GetPostMeeting
-  translation: We had a problem finding the meeting associated with that request or offer.
+  translation: We had a problem finding the event associated with that request or offer.
 - id: GetPosts
   translation: We had a problem finding a list of requests and offers.
 - id: GetPost
@@ -216,7 +222,7 @@
 
 # User
 - id: User.MeetingsAsParticipant
-  translation: We had a problem getting a list of meetings for you.
+  translation: We had a problem getting a list of events for you.
 - id: GetUserOrganizations
   translation: We had a problem finding the list of organizations for the user profile.
 - id: GetUserPosts

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -59,10 +59,16 @@
   translation: We had a problem finding the user data for the participant
 - id: MeetingParticipant.Invite
   translation: We had a problem finding the invite data for the participant
+- id: CreateMeetingParticipant.FindExisting
+  translation: We had an unexpected problem adding you as an event participant
 - id: CreateMeetingParticipant.FindMeeting
   translation: We had a problem finding the event to add you as a participant
 - id: CreateMeetingParticipant.Unauthorized
   translation: You are not allowed to add yourself as a participant in that event
+- id: CreateMeetingParticipant.InvalidSecret
+  translation: That event invite code is not valid for the specified event
+- id: CreateMeetingParticipant.FindBySecret
+  translation: We had a problem validating your invite code for that event
 - id: CreateMeetingParticipant
   translation: We had a problem adding you as a participant in that event
 - id: RemoveMeetingParticipant.FindMeeting

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -559,13 +559,13 @@ func (ms *ModelSuite) TestMeeting_Invites() {
 			name:       "creator",
 			user:       f.Users[0],
 			meeting:    f.Meetings[0],
-			wantEmails: []string{"invitee0@example.com", "invitee1@example.com"},
+			wantEmails: []string{f.MeetingInvites[0].Email, f.MeetingInvites[1].Email},
 		},
 		{
 			name:       "organizer",
 			user:       f.Users[1],
 			meeting:    f.Meetings[0],
-			wantEmails: []string{"invitee0@example.com", "invitee1@example.com"},
+			wantEmails: []string{f.MeetingInvites[0].Email, f.MeetingInvites[1].Email},
 		},
 		{
 			name:       "invitee",

--- a/application/models/meetinginvite.go
+++ b/application/models/meetinginvite.go
@@ -77,26 +77,6 @@ func (m *MeetingInvite) Destroy() error {
 	return DB.Destroy(m)
 }
 
-// IsSecretValid returns true if and only if a MeetingInvite exists that exactly matches all three parameters
-func (m *MeetingInvite) IsSecretValid(meetingID int, email, secret string) (bool, error) {
-	if meetingID < 1 {
-		return false, errors.New("invalid meeting ID in IsSecretValid")
-	}
-	if email == "" {
-		return false, errors.New("empty email in IsSecretValid")
-	}
-	if secret == "" {
-		return false, errors.New("empty secret in IsSecretValid")
-	}
-	var count Count
-	err := DB.RawQuery("SELECT COUNT(*) FROM meeting_invites WHERE meeting_id=? AND email=? AND secret=?",
-		meetingID, email, secret).First(&count)
-	if domain.IsOtherThanNoRows(err) {
-		return false, err
-	}
-	return count.N > 0, nil
-}
-
 // FindBySecret attempts to find a MeetingInvite that exactly matches a given secret, email, and meetingID
 func (m *MeetingInvite) FindBySecret(meetingID int, email, secret string) error {
 	if meetingID < 1 {
@@ -108,9 +88,5 @@ func (m *MeetingInvite) FindBySecret(meetingID int, email, secret string) error 
 	if secret == "" {
 		return errors.New("empty secret in FindBySecret")
 	}
-	err := DB.Where("meeting_id=? AND email=? AND secret=?", meetingID, email, secret).First(m)
-	if domain.IsOtherThanNoRows(err) {
-		return err
-	}
-	return nil
+	return DB.Where("meeting_id=? AND email=? AND secret=?", meetingID, email, secret).First(m)
 }

--- a/application/models/meetinginvite.go
+++ b/application/models/meetinginvite.go
@@ -96,3 +96,21 @@ func (m *MeetingInvite) IsSecretValid(meetingID int, email, secret string) (bool
 	}
 	return count.N > 0, nil
 }
+
+// FindBySecret attempts to find a MeetingInvite that exactly matches a given secret, email, and meetingID
+func (m *MeetingInvite) FindBySecret(meetingID int, email, secret string) error {
+	if meetingID < 1 {
+		return errors.New("invalid meeting ID in FindBySecret")
+	}
+	if email == "" {
+		return errors.New("empty email in FindBySecret")
+	}
+	if secret == "" {
+		return errors.New("empty secret in FindBySecret")
+	}
+	err := DB.Where("meeting_id=? AND email=? AND secret=?", meetingID, email, secret).First(m)
+	if domain.IsOtherThanNoRows(err) {
+		return err
+	}
+	return nil
+}

--- a/application/models/meetinginvite.go
+++ b/application/models/meetinginvite.go
@@ -75,3 +75,12 @@ func (m *MeetingInvite) FindByMeetingIDAndEmail(meetingID int, email string) err
 func (m *MeetingInvite) Destroy() error {
 	return DB.Destroy(m)
 }
+
+// IsSecretValid returns true if and only if a MeetingInvite exists that exactly matches all three parameters
+func (m *MeetingInvite) IsSecretValid(meetingID int, userID int, secret string) (bool, error) {
+	err := DB.Where("meeting_id=? AND user_id=? AND secret=?", meetingID, userID, secret).First(m)
+	if domain.IsOtherThanNoRows(err) {
+		return false, err
+	}
+	return err == nil, nil
+}

--- a/application/models/meetingparticipant.go
+++ b/application/models/meetingparticipant.go
@@ -77,7 +77,7 @@ func (m *MeetingParticipant) CreateFromInvite(invite MeetingInvite, userID int) 
 // Otherwise, `code` must match either a MeetingInvite secret code or a Meeting invite code.
 func (m *MeetingParticipant) Create(ctx context.Context, meeting Meeting, code *string) error {
 	cUser := CurrentUser(ctx)
-	if !cUser.CanCreateMeetingParticipant(domain.GetBuffaloContextFromGqlContext(ctx), meeting, code) {
+	if !cUser.CanCreateMeetingParticipant(domain.GetBuffaloContext(ctx), meeting, code) {
 		return domain.ReportError(ctx, errors.New("authorization failure adding a MeetingParticipant"),
 			"CreateMeetingParticipant.Unauthorized")
 	}

--- a/application/models/meetingparticipant.go
+++ b/application/models/meetingparticipant.go
@@ -89,12 +89,11 @@ func (m *MeetingParticipant) Destroy() error {
 func (m *MeetingParticipant) Create(ctx context.Context, meeting Meeting, code *string) error {
 	cUser := CurrentUser(ctx)
 
-	var p MeetingParticipant
-	if err := p.FindByMeetingIDAndUserID(meeting.ID, cUser.ID); domain.IsOtherThanNoRows(err) {
+	if err := m.FindByMeetingIDAndUserID(meeting.ID, cUser.ID); domain.IsOtherThanNoRows(err) {
 		return domain.ReportError(ctx, err,
 			"CreateMeetingParticipant.FindExisting")
 	}
-	if p.ID > 0 {
+	if m.ID > 0 {
 		return nil
 	}
 

--- a/application/models/meetingparticipant.go
+++ b/application/models/meetingparticipant.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -26,6 +27,12 @@ type MeetingParticipant struct {
 
 // MeetingParticipants is used for methods that operate on lists of objects
 type MeetingParticipants []MeetingParticipant
+
+// String is used to serialize the object for error logging
+func (m MeetingParticipant) String() string {
+	jm, _ := json.Marshal(m)
+	return string(jm)
+}
 
 // Validate gets run every time you call one of: pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate
 func (m *MeetingParticipant) Validate(tx *pop.Connection) (*validate.Errors, error) {

--- a/application/models/meetingparticipant.go
+++ b/application/models/meetingparticipant.go
@@ -84,9 +84,9 @@ func (m *MeetingParticipant) Destroy() error {
 	return DB.Destroy(m)
 }
 
-// Create a new MeetingParticipant from a meeting ID and code. If `code` is nil, the meeting must be non-INVITE_ONLY.
+// FindOrCreate a new MeetingParticipant from a meeting ID and code. If `code` is nil, the meeting must be non-INVITE_ONLY.
 // Otherwise, `code` must match either a MeetingInvite secret code or a Meeting invite code.
-func (m *MeetingParticipant) Create(ctx context.Context, meeting Meeting, code *string) error {
+func (m *MeetingParticipant) FindOrCreate(ctx context.Context, meeting Meeting, code *string) error {
 	cUser := CurrentUser(ctx)
 
 	if err := m.FindByMeetingIDAndUserID(meeting.ID, cUser.ID); domain.IsOtherThanNoRows(err) {

--- a/application/models/meetingparticipant_test.go
+++ b/application/models/meetingparticipant_test.go
@@ -129,7 +129,7 @@ func (ms *ModelSuite) TestMeetingParticipant_User() {
 	}
 }
 
-func (ms *ModelSuite) TestMeetingParticipant_Create() {
+func (ms *ModelSuite) TestMeetingParticipant_FindOrCreate() {
 	f := createMeetingFixtures(ms.DB, 2)
 
 	tests := []struct {
@@ -201,7 +201,7 @@ func (ms *ModelSuite) TestMeetingParticipant_Create() {
 
 			// execute
 			var p MeetingParticipant
-			err := p.Create(ctx, tt.meeting, code)
+			err := p.FindOrCreate(ctx, tt.meeting, code)
 
 			// verify
 			if tt.wantErr != "" {

--- a/application/models/meetingparticipant_test.go
+++ b/application/models/meetingparticipant_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/gobuffalo/nulls"
@@ -218,6 +219,7 @@ func (ms *ModelSuite) TestMeetingParticipant_Create() {
 			for i := range participants {
 				ids[i] = participants[i].UserID
 			}
+			sort.Ints(ids)
 
 			ms.Equal(tt.userIDs, ids)
 

--- a/application/models/meetingparticipant_test.go
+++ b/application/models/meetingparticipant_test.go
@@ -2,6 +2,10 @@ package models
 
 import (
 	"testing"
+
+	"github.com/gobuffalo/nulls"
+
+	"github.com/silinternational/wecarry-api/domain"
 )
 
 func (ms *ModelSuite) TestMeetingParticipant_Validate() {
@@ -120,6 +124,104 @@ func (ms *ModelSuite) TestMeetingParticipant_User() {
 				return
 			}
 			ms.Equal(tt.want.UUID, got.UUID, "wrong user returned")
+		})
+	}
+}
+
+func (ms *ModelSuite) TestMeetingParticipant_Create() {
+	f := createMeetingFixtures(ms.DB, 2)
+
+	tests := []struct {
+		name    string
+		user    User
+		meeting Meeting
+		code    nulls.UUID
+		userIDs []int
+		wantErr string
+	}{
+		{
+			name:    "invalid invite code",
+			user:    f.Users[4],
+			meeting: f.Meetings[0],
+			code:    nulls.NewUUID(domain.GetUUID()),
+			wantErr: "CreateMeetingParticipant.InvalidSecret",
+		},
+		{
+			name:    "creator self-join",
+			user:    f.Users[0],
+			meeting: f.Meetings[0],
+			code:    nulls.UUID{},
+			userIDs: []int{f.Users[0].ID, f.Users[1].ID, f.Users[2].ID, f.Users[3].ID},
+		},
+		{
+			name:    "organizer re-join",
+			user:    f.Users[1],
+			meeting: f.Meetings[0],
+			code:    nulls.UUID{},
+			userIDs: []int{f.Users[0].ID, f.Users[1].ID, f.Users[2].ID, f.Users[3].ID},
+		},
+		{
+			name:    "participant re-join",
+			user:    f.Users[2],
+			meeting: f.Meetings[0],
+			code:    nulls.UUID{},
+			userIDs: []int{f.Users[0].ID, f.Users[1].ID, f.Users[2].ID, f.Users[3].ID},
+		},
+		{
+			name:    "new participant - invite code",
+			user:    f.Users[4],
+			meeting: f.Meetings[0],
+			code:    nulls.NewUUID(f.MeetingInvites[1].Secret),
+			userIDs: []int{f.Users[0].ID, f.Users[1].ID, f.Users[2].ID, f.Users[3].ID, f.Users[4].ID},
+		},
+		{
+			name:    "new participant - meeting code",
+			user:    f.Users[5],
+			meeting: f.Meetings[0],
+			code:    nulls.NewUUID(f.Meetings[0].InviteCode.UUID),
+			userIDs: []int{f.Users[0].ID, f.Users[1].ID, f.Users[2].ID, f.Users[3].ID, f.Users[4].ID, f.Users[5].ID},
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			// setup
+			ctx := &testBuffaloContext{
+				params: map[interface{}]interface{}{},
+			}
+			ctx.Set("current_user", tt.user)
+
+			var code *string
+			if tt.code.Valid {
+				c := tt.code.UUID.String()
+				code = &c
+			} else {
+				code = nil
+			}
+
+			// execute
+			var p MeetingParticipant
+			err := p.Create(ctx, tt.meeting, code)
+
+			// verify
+			if tt.wantErr != "" {
+				ms.Error(err, "did not get expected error")
+				ms.Contains(err.Error(), tt.wantErr)
+				return
+			}
+			ms.NoError(err, "unexpected error")
+
+			ctx.Set("current_user", f.Users[0])
+			participants, err := tt.meeting.Participants(ctx)
+			ms.NoError(err)
+
+			ids := make([]int, len(participants))
+			for i := range participants {
+				ids[i] = participants[i].UserID
+			}
+
+			ms.Equal(tt.userIDs, ids)
+
+			// teardown
 		})
 	}
 }

--- a/application/models/testutils_test.go
+++ b/application/models/testutils_test.go
@@ -277,6 +277,22 @@ func createPotentialProvidersFixtures(ms *ModelSuite) potentialProvidersFixtures
 // createMeetingFixtures generates any number of meeting records for testing. Related records are also
 // created. All meeting fixtures will be assigned to the first Organization in the DB. If no Organization exists,
 // one will be created. All meetings are created by the first User in the DB. If no User exists, one will be created.
+//
+//  Slice index numbers for each object are shown in the following table:
+//
+//  meeting   invites      participants        organizer user  invited user  self-joined user
+//  0         0, 1         0, 1, 2             1               2             3
+//  n         n*2, n*2+1   n*3, n*3+1, n*3+2   n*4+1           n*4+2         n*4+3
+//
+//  Creator for all meetings is user 0
+//  Inviter for all invites is user 0
+//
+//  The first invite is to an existing user
+//  The second invite is to a non-user
+//
+//  The first participant is the meeting organizer
+//  The second participant is an invited user
+//  The third participant is a self-joined user
 func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 	var org Organization
 	if err := tx.First(&org); err != nil {
@@ -309,9 +325,17 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 	}
 
 	const invitesPerMeeting = 2 // one pending and one participating
+	const usersPerMeeting = 4   // one organizer + one invited + one invited but not participating + one self-added
+	const participantsPerMeeting = usersPerMeeting - 1
 	invites := make(MeetingInvites, nMeetings*invitesPerMeeting)
+	users := createUserFixtures(tx, nMeetings*usersPerMeeting).Users
 	for i := range invites {
-		invites[i].Email = "invitee" + strconv.Itoa(i) + "@example.com"
+		if i%invitesPerMeeting == 0 {
+			invites[i].Email = users[i*usersPerMeeting/invitesPerMeeting+1].Email
+		}
+		if i%invitesPerMeeting == 1 {
+			invites[i].Email = "invitee" + strconv.Itoa(i) + "@example.com"
+		}
 		invites[i].MeetingID = meetings[i/invitesPerMeeting].ID
 		invites[i].InviterID = user.ID
 		if err := invites[i].Create(); err != nil {
@@ -319,17 +343,15 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 		}
 	}
 
-	const participantsPerMeeting = 3 // one organizer + one invited + one self-added
-	participatingUsers := createUserFixtures(tx, nMeetings*participantsPerMeeting).Users
-	participants := make(MeetingParticipants, nMeetings*participantsPerMeeting)
+	participants := make(MeetingParticipants, nMeetings*(participantsPerMeeting))
 	for i := range participants {
 		participants[i].MeetingID = meetings[i/participantsPerMeeting].ID
-		participants[i].UserID = participatingUsers[i].ID
+		participants[i].UserID = users[i*usersPerMeeting/participantsPerMeeting].ID
 		if i%participantsPerMeeting == 0 {
 			participants[i].IsOrganizer = true
 		}
 		if i%participantsPerMeeting == 1 {
-			participants[i].InviteID = nulls.NewInt(invites[i/participantsPerMeeting*invitesPerMeeting].ID)
+			participants[i].InviteID = nulls.NewInt(invites[i*invitesPerMeeting/participantsPerMeeting].ID)
 		}
 		mustCreate(tx, &participants[i])
 	}
@@ -338,6 +360,6 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 		Meetings:            meetings,
 		MeetingInvites:      invites,
 		MeetingParticipants: participants,
-		Users:               append(Users{user}, participatingUsers...),
+		Users:               append(Users{user}, users...),
 	}
 }

--- a/application/models/testutils_test.go
+++ b/application/models/testutils_test.go
@@ -334,7 +334,7 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 			invites[i].Email = users[i*usersPerMeeting/invitesPerMeeting+1].Email
 		}
 		if i%invitesPerMeeting == 1 {
-			invites[i].Email = "invitee" + strconv.Itoa(i) + "@example.com"
+			invites[i].Email = users[i*usersPerMeeting/invitesPerMeeting+1].Email
 		}
 		invites[i].MeetingID = meetings[i/invitesPerMeeting].ID
 		invites[i].InviterID = user.ID

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -762,19 +762,6 @@ func (u *User) HasOrganization() bool {
 	return true
 }
 
-func (u *User) isMeetingOrganizer(ctx buffalo.Context, meeting Meeting) bool {
-	organizers, err := meeting.Organizers(ctx)
-	if err != nil {
-		domain.Error(ctx, "isMeetingOrganizer() error reading list of meeting organizers, "+err.Error())
-	}
-	for _, o := range organizers {
-		if o.ID == u.ID {
-			return true
-		}
-	}
-	return false
-}
-
 func (u *User) isSuperAdmin() bool {
 	return u.AdminRole == UserAdminRoleSuperAdmin
 }
@@ -793,35 +780,17 @@ func (u *User) MeetingsAsParticipant(ctx context.Context) ([]Meeting, error) {
 }
 
 func (u *User) CanCreateMeetingInvite(ctx buffalo.Context, meeting Meeting) bool {
-	return u.ID == meeting.CreatedByID || u.isMeetingOrganizer(ctx, meeting) || u.isSuperAdmin()
+	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }
 
 func (u *User) CanRemoveMeetingInvite(ctx buffalo.Context, meeting Meeting) bool {
-	return u.ID == meeting.CreatedByID || u.isMeetingOrganizer(ctx, meeting) || u.isSuperAdmin()
+	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }
 
-// CanCreateMeetingParticipant allows the meeting creator, the meeting organizer(s), and super admins to create
-// a MeetingParticipant for any user. In addition, any user can create a MeetingParticipant if the given code
-// matches the meeting invite code OR is a valid secret code for a MeetingInvite on that meeting
-func (u *User) CanCreateMeetingParticipant(ctx buffalo.Context, meeting Meeting, code *string) bool {
-	if u.ID == meeting.CreatedByID || u.isMeetingOrganizer(ctx, meeting) || u.isSuperAdmin() {
-		return true
-	}
-	if code == nil {
-		return false
-	}
-	if meeting.InviteCode.Valid && meeting.InviteCode.UUID.String() == *code {
-		return true
-	}
-	var invite MeetingInvite
-	isCodeGood, err := invite.IsSecretValid(meeting.ID, u.Email, *code)
-	if err != nil {
-		domain.Error(ctx, "error finding MeetingInvite by meeting ID and secret",
-			map[string]interface{}{"meeting": meeting.UUID, "secret": *code})
-	}
-	return isCodeGood
+func (u *User) CanCreateMeetingParticipant(ctx buffalo.Context, meeting Meeting) bool {
+	return u.ID == meeting.CreatedByID || meeting.isVisible(ctx, u.ID) || u.isSuperAdmin()
 }
 
 func (u *User) CanRemoveMeetingParticipant(ctx buffalo.Context, meeting Meeting) bool {
-	return u.ID == meeting.CreatedByID || u.isMeetingOrganizer(ctx, meeting) || u.isSuperAdmin()
+	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -825,7 +825,7 @@ func (u *User) CanCreateMeetingParticipant(ctx buffalo.Context, meeting Meeting,
 		return true
 	}
 	var invite MeetingInvite
-	isCodeGood, err := invite.IsSecretValid(meeting.ID, u.ID, *code)
+	isCodeGood, err := invite.IsSecretValid(meeting.ID, u.Email, *code)
 	if err != nil {
 		domain.Error(ctx, "error finding MeetingInvite by meeting ID and secret",
 			map[string]interface{}{"meeting": meeting.UUID, "secret": *code})

--- a/application/models/user_test.go
+++ b/application/models/user_test.go
@@ -1531,46 +1531,6 @@ func (ms *ModelSuite) TestUser_HasOrganization() {
 	}
 }
 
-func (ms *ModelSuite) TestUser_isMeetingOrganizer() {
-	f := createMeetingFixtures(ms.DB, 2)
-
-	tests := []struct {
-		name    string
-		user    User
-		meeting Meeting
-		want    bool
-	}{
-		{
-			name:    "creator",
-			user:    f.Users[0],
-			meeting: f.Meetings[0],
-			want:    false,
-		},
-		{
-			name:    "organizer",
-			user:    f.Users[1],
-			meeting: f.Meetings[0],
-			want:    true,
-		},
-		{
-			name:    "participant",
-			user:    f.Users[2],
-			meeting: f.Meetings[0],
-			want:    false,
-		},
-	}
-	for _, tt := range tests {
-		ms.T().Run(tt.name, func(t *testing.T) {
-			ctx := &testBuffaloContext{
-				params: map[interface{}]interface{}{},
-			}
-			ctx.Set("current_user", tt.user)
-			got := tt.user.isMeetingOrganizer(ctx, tt.meeting)
-			ms.Equal(tt.want, got)
-		})
-	}
-}
-
 func (ms *ModelSuite) TestUser_MeetingsAsParticipant() {
 	f := createMeetingFixtures(ms.DB, 2)
 
@@ -1630,6 +1590,69 @@ func (ms *ModelSuite) TestUser_MeetingsAsParticipant() {
 			ms.Equal(tt.want, ids)
 
 			// teardown
+		})
+	}
+}
+
+func (ms *ModelSuite) TestUser_CanCreateMeetingParticipant() {
+	f := createMeetingFixtures(ms.DB, 2)
+
+	tests := []struct {
+		name    string
+		user    User
+		meeting Meeting
+		want    bool
+	}{
+		{
+			name:    "creator",
+			user:    f.Users[0],
+			meeting: f.Meetings[0],
+			want:    true,
+		},
+		{
+			name:    "organizer",
+			user:    f.Users[1],
+			meeting: f.Meetings[0],
+			want:    true,
+		},
+		{
+			name:    "invited participant",
+			user:    f.Users[2],
+			meeting: f.Meetings[0],
+			want:    true,
+		},
+		{
+			name:    "self-joined participant",
+			user:    f.Users[3],
+			meeting: f.Meetings[0],
+			want:    true,
+		},
+		{
+			name:    "not yet participant, cannot see meeting",
+			user:    f.Users[4],
+			meeting: f.Meetings[0],
+			want:    true, // will be false when meeting visibility is implemented
+		},
+		{
+			name:    "not yet participant, can see meeting",
+			user:    f.Users[4],
+			meeting: f.Meetings[0],
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		ms.T().Run(tt.name, func(t *testing.T) {
+			// setup
+			ctx := &testBuffaloContext{
+				params: map[interface{}]interface{}{},
+			}
+			ctx.Set("current_user", tt.user)
+
+			// exercise
+			got := tt.user.CanCreateMeetingParticipant(ctx, tt.meeting)
+
+			// verify
+			ms.Equal(tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Implements `createMeetingParticipant` mutation.

Caveat: since the event visibility parameter has not been implemented, anyone can add themselves to any meeting.

Also in this PR:
- changed "meeting" to "event" in error message translation text
- `domain.Error()` doesn't panic if it is passed a context without an attached logger (e.g. a test context)
- `GetBuffaloContextFromGqlContext` renamed to `GetBuffaloContext` because it can take a `BuffaloContext` without panicking