### PR TITLE
sort GraphQL schema

### DIFF
--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -295,31 +295,31 @@ type MessageResolver interface {
 	Thread(ctx context.Context, obj *models.Message) (*models.Thread, error)
 }
 type MutationResolver interface {
+	CreateMeeting(ctx context.Context, input meetingInput) (*models.Meeting, error)
+	UpdateMeeting(ctx context.Context, input meetingInput) (*models.Meeting, error)
+	CreateMeetingInvites(ctx context.Context, input CreateMeetingInvitesInput) ([]models.MeetingInvite, error)
+	RemoveMeetingInvite(ctx context.Context, input RemoveMeetingInviteInput) ([]models.MeetingInvite, error)
+	CreateMeetingParticipant(ctx context.Context, input CreateMeetingParticipantInput) (*models.MeetingParticipant, error)
+	RemoveMeetingParticipant(ctx context.Context, input RemoveMeetingParticipantInput) ([]models.MeetingParticipant, error)
+	CreateMessage(ctx context.Context, input CreateMessageInput) (*models.Message, error)
+	CreateOrganization(ctx context.Context, input CreateOrganizationInput) (*models.Organization, error)
+	UpdateOrganization(ctx context.Context, input UpdateOrganizationInput) (*models.Organization, error)
+	CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error)
+	RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]models.OrganizationDomain, error)
+	UpdateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error)
+	CreateOrganizationTrust(ctx context.Context, input CreateOrganizationTrustInput) (*models.Organization, error)
+	RemoveOrganizationTrust(ctx context.Context, input RemoveOrganizationTrustInput) (*models.Organization, error)
 	CreatePost(ctx context.Context, input postInput) (*models.Post, error)
 	UpdatePost(ctx context.Context, input postInput) (*models.Post, error)
 	UpdatePostStatus(ctx context.Context, input UpdatePostStatusInput) (*models.Post, error)
 	AddMeAsPotentialProvider(ctx context.Context, postID string) (*models.Post, error)
 	RemoveMeAsPotentialProvider(ctx context.Context, postID string) (*models.Post, error)
 	RemovePotentialProvider(ctx context.Context, postID string, userID string) (*models.Post, error)
-	UpdateUser(ctx context.Context, input UpdateUserInput) (*models.User, error)
-	CreateMeeting(ctx context.Context, input meetingInput) (*models.Meeting, error)
-	UpdateMeeting(ctx context.Context, input meetingInput) (*models.Meeting, error)
-	CreateMessage(ctx context.Context, input CreateMessageInput) (*models.Message, error)
-	CreateOrganization(ctx context.Context, input CreateOrganizationInput) (*models.Organization, error)
-	UpdateOrganization(ctx context.Context, input UpdateOrganizationInput) (*models.Organization, error)
-	CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error)
-	UpdateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error)
-	RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]models.OrganizationDomain, error)
 	SetThreadLastViewedAt(ctx context.Context, input SetThreadLastViewedAtInput) (*models.Thread, error)
+	UpdateUser(ctx context.Context, input UpdateUserInput) (*models.User, error)
 	CreateWatch(ctx context.Context, input watchInput) (*models.Watch, error)
-	UpdateWatch(ctx context.Context, input watchInput) (*models.Watch, error)
 	RemoveWatch(ctx context.Context, input RemoveWatchInput) ([]models.Watch, error)
-	CreateOrganizationTrust(ctx context.Context, input CreateOrganizationTrustInput) (*models.Organization, error)
-	RemoveOrganizationTrust(ctx context.Context, input RemoveOrganizationTrustInput) (*models.Organization, error)
-	CreateMeetingInvites(ctx context.Context, input CreateMeetingInvitesInput) ([]models.MeetingInvite, error)
-	RemoveMeetingInvite(ctx context.Context, input RemoveMeetingInviteInput) ([]models.MeetingInvite, error)
-	CreateMeetingParticipant(ctx context.Context, input CreateMeetingParticipantInput) (*models.MeetingParticipant, error)
-	RemoveMeetingParticipant(ctx context.Context, input RemoveMeetingParticipantInput) ([]models.MeetingParticipant, error)
+	UpdateWatch(ctx context.Context, input watchInput) (*models.Watch, error)
 }
 type OrganizationResolver interface {
 	ID(ctx context.Context, obj *models.Organization) (string, error)
@@ -359,19 +359,19 @@ type PostResolver interface {
 	IsEditable(ctx context.Context, obj *models.Post) (bool, error)
 }
 type QueryResolver interface {
-	Users(ctx context.Context) ([]models.User, error)
-	User(ctx context.Context, id *string) (*models.User, error)
-	Posts(ctx context.Context, destination *LocationInput, origin *LocationInput, searchText *string) ([]models.Post, error)
-	Post(ctx context.Context, id *string) (*models.Post, error)
-	Threads(ctx context.Context) ([]models.Thread, error)
-	MyThreads(ctx context.Context) ([]models.Thread, error)
-	Message(ctx context.Context, id *string) (*models.Message, error)
-	Organizations(ctx context.Context) ([]models.Organization, error)
-	Organization(ctx context.Context, id *string) (*models.Organization, error)
 	Meetings(ctx context.Context, endAfter *string, endBefore *string, startAfter *string, startBefore *string) ([]models.Meeting, error)
 	Meeting(ctx context.Context, id *string) (*models.Meeting, error)
-	RecentMeetings(ctx context.Context) ([]models.Meeting, error)
+	Message(ctx context.Context, id *string) (*models.Message, error)
+	MyThreads(ctx context.Context) ([]models.Thread, error)
 	MyWatches(ctx context.Context) ([]models.Watch, error)
+	Organization(ctx context.Context, id *string) (*models.Organization, error)
+	Organizations(ctx context.Context) ([]models.Organization, error)
+	Post(ctx context.Context, id *string) (*models.Post, error)
+	Posts(ctx context.Context, destination *LocationInput, origin *LocationInput, searchText *string) ([]models.Post, error)
+	RecentMeetings(ctx context.Context) ([]models.Meeting, error)
+	Threads(ctx context.Context) ([]models.Thread, error)
+	User(ctx context.Context, id *string) (*models.User, error)
+	Users(ctx context.Context) ([]models.User, error)
 }
 type ThreadResolver interface {
 	ID(ctx context.Context, obj *models.Thread) (string, error)
@@ -1680,32 +1680,6 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 var parsedSchema = gqlparser.MustLoadSchema(
 	&ast.Source{Name: "schema.graphql", Input: `type Query {
 
-    users: [User!]!
-    user(id: ID): User
-
-    """
-    Posts, aka Requests. With no parameters supplied, all posts visible to the authenticated user are returned. Filter
-    parameters only remove from this default list and never include posts that are not visible to the authenticated
-    user. For posts associated with a ` + "`" + `User` + "`" + ` or ` + "`" + `Meeting` + "`" + `, use the ` + "`" + `posts` + "`" + ` field on ` + "`" + `User` + "`" + ` and ` + "`" + `Meeting` + "`" + `.
-    """
-    posts(
-        "Only include posts that have a destination near the given location."
-        destination: LocationInput,
-
-        "Only include posts that have an origin near the given location."
-        origin: LocationInput
-
-        "Search by text in ` + "`" + `title` + "`" + ` or ` + "`" + `description` + "`" + `"
-        searchText: String
-    ): [Post!]!
-
-    post(id: ID): Post
-    threads: [Thread!]!
-    myThreads: [Thread!]!
-    message(id: ID): Message!
-    organizations: [Organization!]!
-    organization(id: ID): Organization!
-
     """
     Meetings, aka Events. With no parameters supplied, only future meetings are returned.
     NOT YET IMPLEMENTED: ` + "`" + `endAfter` + "`" + `, ` + "`" + `endBefore` + "`" + `, ` + "`" + `startafter` + "`" + `, ` + "`" + `startBefore` + "`" + `
@@ -1735,41 +1709,44 @@ var parsedSchema = gqlparser.MustLoadSchema(
         """
         startBefore: Date
     ): [Meeting!]!
+
     meeting(id: ID): Meeting
+    message(id: ID): Message!
+    myThreads: [Thread!]!
+    myWatches: [Watch!]!
+    organization(id: ID): Organization!
+    organizations: [Organization!]!
+    post(id: ID): Post
+
+    """
+    Posts, aka Requests. With no parameters supplied, all posts visible to the authenticated user are returned. Filter
+    parameters only remove from this default list and never include posts that are not visible to the authenticated
+    user. For posts associated with a ` + "`" + `User` + "`" + ` or ` + "`" + `Meeting` + "`" + `, use the ` + "`" + `posts` + "`" + ` field on ` + "`" + `User` + "`" + ` and ` + "`" + `Meeting` + "`" + `.
+    """
+    posts(
+        "Only include posts that have a destination near the given location."
+        destination: LocationInput,
+
+        "Only include posts that have an origin near the given location."
+        origin: LocationInput
+
+        "Search by text in ` + "`" + `title` + "`" + ` or ` + "`" + `description` + "`" + `"
+        searchText: String
+    ): [Post!]!
 
     """
     DEPRECATED: ` + "`" + `Query.recentMeetings` + "`" + ` will be replaced by the ` + "`" + `endAfter` + "`" + ` parameter of ` + "`" + `Query.meetings` + "`" + `
     """
     recentMeetings: [Meeting!]! @deprecated(reason: "` + "`" + `Query.recentMeetings` + "`" + ` will be replaced by ` + "`" + `endAfter` + "`" + ` parameter of ` + "`" + `Query.meetings` + "`" + `")
-    myWatches: [Watch!]!
+
+    threads: [Thread!]!
+    user(id: ID): User
+    users: [User!]!
 }
 
 type Mutation {
-    createPost(input: CreatePostInput!): Post!
-    updatePost(input: UpdatePostInput!): Post!
-    updatePostStatus(input: UpdatePostStatusInput!): Post!
-    addMeAsPotentialProvider(postID: String!): Post!
-    removeMeAsPotentialProvider(postID: String!): Post!
-    removePotentialProvider(postID: String!, userID: String!): Post!
-
-    """
-    Update User profile information. If ID is not specified, the authenticated user is assumed.
-    """
-    updateUser(input: UpdateUserInput!): User!
     createMeeting(input: CreateMeetingInput!): Meeting!
     updateMeeting(input: UpdateMeetingInput!): Meeting!
-    createMessage(input: CreateMessageInput!): Message!
-    createOrganization(input: CreateOrganizationInput!): Organization!
-    updateOrganization(input: UpdateOrganizationInput!): Organization!
-    createOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
-    updateOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
-    removeOrganizationDomain(input: RemoveOrganizationDomainInput!): [OrganizationDomain!]!
-    setThreadLastViewedAt(input: SetThreadLastViewedAtInput!): Thread!
-    createWatch(input: CreateWatchInput!): Watch!
-    updateWatch(input: UpdateWatchInput!): Watch!
-    removeWatch(input: RemoveWatchInput!): [Watch!]!
-    createOrganizationTrust(input: CreateOrganizationTrustInput!): Organization!
-    removeOrganizationTrust(input: RemoveOrganizationTrustInput!): Organization!
 
     """
     Bulk create ` + "`" + `MeetingInvite` + "`" + `s and return the updated list of invites for the specified meeting. Subsequent calls
@@ -1789,53 +1766,38 @@ type Mutation {
 
     "Remove a ` + "`" + `MeetingParticipant` + "`" + ` and return the remaining participants for the ` + "`" + `Meeting` + "`" + `"
     removeMeetingParticipant(input: RemoveMeetingParticipantInput!): [MeetingParticipant!]!
-}
 
-"Date and Time in ISO-8601 format (e.g. 2020-02-11T18:08:56Z)"
-scalar Time
+    createMessage(input: CreateMessageInput!): Message!
+    createOrganization(input: CreateOrganizationInput!): Organization!
+    updateOrganization(input: UpdateOrganizationInput!): Organization!
+    createOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
+    removeOrganizationDomain(input: RemoveOrganizationDomainInput!): [OrganizationDomain!]!
+    updateOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
+    createOrganizationTrust(input: CreateOrganizationTrustInput!): Organization!
+    removeOrganizationTrust(input: RemoveOrganizationTrustInput!): Organization!
+    createPost(input: CreatePostInput!): Post!
+    updatePost(input: UpdatePostInput!): Post!
+    updatePostStatus(input: UpdatePostStatusInput!): Post!
+    addMeAsPotentialProvider(postID: String!): Post!
+    removeMeAsPotentialProvider(postID: String!): Post!
+    removePotentialProvider(postID: String!, userID: String!): Post!
+    setThreadLastViewedAt(input: SetThreadLastViewedAtInput!): Thread!
+
+    """
+    Update User profile information. If ID is not specified, the authenticated user is assumed.
+    """
+    updateUser(input: UpdateUserInput!): User!
+
+    createWatch(input: CreateWatchInput!): Watch!
+    removeWatch(input: RemoveWatchInput!): [Watch!]!
+    updateWatch(input: UpdateWatchInput!): Watch!
+}
 
 "Date in ISO-8601 format (e.g. 2020-02-11)"
 scalar Date
 
-enum UserAdminRole {
-    SUPERADMIN
-    SALESADMIN
-    ADMIN
-    USER
-}
-
-enum PostRole {
-    CREATEDBY
-    RECEIVING
-    PROVIDING
-}
-
-enum PostStatus {
-    OPEN
-    ACCEPTED
-    DELIVERED
-    RECEIVED
-    COMPLETED
-    REMOVED
-}
-
-enum PostSize {
-    TINY
-    SMALL
-    MEDIUM
-    LARGE
-    XLARGE
-}
-
-"Visibility for Posts, ALL organizations, TRUSTED organizations, or SAME organization only"
-enum PostVisibility {
-    "Visible to all users from all organizations in the system"
-    ALL
-    "Visible to users from all organizations trusted by the Post creator's organization"
-    TRUSTED
-    "Visible only to users from the same organization as the Post creator"
-    SAME
-}
+"Date and Time in ISO-8601 format (e.g. 2020-02-11T18:08:56Z)"
+scalar Time
 
 "Visibility for Meetings (Events), determines who can see a ` + "`" + `Meeting` + "`" + `."
 enum MeetingVisibility {
@@ -1849,44 +1811,42 @@ enum MeetingVisibility {
     INVITE_ONLY
 }
 
-type User {
-    id: ID!
-    email: String!
-    nickname: String!
-    createdAt: Time!
-    updatedAt: Time!
-    adminRole: UserAdminRole
-    "avatarURL is generated from an attached photo if present, an external URL if present, or a Gravatar URL"
-    avatarURL: String
-    "` + "`" + `File` + "`" + ` ID of the user's photo, if present"
-    photoID: String
-    preferences: UserPreferences
-    "user's home location"
-    location: Location
-    unreadMessageCount: Int!
-    organizations: [Organization!]!
-    posts(role: PostRole!): [Post!]!
-    "meetings in which the user is a participant"
-    meetingsAsParticipant: [Meeting!]!
+enum PostRole {
+    CREATEDBY
+    RECEIVING
+    PROVIDING
 }
 
-type UserPreferences {
-    language: String
-    timeZone: String
-    weightUnit: String
+enum PostSize {
+    TINY
+    SMALL
+    MEDIUM
+    LARGE
+    XLARGE
 }
 
-"Input object for ` + "`" + `updateUser` + "`" + `"
-input UpdateUserInput {
-    id: ID
-    nickname: String
-    "File ID of avatar photo. If omitted or ` + "`" + `null` + "`" + `, the photo is removed from the profile."
-    photoID: String
-    """
-    Specify the user's "home" location. If omitted or ` + "`" + `null` + "`" + `, the location is removed from the profile.
-    """
-    location: LocationInput
-    preferences: UpdateUserPreferencesInput
+enum PostStatus {
+    OPEN
+    ACCEPTED
+    DELIVERED
+    RECEIVED
+    COMPLETED
+    REMOVED
+}
+
+enum PostType {
+    REQUEST
+    OFFER
+}
+
+"Visibility for Posts, ALL organizations, TRUSTED organizations, or SAME organization only"
+enum PostVisibility {
+    "Visible to all users from all organizations in the system"
+    ALL
+    "Visible to users from all organizations trusted by the Post creator's organization"
+    TRUSTED
+    "Visible only to users from the same organization as the Post creator"
+    SAME
 }
 
 enum PreferredLanguage {
@@ -1902,75 +1862,20 @@ enum PreferredWeightUnit {
     KILOGRAMS
 }
 
-
-input UpdateUserPreferencesInput {
-    language: PreferredLanguage
-    timeZone: String
-    weightUnit: PreferredWeightUnit
+enum UserAdminRole {
+    SUPERADMIN
+    SALESADMIN
+    ADMIN
+    USER
 }
 
-"User fields that can safely be visible to any user in the system"
-type PublicProfile {
+type File {
     id: ID!
-    nickname: String!
-    avatarURL: String
-}
-
-enum PostType {
-    REQUEST
-    OFFER
-}
-
-type Post {
-    id: ID!
-    type: PostType!
-    "Profile of the user that created this post."
-    createdBy: PublicProfile!
-    "Profile of the user that is receiver of this post. For requests, this is the same as ` + "`" + `createdBy` + "`" + `."
-    receiver: PublicProfile
-    "Profile of the user that is the provider for this post. For offers, this is the same as ` + "`" + `createdBy` + "`" + `."
-    provider: PublicProfile
-    potentialProviders: [PublicProfile!]
-    "Organization associated with this post."
-    organization: Organization
-    "Short description of item"
-    title: String!
-    "Optional, longer description of the item."
-    description: String
-    "Geographic location where item is needed"
-    destination: Location!
-    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
-    neededBefore: Date
-    "Date (yyyy-mm-dd) on which the request moved into the COMPLETED status"
-    completedOn: Date
-    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
-    origin: Location
-    "Broad category of the size of item"
-    size: PostSize!
-    "Status of the post. Use mutation ` + "`" + `updatePostStatus` + "`" + ` to change the status."
-    status: PostStatus!
-    "List of message threads associated with this post"
-    threads: [Thread!]!
-    "Date and time this post was created"
-    createdAt: Time!
-    "Date and time this post was last updated"
-    updatedAt: Time!
-    "Optional URL to further describe or point to detail about the item"
-    url: String
-    "Optional weight of the item, measured in kilograms"
-    kilograms: Float
-    "Photo of the item"
-    photo: File
-    "UUID of the photo of the item"
-    photoID: ID
-    "List of attached files. Does not include the post photo."
-    files: [File!]!
-    "Meeting associated with this post. Affects visibility of the post."
-    meeting: Meeting
-    "Dynamically set to indicate if the current user is allowed to edit this post using the ` + "`" + `updatePost` + "`" + ` mutation"
-    isEditable: Boolean!
-    "Visibility restrictions for this post"
-    visibility: PostVisibility!
+    url: String!
+    urlExpiration: Time!
+    name: String!
+    size: Int!
+    contentType: String!
 }
 
 type Meeting {
@@ -2002,136 +1907,6 @@ type Meeting {
     organizers: [PublicProfile!]!
 }
 
-type Organization {
-    id: ID!
-    name: String!
-    url: String
-    createdAt: Time!
-    updatedAt: Time!
-    domains: [OrganizationDomain!]!
-    logoURL: String
-    trustedOrganizations: [Organization!]!
-}
-
-input CreateOrganizationInput {
-    name: String!
-    url: String
-    authType: String!
-    authConfig: String!
-    logoFileID: ID
-}
-
-input UpdateOrganizationInput {
-    id: ID!
-    name: String!
-    url: String
-    authType: String!
-    authConfig: String!
-    logoFileID: ID
-}
-
-type OrganizationDomain {
-    domain: String!
-    organizationID: ID!
-    authType: String!
-    authConfig: String!
-}
-
-input CreateOrganizationDomainInput {
-    domain: String!
-    organizationID: ID!
-    authType: String
-    authConfig: String
-}
-
-input RemoveOrganizationDomainInput {
-    domain: String!
-    organizationID: ID!
-}
-
-type Thread {
-    id: ID!
-    participants: [PublicProfile!]!
-    messages: [Message!]!
-    postID: String!
-    post: Post!
-    lastViewedAt: Time!
-    createdAt: Time!
-    updatedAt: Time!
-    unreadMessageCount: Int!
-}
-
-type Message {
-    id: ID!
-    sender: PublicProfile!
-    content: String!
-    thread: Thread!
-    createdAt: Time!
-    updatedAt: Time!
-}
-
-input CreatePostInput {
-    "ID of associated Organization. Affects visibility of the post, see also the ` + "`" + `visibility` + "`" + ` field."
-    orgID: String!
-    type: PostType!
-    "Short description, limited to 255 characters"
-    title: String!
-    "Optional, longer description, limited to 4096 characters"
-    description: String
-    "Geographic location where item is needed"
-    destination: LocationInput!
-    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
-    neededBefore: Date
-    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
-    origin: LocationInput
-    "Broad category of the size of item"
-    size: PostSize!
-    "Optional URL to further describe or point to detail about the item"
-    url: String
-    "Optional weight of the item, measured in kilograms"
-    kilograms: Float
-    "Optional photo ` + "`" + `file` + "`" + ` ID. First upload a file using the ` + "`" + `/upload` + "`" + ` REST API and then submit its ID here."
-    photoID: ID
-    "Optional meeting ID. Affects visibility of the post."
-    meetingID: ID
-    "Visibility restrictions for this post"
-    visibility: PostVisibility
-}
-
-input UpdatePostInput {
-    "ID of the post to update"
-    id: ID!
-    "Short description, limited to 255 characters. If omitted or ` + "`" + `null` + "`" + `, no change is made."
-    title: String
-    "Longer description, limited to 4096 characters. If omitted or ` + "`" + `null` + "`" + `, the description is removed"
-    description: String
-    "Geographic location where item is needed. If omitted or ` + "`" + `null` + "`" + `, no change is made."
-    destination: LocationInput
-    """
-    Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date. If
-    omitted or ` + "`" + `null` + "`" + `, the date is removed.
-    """
-    neededBefore: Date
-    """
-    Optional geographic location where the item can be picked up, purchased, or otherwise obtained. If omitted or
-    ` + "`" + `null` + "`" + `, the origin location is removed.
-    """
-    origin: LocationInput
-    "Broad category of the size of item. If omitted or ` + "`" + `null` + "`" + `, no change is made."
-    size: PostSize
-    "Optional URL to further describe or point to detail about the item. If omitted or ` + "`" + `null` + "`" + `, the URL is removed."
-    url: String
-    "Optional weight of the item, measured in kilograms. If omitted or ` + "`" + `null` + "`" + `, the value is removed."
-    kilograms: Float
-    """
-    Optional photo ` + "`" + `file` + "`" + ` ID. First upload a file using the ` + "`" + `/upload` + "`" + ` REST API and then submit its ID here. Any
-    previously attached photo will be deleted. If omitted or ` + "`" + `null` + "`" + `, no photo will be attached to this post.
-    """
-    photoID: ID
-    "Visibility restrictions for this post. If omitted or ` + "`" + `null` + "`" + `, the visibility is set to ` + "`" + `ALL` + "`" + `."
-    visibility: PostVisibility
-}
-
 input CreateMeetingInput {
     name: String!
     description: String
@@ -2140,7 +1915,7 @@ input CreateMeetingInput {
     moreInfoURL: String
     imageFileID: ID
     location: LocationInput!
-    
+
     "NOT YET IMPLEMENTED -- Who can see this meeting"
     visibility: MeetingVisibility!
 }
@@ -2157,79 +1932,6 @@ input UpdateMeetingInput {
 
     "NOT YET IMPLEMENTED -- Who can see this meeting"
     visibility: MeetingVisibility!
-}
-
-input CreateMessageInput {
-    content: String!
-    postID: String!
-    threadID: String
-}
-
-type File {
-    id: ID!
-    url: String!
-    urlExpiration: Time!
-    name: String!
-    size: Int!
-    contentType: String!
-}
-
-input SetThreadLastViewedAtInput {
-    threadID: ID!
-    time: Time!
-}
-
-"Describes a Geographic location"
-type Location {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
-}
-
-"Specify a Geographic location"
-input LocationInput {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
-}
-
-input UpdatePostStatusInput {
-    id: ID!
-    status: PostStatus!
-    providerUserID: ID
-}
-
-type Watch {
-    id: ID!
-    owner: PublicProfile!
-    location: Location
-}
-
-input CreateWatchInput {
-    location: LocationInput
-}
-
-input UpdateWatchInput {
-    id: ID!
-    location: LocationInput
-}
-
-input RemoveWatchInput {
-    id: ID!
-}
-
-input CreateOrganizationTrustInput {
-    primaryID: ID!
-    secondaryID: ID!
-}
-
-input RemoveOrganizationTrustInput {
-    primaryID: ID!
-    secondaryID: ID!
 }
 
 """
@@ -2298,6 +2000,305 @@ input RemoveMeetingParticipantInput {
     meetingID: ID!
     "` + "`" + `User` + "`" + ` ID of the ` + "`" + `Meeting` + "`" + ` participant to remove"
     userID: ID!
+}
+
+type Message {
+    id: ID!
+    sender: PublicProfile!
+    content: String!
+    thread: Thread!
+    createdAt: Time!
+    updatedAt: Time!
+}
+
+input CreateMessageInput {
+    content: String!
+    postID: String!
+    threadID: String
+}
+
+"Describes a Geographic location"
+type Location {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
+"Specify a Geographic location"
+input LocationInput {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
+type Organization {
+    id: ID!
+    name: String!
+    url: String
+    createdAt: Time!
+    updatedAt: Time!
+    domains: [OrganizationDomain!]!
+    logoURL: String
+    trustedOrganizations: [Organization!]!
+}
+
+input CreateOrganizationInput {
+    name: String!
+    url: String
+    authType: String!
+    authConfig: String!
+    logoFileID: ID
+}
+
+input UpdateOrganizationInput {
+    id: ID!
+    name: String!
+    url: String
+    authType: String!
+    authConfig: String!
+    logoFileID: ID
+}
+
+type OrganizationDomain {
+    domain: String!
+    organizationID: ID!
+    authType: String!
+    authConfig: String!
+}
+
+input CreateOrganizationDomainInput {
+    domain: String!
+    organizationID: ID!
+    authType: String
+    authConfig: String
+}
+
+input RemoveOrganizationDomainInput {
+    domain: String!
+    organizationID: ID!
+}
+
+input CreateOrganizationTrustInput {
+    primaryID: ID!
+    secondaryID: ID!
+}
+
+input RemoveOrganizationTrustInput {
+    primaryID: ID!
+    secondaryID: ID!
+}
+
+type Post {
+    id: ID!
+    type: PostType!
+    "Profile of the user that created this post."
+    createdBy: PublicProfile!
+    "Profile of the user that is receiver of this post. For requests, this is the same as ` + "`" + `createdBy` + "`" + `."
+    receiver: PublicProfile
+    "Profile of the user that is the provider for this post. For offers, this is the same as ` + "`" + `createdBy` + "`" + `."
+    provider: PublicProfile
+    potentialProviders: [PublicProfile!]
+    "Organization associated with this post."
+    organization: Organization
+    "Short description of item"
+    title: String!
+    "Optional, longer description of the item."
+    description: String
+    "Geographic location where item is needed"
+    destination: Location!
+    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
+    neededBefore: Date
+    "Date (yyyy-mm-dd) on which the request moved into the COMPLETED status"
+    completedOn: Date
+    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
+    origin: Location
+    "Broad category of the size of item"
+    size: PostSize!
+    "Status of the post. Use mutation ` + "`" + `updatePostStatus` + "`" + ` to change the status."
+    status: PostStatus!
+    "List of message threads associated with this post"
+    threads: [Thread!]!
+    "Date and time this post was created"
+    createdAt: Time!
+    "Date and time this post was last updated"
+    updatedAt: Time!
+    "Optional URL to further describe or point to detail about the item"
+    url: String
+    "Optional weight of the item, measured in kilograms"
+    kilograms: Float
+    "Photo of the item"
+    photo: File
+    "UUID of the photo of the item"
+    photoID: ID
+    "List of attached files. Does not include the post photo."
+    files: [File!]!
+    "Meeting associated with this post. Affects visibility of the post."
+    meeting: Meeting
+    "Dynamically set to indicate if the current user is allowed to edit this post using the ` + "`" + `updatePost` + "`" + ` mutation"
+    isEditable: Boolean!
+    "Visibility restrictions for this post"
+    visibility: PostVisibility!
+}
+
+input CreatePostInput {
+    "ID of associated Organization. Affects visibility of the post, see also the ` + "`" + `visibility` + "`" + ` field."
+    orgID: String!
+    type: PostType!
+    "Short description, limited to 255 characters"
+    title: String!
+    "Optional, longer description, limited to 4096 characters"
+    description: String
+    "Geographic location where item is needed"
+    destination: LocationInput!
+    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
+    neededBefore: Date
+    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
+    origin: LocationInput
+    "Broad category of the size of item"
+    size: PostSize!
+    "Optional URL to further describe or point to detail about the item"
+    url: String
+    "Optional weight of the item, measured in kilograms"
+    kilograms: Float
+    "Optional photo ` + "`" + `file` + "`" + ` ID. First upload a file using the ` + "`" + `/upload` + "`" + ` REST API and then submit its ID here."
+    photoID: ID
+    "Optional meeting ID. Affects visibility of the post."
+    meetingID: ID
+    "Visibility restrictions for this post"
+    visibility: PostVisibility
+}
+
+input UpdatePostInput {
+    "ID of the post to update"
+    id: ID!
+    "Short description, limited to 255 characters. If omitted or ` + "`" + `null` + "`" + `, no change is made."
+    title: String
+    "Longer description, limited to 4096 characters. If omitted or ` + "`" + `null` + "`" + `, the description is removed"
+    description: String
+    "Geographic location where item is needed. If omitted or ` + "`" + `null` + "`" + `, no change is made."
+    destination: LocationInput
+    """
+    Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date. If
+    omitted or ` + "`" + `null` + "`" + `, the date is removed.
+    """
+    neededBefore: Date
+    """
+    Optional geographic location where the item can be picked up, purchased, or otherwise obtained. If omitted or
+    ` + "`" + `null` + "`" + `, the origin location is removed.
+    """
+    origin: LocationInput
+    "Broad category of the size of item. If omitted or ` + "`" + `null` + "`" + `, no change is made."
+    size: PostSize
+    "Optional URL to further describe or point to detail about the item. If omitted or ` + "`" + `null` + "`" + `, the URL is removed."
+    url: String
+    "Optional weight of the item, measured in kilograms. If omitted or ` + "`" + `null` + "`" + `, the value is removed."
+    kilograms: Float
+    """
+    Optional photo ` + "`" + `file` + "`" + ` ID. First upload a file using the ` + "`" + `/upload` + "`" + ` REST API and then submit its ID here. Any
+    previously attached photo will be deleted. If omitted or ` + "`" + `null` + "`" + `, no photo will be attached to this post.
+    """
+    photoID: ID
+    "Visibility restrictions for this post. If omitted or ` + "`" + `null` + "`" + `, the visibility is set to ` + "`" + `ALL` + "`" + `."
+    visibility: PostVisibility
+}
+
+input UpdatePostStatusInput {
+    id: ID!
+    status: PostStatus!
+    providerUserID: ID
+}
+
+type Thread {
+    id: ID!
+    participants: [PublicProfile!]!
+    messages: [Message!]!
+    postID: String!
+    post: Post!
+    lastViewedAt: Time!
+    createdAt: Time!
+    updatedAt: Time!
+    unreadMessageCount: Int!
+}
+
+input SetThreadLastViewedAtInput {
+    threadID: ID!
+    time: Time!
+}
+
+type User {
+    id: ID!
+    email: String!
+    nickname: String!
+    createdAt: Time!
+    updatedAt: Time!
+    adminRole: UserAdminRole
+    "avatarURL is generated from an attached photo if present, an external URL if present, or a Gravatar URL"
+    avatarURL: String
+    "` + "`" + `File` + "`" + ` ID of the user's photo, if present"
+    photoID: String
+    preferences: UserPreferences
+    "user's home location"
+    location: Location
+    unreadMessageCount: Int!
+    organizations: [Organization!]!
+    posts(role: PostRole!): [Post!]!
+    "meetings in which the user is a participant"
+    meetingsAsParticipant: [Meeting!]!
+}
+
+"User fields that can safely be visible to any user in the system"
+type PublicProfile {
+    id: ID!
+    nickname: String!
+    avatarURL: String
+}
+
+"Input object for ` + "`" + `updateUser` + "`" + `"
+input UpdateUserInput {
+    id: ID
+    nickname: String
+    "File ID of avatar photo. If omitted or ` + "`" + `null` + "`" + `, the photo is removed from the profile."
+    photoID: String
+    """
+    Specify the user's "home" location. If omitted or ` + "`" + `null` + "`" + `, the location is removed from the profile.
+    """
+    location: LocationInput
+    preferences: UpdateUserPreferencesInput
+}
+
+type UserPreferences {
+    language: String
+    timeZone: String
+    weightUnit: String
+}
+
+input UpdateUserPreferencesInput {
+    language: PreferredLanguage
+    timeZone: String
+    weightUnit: PreferredWeightUnit
+}
+
+type Watch {
+    id: ID!
+    owner: PublicProfile!
+    location: Location
+}
+
+input CreateWatchInput {
+    location: LocationInput
+}
+
+input RemoveWatchInput {
+    id: ID!
+}
+
+input UpdateWatchInput {
+    id: ID!
+    location: LocationInput
 }
 `},
 )
@@ -4325,6 +4326,622 @@ func (ec *executionContext) _Message_updatedAt(ctx context.Context, field graphq
 	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_createMeeting(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createMeeting_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateMeeting(rctx, args["input"].(meetingInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Meeting)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeeting2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_updateMeeting(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateMeeting_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateMeeting(rctx, args["input"].(meetingInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Meeting)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeeting2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createMeetingInvites(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createMeetingInvites_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateMeetingInvites(rctx, args["input"].(CreateMeetingInvitesInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.MeetingInvite)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeetingInvite2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingInvite(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_removeMeetingInvite(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_removeMeetingInvite_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveMeetingInvite(rctx, args["input"].(RemoveMeetingInviteInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.MeetingInvite)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeetingInvite2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingInvite(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createMeetingParticipant(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createMeetingParticipant_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateMeetingParticipant(rctx, args["input"].(CreateMeetingParticipantInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.MeetingParticipant)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeetingParticipant2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingParticipant(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_removeMeetingParticipant(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_removeMeetingParticipant_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveMeetingParticipant(rctx, args["input"].(RemoveMeetingParticipantInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.MeetingParticipant)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeetingParticipant2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingParticipant(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createMessage(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createMessage_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateMessage(rctx, args["input"].(CreateMessageInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Message)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMessage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createOrganization_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateOrganization(rctx, args["input"].(CreateOrganizationInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_updateOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateOrganization_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateOrganization(rctx, args["input"].(UpdateOrganizationInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createOrganizationDomain_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateOrganizationDomain(rctx, args["input"].(CreateOrganizationDomainInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.OrganizationDomain)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_removeOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_removeOrganizationDomain_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveOrganizationDomain(rctx, args["input"].(RemoveOrganizationDomainInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.OrganizationDomain)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_updateOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateOrganizationDomain_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateOrganizationDomain(rctx, args["input"].(CreateOrganizationDomainInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.OrganizationDomain)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createOrganizationTrust(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createOrganizationTrust_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateOrganizationTrust(rctx, args["input"].(CreateOrganizationTrustInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_removeOrganizationTrust(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_removeOrganizationTrust_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RemoveOrganizationTrust(rctx, args["input"].(RemoveOrganizationTrustInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Mutation_createPost(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -4589,402 +5206,6 @@ func (ec *executionContext) _Mutation_removePotentialProvider(ctx context.Contex
 	return ec.marshalNPost2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_updateUser_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateUser(rctx, args["input"].(UpdateUserInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.User)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_createMeeting(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createMeeting_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateMeeting(rctx, args["input"].(meetingInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Meeting)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeeting2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_updateMeeting(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_updateMeeting_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateMeeting(rctx, args["input"].(meetingInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Meeting)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeeting2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_createMessage(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createMessage_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateMessage(rctx, args["input"].(CreateMessageInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Message)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMessage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_createOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createOrganization_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateOrganization(rctx, args["input"].(CreateOrganizationInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Organization)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_updateOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_updateOrganization_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateOrganization(rctx, args["input"].(UpdateOrganizationInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Organization)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_createOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createOrganizationDomain_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateOrganizationDomain(rctx, args["input"].(CreateOrganizationDomainInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.OrganizationDomain)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_updateOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_updateOrganizationDomain_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateOrganizationDomain(rctx, args["input"].(CreateOrganizationDomainInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.OrganizationDomain)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_removeOrganizationDomain(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_removeOrganizationDomain_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().RemoveOrganizationDomain(rctx, args["input"].(RemoveOrganizationDomainInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.OrganizationDomain)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganizationDomain2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganizationDomain(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _Mutation_setThreadLastViewedAt(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -5029,6 +5250,50 @@ func (ec *executionContext) _Mutation_setThreadLastViewedAt(ctx context.Context,
 	return ec.marshalNThread2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateUser_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateUser(rctx, args["input"].(UpdateUserInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.User)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Mutation_createWatch(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -5056,50 +5321,6 @@ func (ec *executionContext) _Mutation_createWatch(ctx context.Context, field gra
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.Mutation().CreateWatch(rctx, args["input"].(watchInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Watch)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNWatch2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐWatch(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_updateWatch(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_updateWatch_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateWatch(rctx, args["input"].(watchInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5161,7 +5382,7 @@ func (ec *executionContext) _Mutation_removeWatch(ctx context.Context, field gra
 	return ec.marshalNWatch2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐWatch(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Mutation_createOrganizationTrust(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+func (ec *executionContext) _Mutation_updateWatch(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -5178,7 +5399,7 @@ func (ec *executionContext) _Mutation_createOrganizationTrust(ctx context.Contex
 	}
 	ctx = graphql.WithResolverContext(ctx, rctx)
 	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createOrganizationTrust_args(ctx, rawArgs)
+	args, err := ec.field_Mutation_updateWatch_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
@@ -5187,7 +5408,7 @@ func (ec *executionContext) _Mutation_createOrganizationTrust(ctx context.Contex
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateOrganizationTrust(rctx, args["input"].(CreateOrganizationTrustInput))
+		return ec.resolvers.Mutation().UpdateWatch(rctx, args["input"].(watchInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5199,230 +5420,10 @@ func (ec *executionContext) _Mutation_createOrganizationTrust(ctx context.Contex
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*models.Organization)
+	res := resTmp.(*models.Watch)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_removeOrganizationTrust(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_removeOrganizationTrust_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().RemoveOrganizationTrust(rctx, args["input"].(RemoveOrganizationTrustInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Organization)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_createMeetingInvites(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createMeetingInvites_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateMeetingInvites(rctx, args["input"].(CreateMeetingInvitesInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.MeetingInvite)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeetingInvite2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingInvite(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_removeMeetingInvite(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_removeMeetingInvite_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().RemoveMeetingInvite(rctx, args["input"].(RemoveMeetingInviteInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.MeetingInvite)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeetingInvite2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingInvite(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_createMeetingParticipant(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_createMeetingParticipant_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateMeetingParticipant(rctx, args["input"].(CreateMeetingParticipantInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.MeetingParticipant)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeetingParticipant2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingParticipant(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Mutation_removeMeetingParticipant(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Mutation",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_removeMeetingParticipant_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().RemoveMeetingParticipant(rctx, args["input"].(RemoveMeetingParticipantInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.MeetingParticipant)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeetingParticipant2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeetingParticipant(ctx, field.Selections, res)
+	return ec.marshalNWatch2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐWatch(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Organization_id(ctx context.Context, field graphql.CollectedField, obj *models.Organization) (ret graphql.Marshaler) {
@@ -6894,368 +6895,6 @@ func (ec *executionContext) _PublicProfile_avatarURL(ctx context.Context, field 
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Query_users(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Users(rctx)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.User)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNUser2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_user(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Query_user_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().User(rctx, args["id"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*models.User)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_posts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Query_posts_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Posts(rctx, args["destination"].(*LocationInput), args["origin"].(*LocationInput), args["searchText"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.Post)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_post(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Query_post_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Post(rctx, args["id"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*models.Post)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOPost2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_threads(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Threads(rctx)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.Thread)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_myThreads(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().MyThreads(rctx)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.Thread)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_message(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Query_message_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Message(rctx, args["id"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Message)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMessage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_organizations(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Organizations(rctx)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]models.Organization)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Query_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Query",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Query_organization_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	rctx.Args = args
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Organization(rctx, args["id"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*models.Organization)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _Query_meetings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -7341,7 +6980,51 @@ func (ec *executionContext) _Query_meeting(ctx context.Context, field graphql.Co
 	return ec.marshalOMeeting2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Query_recentMeetings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+func (ec *executionContext) _Query_message(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_message_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Message(rctx, args["id"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Message)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMessage2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_myThreads(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -7360,7 +7043,7 @@ func (ec *executionContext) _Query_recentMeetings(ctx context.Context, field gra
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().RecentMeetings(rctx)
+		return ec.resolvers.Query().MyThreads(rctx)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -7372,10 +7055,10 @@ func (ec *executionContext) _Query_recentMeetings(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]models.Meeting)
+	res := resTmp.([]models.Thread)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNMeeting2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
+	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_myWatches(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -7413,6 +7096,324 @@ func (ec *executionContext) _Query_myWatches(ctx context.Context, field graphql.
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNWatch2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐWatch(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_organization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_organization_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Organization(rctx, args["id"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_organizations(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Organizations(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Organization)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNOrganization2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_post(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_post_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Post(rctx, args["id"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.Post)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOPost2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_posts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_posts_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Posts(rctx, args["destination"].(*LocationInput), args["origin"].(*LocationInput), args["searchText"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Post)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNPost2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐPost(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_recentMeetings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().RecentMeetings(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Meeting)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNMeeting2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_threads(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Threads(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.Thread)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNThread2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐThread(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_user(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_user_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().User(rctx, args["id"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.User)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOUser2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_users(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Query",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Users(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]models.User)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNUser2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -11096,6 +11097,76 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Mutation")
+		case "createMeeting":
+			out.Values[i] = ec._Mutation_createMeeting(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateMeeting":
+			out.Values[i] = ec._Mutation_updateMeeting(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createMeetingInvites":
+			out.Values[i] = ec._Mutation_createMeetingInvites(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "removeMeetingInvite":
+			out.Values[i] = ec._Mutation_removeMeetingInvite(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createMeetingParticipant":
+			out.Values[i] = ec._Mutation_createMeetingParticipant(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "removeMeetingParticipant":
+			out.Values[i] = ec._Mutation_removeMeetingParticipant(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createMessage":
+			out.Values[i] = ec._Mutation_createMessage(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createOrganization":
+			out.Values[i] = ec._Mutation_createOrganization(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateOrganization":
+			out.Values[i] = ec._Mutation_updateOrganization(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createOrganizationDomain":
+			out.Values[i] = ec._Mutation_createOrganizationDomain(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "removeOrganizationDomain":
+			out.Values[i] = ec._Mutation_removeOrganizationDomain(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateOrganizationDomain":
+			out.Values[i] = ec._Mutation_updateOrganizationDomain(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createOrganizationTrust":
+			out.Values[i] = ec._Mutation_createOrganizationTrust(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "removeOrganizationTrust":
+			out.Values[i] = ec._Mutation_removeOrganizationTrust(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "createPost":
 			out.Values[i] = ec._Mutation_createPost(ctx, field)
 			if out.Values[i] == graphql.Null {
@@ -11126,53 +11197,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "updateUser":
-			out.Values[i] = ec._Mutation_updateUser(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "createMeeting":
-			out.Values[i] = ec._Mutation_createMeeting(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "updateMeeting":
-			out.Values[i] = ec._Mutation_updateMeeting(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "createMessage":
-			out.Values[i] = ec._Mutation_createMessage(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "createOrganization":
-			out.Values[i] = ec._Mutation_createOrganization(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "updateOrganization":
-			out.Values[i] = ec._Mutation_updateOrganization(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "createOrganizationDomain":
-			out.Values[i] = ec._Mutation_createOrganizationDomain(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "updateOrganizationDomain":
-			out.Values[i] = ec._Mutation_updateOrganizationDomain(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "removeOrganizationDomain":
-			out.Values[i] = ec._Mutation_removeOrganizationDomain(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "setThreadLastViewedAt":
 			out.Values[i] = ec._Mutation_setThreadLastViewedAt(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateUser":
+			out.Values[i] = ec._Mutation_updateUser(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -11181,43 +11212,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "updateWatch":
-			out.Values[i] = ec._Mutation_updateWatch(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "removeWatch":
 			out.Values[i] = ec._Mutation_removeWatch(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "createOrganizationTrust":
-			out.Values[i] = ec._Mutation_createOrganizationTrust(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "removeOrganizationTrust":
-			out.Values[i] = ec._Mutation_removeOrganizationTrust(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "createMeetingInvites":
-			out.Values[i] = ec._Mutation_createMeetingInvites(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "removeMeetingInvite":
-			out.Values[i] = ec._Mutation_removeMeetingInvite(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "createMeetingParticipant":
-			out.Values[i] = ec._Mutation_createMeetingParticipant(ctx, field)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "removeMeetingParticipant":
-			out.Values[i] = ec._Mutation_removeMeetingParticipant(ctx, field)
+		case "updateWatch":
+			out.Values[i] = ec._Mutation_updateWatch(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -11717,126 +11718,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Query")
-		case "users":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_users(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "user":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_user(ctx, field)
-				return res
-			})
-		case "posts":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_posts(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "post":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_post(ctx, field)
-				return res
-			})
-		case "threads":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_threads(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "myThreads":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_myThreads(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "message":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_message(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "organizations":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_organizations(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "organization":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_organization(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
 		case "meetings":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -11862,7 +11743,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				res = ec._Query_meeting(ctx, field)
 				return res
 			})
-		case "recentMeetings":
+		case "message":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
 				defer func() {
@@ -11870,7 +11751,21 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_recentMeetings(ctx, field)
+				res = ec._Query_message(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "myThreads":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_myThreads(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -11885,6 +11780,112 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_myWatches(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "organization":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_organization(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "organizations":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_organizations(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "post":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_post(ctx, field)
+				return res
+			})
+		case "posts":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_posts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "recentMeetings":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_recentMeetings(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "threads":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_threads(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
+		case "user":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_user(ctx, field)
+				return res
+			})
+		case "users":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_users(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -1878,6 +1878,24 @@ type File {
     contentType: String!
 }
 
+"Describes a Geographic location"
+type Location {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
+"Specify a Geographic location"
+input LocationInput {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
 type Meeting {
     id: ID!
     name: String!
@@ -2015,24 +2033,6 @@ input CreateMessageInput {
     content: String!
     postID: String!
     threadID: String
-}
-
-"Describes a Geographic location"
-type Location {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
-}
-
-"Specify a Geographic location"
-input LocationInput {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
 }
 
 type Organization {

--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -17,6 +17,55 @@ autobind:
   - github.com/silinternational/wecarry-api/models
   - github.com/silinternational/wecarry-api/gqlgen
 models:
+  File:
+    model: models.File
+    fields:
+      id:
+        resolver: true
+  Location:
+    model: models.Location
+  Meeting:
+    model: models.Meeting
+    fields:
+      id:
+        resolver: true
+      createdBy:
+        resolver: true
+      startDate:
+        resolver: true
+      endDate:
+        resolver: true
+      location:
+        resolver: true
+      imageFile:
+        resolver: true
+      moreInfoURL:
+        resolver: true
+  CreateMeetingInput:
+    model: gqlgen.meetingInput
+  UpdateMeetingInput:
+    model: gqlgen.meetingInput
+  MeetingInvite:
+    model: models.MeetingInvite
+    fields:
+      avatarURL:
+        resolver: true
+  MeetingParticipant:
+    model: models.MeetingParticipant
+    fields:
+      meeting:
+        resolver: true
+      user:
+        resolver: true
+      invite:
+        resolver: true
+  Message:
+    model: models.Message
+    fields:
+      id:
+        resolver: true
+      thread:
+        resolver: true
   Organization:
     model: models.Organization
     fields:
@@ -30,19 +79,6 @@ models:
     model: models.OrganizationDomain
     fields:
       organizationID:
-        resolver: true
-  User:
-    model: models.User
-    fields:
-      id:
-        resolver: true
-      photoURL:
-        resolver: true
-      location:
-        resolver: true
-      unreadMessageCount:
-        resolver: true
-      userPreferences:
         resolver: true
   Post:
     model: models.Post
@@ -71,23 +107,18 @@ models:
         resolver: true
       meeting:
         resolver: true
-  Meeting:
-    model: models.Meeting
-    fields:
-      id:
-        resolver: true
-      createdBy:
-        resolver: true
-      startDate:
-        resolver: true
-      endDate:
-        resolver: true
-      location:
-        resolver: true
-      imageFile:
-        resolver: true
-      moreInfoURL:
-        resolver: true
+  CreatePostInput:
+    model: gqlgen.postInput
+  UpdatePostInput:
+    model: gqlgen.postInput
+  PostSize:
+    model: models.PostSize
+  PostStatus:
+    model: models.PostStatus
+  PostType:
+    model: models.PostType
+  PostVisibility:
+    model: models.PostVisibility
   Thread:
     model: models.Thread
     fields:
@@ -101,36 +132,19 @@ models:
         resolver: true
       messages:
         resolver: true
-  Message:
-    model: models.Message
+  User:
+    model: models.User
     fields:
       id:
         resolver: true
-      thread:
+      photoURL:
         resolver: true
-  File:
-    model: models.File
-    fields:
-      id:
+      location:
         resolver: true
-  UpdateMeetingInput:
-    model: gqlgen.meetingInput
-  CreateMeetingInput:
-    model: gqlgen.meetingInput
-  UpdatePostInput:
-    model: gqlgen.postInput
-  CreatePostInput:
-    model: gqlgen.postInput
-  Location:
-    model: models.Location
-  PostType:
-    model: models.PostType
-  PostStatus:
-    model: models.PostStatus
-  PostSize:
-    model: models.PostSize
-  PostVisibility:
-    model: models.PostVisibility
+      unreadMessageCount:
+        resolver: true
+      userPreferences:
+        resolver: true
   UserAdminRole:
     model: models.UserAdminRole
   UserPreferences:
@@ -144,17 +158,3 @@ models:
     model: gqlgen.watchInput
   UpdateWatchInput:
     model: gqlgen.watchInput
-  MeetingInvite:
-    model: models.MeetingInvite
-    fields:
-      avatarURL:
-        resolver: true
-  MeetingParticipant:
-    model: models.MeetingParticipant
-    fields:
-      meeting:
-        resolver: true
-      user:
-        resolver: true
-      invite:
-        resolver: true

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -1,31 +1,5 @@
 type Query {
 
-    users: [User!]!
-    user(id: ID): User
-
-    """
-    Posts, aka Requests. With no parameters supplied, all posts visible to the authenticated user are returned. Filter
-    parameters only remove from this default list and never include posts that are not visible to the authenticated
-    user. For posts associated with a `User` or `Meeting`, use the `posts` field on `User` and `Meeting`.
-    """
-    posts(
-        "Only include posts that have a destination near the given location."
-        destination: LocationInput,
-
-        "Only include posts that have an origin near the given location."
-        origin: LocationInput
-
-        "Search by text in `title` or `description`"
-        searchText: String
-    ): [Post!]!
-
-    post(id: ID): Post
-    threads: [Thread!]!
-    myThreads: [Thread!]!
-    message(id: ID): Message!
-    organizations: [Organization!]!
-    organization(id: ID): Organization!
-
     """
     Meetings, aka Events. With no parameters supplied, only future meetings are returned.
     NOT YET IMPLEMENTED: `endAfter`, `endBefore`, `startafter`, `startBefore`
@@ -55,41 +29,44 @@ type Query {
         """
         startBefore: Date
     ): [Meeting!]!
+
     meeting(id: ID): Meeting
+    message(id: ID): Message!
+    myThreads: [Thread!]!
+    myWatches: [Watch!]!
+    organization(id: ID): Organization!
+    organizations: [Organization!]!
+    post(id: ID): Post
+
+    """
+    Posts, aka Requests. With no parameters supplied, all posts visible to the authenticated user are returned. Filter
+    parameters only remove from this default list and never include posts that are not visible to the authenticated
+    user. For posts associated with a `User` or `Meeting`, use the `posts` field on `User` and `Meeting`.
+    """
+    posts(
+        "Only include posts that have a destination near the given location."
+        destination: LocationInput,
+
+        "Only include posts that have an origin near the given location."
+        origin: LocationInput
+
+        "Search by text in `title` or `description`"
+        searchText: String
+    ): [Post!]!
 
     """
     DEPRECATED: `Query.recentMeetings` will be replaced by the `endAfter` parameter of `Query.meetings`
     """
     recentMeetings: [Meeting!]! @deprecated(reason: "`Query.recentMeetings` will be replaced by `endAfter` parameter of `Query.meetings`")
-    myWatches: [Watch!]!
+
+    threads: [Thread!]!
+    user(id: ID): User
+    users: [User!]!
 }
 
 type Mutation {
-    createPost(input: CreatePostInput!): Post!
-    updatePost(input: UpdatePostInput!): Post!
-    updatePostStatus(input: UpdatePostStatusInput!): Post!
-    addMeAsPotentialProvider(postID: String!): Post!
-    removeMeAsPotentialProvider(postID: String!): Post!
-    removePotentialProvider(postID: String!, userID: String!): Post!
-
-    """
-    Update User profile information. If ID is not specified, the authenticated user is assumed.
-    """
-    updateUser(input: UpdateUserInput!): User!
     createMeeting(input: CreateMeetingInput!): Meeting!
     updateMeeting(input: UpdateMeetingInput!): Meeting!
-    createMessage(input: CreateMessageInput!): Message!
-    createOrganization(input: CreateOrganizationInput!): Organization!
-    updateOrganization(input: UpdateOrganizationInput!): Organization!
-    createOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
-    updateOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
-    removeOrganizationDomain(input: RemoveOrganizationDomainInput!): [OrganizationDomain!]!
-    setThreadLastViewedAt(input: SetThreadLastViewedAtInput!): Thread!
-    createWatch(input: CreateWatchInput!): Watch!
-    updateWatch(input: UpdateWatchInput!): Watch!
-    removeWatch(input: RemoveWatchInput!): [Watch!]!
-    createOrganizationTrust(input: CreateOrganizationTrustInput!): Organization!
-    removeOrganizationTrust(input: RemoveOrganizationTrustInput!): Organization!
 
     """
     Bulk create `MeetingInvite`s and return the updated list of invites for the specified meeting. Subsequent calls
@@ -109,53 +86,38 @@ type Mutation {
 
     "Remove a `MeetingParticipant` and return the remaining participants for the `Meeting`"
     removeMeetingParticipant(input: RemoveMeetingParticipantInput!): [MeetingParticipant!]!
-}
 
-"Date and Time in ISO-8601 format (e.g. 2020-02-11T18:08:56Z)"
-scalar Time
+    createMessage(input: CreateMessageInput!): Message!
+    createOrganization(input: CreateOrganizationInput!): Organization!
+    updateOrganization(input: UpdateOrganizationInput!): Organization!
+    createOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
+    removeOrganizationDomain(input: RemoveOrganizationDomainInput!): [OrganizationDomain!]!
+    updateOrganizationDomain(input: CreateOrganizationDomainInput!): [OrganizationDomain!]!
+    createOrganizationTrust(input: CreateOrganizationTrustInput!): Organization!
+    removeOrganizationTrust(input: RemoveOrganizationTrustInput!): Organization!
+    createPost(input: CreatePostInput!): Post!
+    updatePost(input: UpdatePostInput!): Post!
+    updatePostStatus(input: UpdatePostStatusInput!): Post!
+    addMeAsPotentialProvider(postID: String!): Post!
+    removeMeAsPotentialProvider(postID: String!): Post!
+    removePotentialProvider(postID: String!, userID: String!): Post!
+    setThreadLastViewedAt(input: SetThreadLastViewedAtInput!): Thread!
+
+    """
+    Update User profile information. If ID is not specified, the authenticated user is assumed.
+    """
+    updateUser(input: UpdateUserInput!): User!
+
+    createWatch(input: CreateWatchInput!): Watch!
+    removeWatch(input: RemoveWatchInput!): [Watch!]!
+    updateWatch(input: UpdateWatchInput!): Watch!
+}
 
 "Date in ISO-8601 format (e.g. 2020-02-11)"
 scalar Date
 
-enum UserAdminRole {
-    SUPERADMIN
-    SALESADMIN
-    ADMIN
-    USER
-}
-
-enum PostRole {
-    CREATEDBY
-    RECEIVING
-    PROVIDING
-}
-
-enum PostStatus {
-    OPEN
-    ACCEPTED
-    DELIVERED
-    RECEIVED
-    COMPLETED
-    REMOVED
-}
-
-enum PostSize {
-    TINY
-    SMALL
-    MEDIUM
-    LARGE
-    XLARGE
-}
-
-"Visibility for Posts, ALL organizations, TRUSTED organizations, or SAME organization only"
-enum PostVisibility {
-    "Visible to all users from all organizations in the system"
-    ALL
-    "Visible to users from all organizations trusted by the Post creator's organization"
-    TRUSTED
-    "Visible only to users from the same organization as the Post creator"
-    SAME
-}
+"Date and Time in ISO-8601 format (e.g. 2020-02-11T18:08:56Z)"
+scalar Time
 
 "Visibility for Meetings (Events), determines who can see a `Meeting`."
 enum MeetingVisibility {
@@ -169,44 +131,42 @@ enum MeetingVisibility {
     INVITE_ONLY
 }
 
-type User {
-    id: ID!
-    email: String!
-    nickname: String!
-    createdAt: Time!
-    updatedAt: Time!
-    adminRole: UserAdminRole
-    "avatarURL is generated from an attached photo if present, an external URL if present, or a Gravatar URL"
-    avatarURL: String
-    "`File` ID of the user's photo, if present"
-    photoID: String
-    preferences: UserPreferences
-    "user's home location"
-    location: Location
-    unreadMessageCount: Int!
-    organizations: [Organization!]!
-    posts(role: PostRole!): [Post!]!
-    "meetings in which the user is a participant"
-    meetingsAsParticipant: [Meeting!]!
+enum PostRole {
+    CREATEDBY
+    RECEIVING
+    PROVIDING
 }
 
-type UserPreferences {
-    language: String
-    timeZone: String
-    weightUnit: String
+enum PostSize {
+    TINY
+    SMALL
+    MEDIUM
+    LARGE
+    XLARGE
 }
 
-"Input object for `updateUser`"
-input UpdateUserInput {
-    id: ID
-    nickname: String
-    "File ID of avatar photo. If omitted or `null`, the photo is removed from the profile."
-    photoID: String
-    """
-    Specify the user's "home" location. If omitted or `null`, the location is removed from the profile.
-    """
-    location: LocationInput
-    preferences: UpdateUserPreferencesInput
+enum PostStatus {
+    OPEN
+    ACCEPTED
+    DELIVERED
+    RECEIVED
+    COMPLETED
+    REMOVED
+}
+
+enum PostType {
+    REQUEST
+    OFFER
+}
+
+"Visibility for Posts, ALL organizations, TRUSTED organizations, or SAME organization only"
+enum PostVisibility {
+    "Visible to all users from all organizations in the system"
+    ALL
+    "Visible to users from all organizations trusted by the Post creator's organization"
+    TRUSTED
+    "Visible only to users from the same organization as the Post creator"
+    SAME
 }
 
 enum PreferredLanguage {
@@ -222,75 +182,20 @@ enum PreferredWeightUnit {
     KILOGRAMS
 }
 
-
-input UpdateUserPreferencesInput {
-    language: PreferredLanguage
-    timeZone: String
-    weightUnit: PreferredWeightUnit
+enum UserAdminRole {
+    SUPERADMIN
+    SALESADMIN
+    ADMIN
+    USER
 }
 
-"User fields that can safely be visible to any user in the system"
-type PublicProfile {
+type File {
     id: ID!
-    nickname: String!
-    avatarURL: String
-}
-
-enum PostType {
-    REQUEST
-    OFFER
-}
-
-type Post {
-    id: ID!
-    type: PostType!
-    "Profile of the user that created this post."
-    createdBy: PublicProfile!
-    "Profile of the user that is receiver of this post. For requests, this is the same as `createdBy`."
-    receiver: PublicProfile
-    "Profile of the user that is the provider for this post. For offers, this is the same as `createdBy`."
-    provider: PublicProfile
-    potentialProviders: [PublicProfile!]
-    "Organization associated with this post."
-    organization: Organization
-    "Short description of item"
-    title: String!
-    "Optional, longer description of the item."
-    description: String
-    "Geographic location where item is needed"
-    destination: Location!
-    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
-    neededBefore: Date
-    "Date (yyyy-mm-dd) on which the request moved into the COMPLETED status"
-    completedOn: Date
-    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
-    origin: Location
-    "Broad category of the size of item"
-    size: PostSize!
-    "Status of the post. Use mutation `updatePostStatus` to change the status."
-    status: PostStatus!
-    "List of message threads associated with this post"
-    threads: [Thread!]!
-    "Date and time this post was created"
-    createdAt: Time!
-    "Date and time this post was last updated"
-    updatedAt: Time!
-    "Optional URL to further describe or point to detail about the item"
-    url: String
-    "Optional weight of the item, measured in kilograms"
-    kilograms: Float
-    "Photo of the item"
-    photo: File
-    "UUID of the photo of the item"
-    photoID: ID
-    "List of attached files. Does not include the post photo."
-    files: [File!]!
-    "Meeting associated with this post. Affects visibility of the post."
-    meeting: Meeting
-    "Dynamically set to indicate if the current user is allowed to edit this post using the `updatePost` mutation"
-    isEditable: Boolean!
-    "Visibility restrictions for this post"
-    visibility: PostVisibility!
+    url: String!
+    urlExpiration: Time!
+    name: String!
+    size: Int!
+    contentType: String!
 }
 
 type Meeting {
@@ -322,136 +227,6 @@ type Meeting {
     organizers: [PublicProfile!]!
 }
 
-type Organization {
-    id: ID!
-    name: String!
-    url: String
-    createdAt: Time!
-    updatedAt: Time!
-    domains: [OrganizationDomain!]!
-    logoURL: String
-    trustedOrganizations: [Organization!]!
-}
-
-input CreateOrganizationInput {
-    name: String!
-    url: String
-    authType: String!
-    authConfig: String!
-    logoFileID: ID
-}
-
-input UpdateOrganizationInput {
-    id: ID!
-    name: String!
-    url: String
-    authType: String!
-    authConfig: String!
-    logoFileID: ID
-}
-
-type OrganizationDomain {
-    domain: String!
-    organizationID: ID!
-    authType: String!
-    authConfig: String!
-}
-
-input CreateOrganizationDomainInput {
-    domain: String!
-    organizationID: ID!
-    authType: String
-    authConfig: String
-}
-
-input RemoveOrganizationDomainInput {
-    domain: String!
-    organizationID: ID!
-}
-
-type Thread {
-    id: ID!
-    participants: [PublicProfile!]!
-    messages: [Message!]!
-    postID: String!
-    post: Post!
-    lastViewedAt: Time!
-    createdAt: Time!
-    updatedAt: Time!
-    unreadMessageCount: Int!
-}
-
-type Message {
-    id: ID!
-    sender: PublicProfile!
-    content: String!
-    thread: Thread!
-    createdAt: Time!
-    updatedAt: Time!
-}
-
-input CreatePostInput {
-    "ID of associated Organization. Affects visibility of the post, see also the `visibility` field."
-    orgID: String!
-    type: PostType!
-    "Short description, limited to 255 characters"
-    title: String!
-    "Optional, longer description, limited to 4096 characters"
-    description: String
-    "Geographic location where item is needed"
-    destination: LocationInput!
-    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
-    neededBefore: Date
-    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
-    origin: LocationInput
-    "Broad category of the size of item"
-    size: PostSize!
-    "Optional URL to further describe or point to detail about the item"
-    url: String
-    "Optional weight of the item, measured in kilograms"
-    kilograms: Float
-    "Optional photo `file` ID. First upload a file using the `/upload` REST API and then submit its ID here."
-    photoID: ID
-    "Optional meeting ID. Affects visibility of the post."
-    meetingID: ID
-    "Visibility restrictions for this post"
-    visibility: PostVisibility
-}
-
-input UpdatePostInput {
-    "ID of the post to update"
-    id: ID!
-    "Short description, limited to 255 characters. If omitted or `null`, no change is made."
-    title: String
-    "Longer description, limited to 4096 characters. If omitted or `null`, the description is removed"
-    description: String
-    "Geographic location where item is needed. If omitted or `null`, no change is made."
-    destination: LocationInput
-    """
-    Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date. If
-    omitted or `null`, the date is removed.
-    """
-    neededBefore: Date
-    """
-    Optional geographic location where the item can be picked up, purchased, or otherwise obtained. If omitted or
-    `null`, the origin location is removed.
-    """
-    origin: LocationInput
-    "Broad category of the size of item. If omitted or `null`, no change is made."
-    size: PostSize
-    "Optional URL to further describe or point to detail about the item. If omitted or `null`, the URL is removed."
-    url: String
-    "Optional weight of the item, measured in kilograms. If omitted or `null`, the value is removed."
-    kilograms: Float
-    """
-    Optional photo `file` ID. First upload a file using the `/upload` REST API and then submit its ID here. Any
-    previously attached photo will be deleted. If omitted or `null`, no photo will be attached to this post.
-    """
-    photoID: ID
-    "Visibility restrictions for this post. If omitted or `null`, the visibility is set to `ALL`."
-    visibility: PostVisibility
-}
-
 input CreateMeetingInput {
     name: String!
     description: String
@@ -460,7 +235,7 @@ input CreateMeetingInput {
     moreInfoURL: String
     imageFileID: ID
     location: LocationInput!
-    
+
     "NOT YET IMPLEMENTED -- Who can see this meeting"
     visibility: MeetingVisibility!
 }
@@ -477,79 +252,6 @@ input UpdateMeetingInput {
 
     "NOT YET IMPLEMENTED -- Who can see this meeting"
     visibility: MeetingVisibility!
-}
-
-input CreateMessageInput {
-    content: String!
-    postID: String!
-    threadID: String
-}
-
-type File {
-    id: ID!
-    url: String!
-    urlExpiration: Time!
-    name: String!
-    size: Int!
-    contentType: String!
-}
-
-input SetThreadLastViewedAtInput {
-    threadID: ID!
-    time: Time!
-}
-
-"Describes a Geographic location"
-type Location {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
-}
-
-"Specify a Geographic location"
-input LocationInput {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
-}
-
-input UpdatePostStatusInput {
-    id: ID!
-    status: PostStatus!
-    providerUserID: ID
-}
-
-type Watch {
-    id: ID!
-    owner: PublicProfile!
-    location: Location
-}
-
-input CreateWatchInput {
-    location: LocationInput
-}
-
-input UpdateWatchInput {
-    id: ID!
-    location: LocationInput
-}
-
-input RemoveWatchInput {
-    id: ID!
-}
-
-input CreateOrganizationTrustInput {
-    primaryID: ID!
-    secondaryID: ID!
-}
-
-input RemoveOrganizationTrustInput {
-    primaryID: ID!
-    secondaryID: ID!
 }
 
 """
@@ -618,4 +320,303 @@ input RemoveMeetingParticipantInput {
     meetingID: ID!
     "`User` ID of the `Meeting` participant to remove"
     userID: ID!
+}
+
+type Message {
+    id: ID!
+    sender: PublicProfile!
+    content: String!
+    thread: Thread!
+    createdAt: Time!
+    updatedAt: Time!
+}
+
+input CreateMessageInput {
+    content: String!
+    postID: String!
+    threadID: String
+}
+
+"Describes a Geographic location"
+type Location {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
+"Specify a Geographic location"
+input LocationInput {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
+type Organization {
+    id: ID!
+    name: String!
+    url: String
+    createdAt: Time!
+    updatedAt: Time!
+    domains: [OrganizationDomain!]!
+    logoURL: String
+    trustedOrganizations: [Organization!]!
+}
+
+input CreateOrganizationInput {
+    name: String!
+    url: String
+    authType: String!
+    authConfig: String!
+    logoFileID: ID
+}
+
+input UpdateOrganizationInput {
+    id: ID!
+    name: String!
+    url: String
+    authType: String!
+    authConfig: String!
+    logoFileID: ID
+}
+
+type OrganizationDomain {
+    domain: String!
+    organizationID: ID!
+    authType: String!
+    authConfig: String!
+}
+
+input CreateOrganizationDomainInput {
+    domain: String!
+    organizationID: ID!
+    authType: String
+    authConfig: String
+}
+
+input RemoveOrganizationDomainInput {
+    domain: String!
+    organizationID: ID!
+}
+
+input CreateOrganizationTrustInput {
+    primaryID: ID!
+    secondaryID: ID!
+}
+
+input RemoveOrganizationTrustInput {
+    primaryID: ID!
+    secondaryID: ID!
+}
+
+type Post {
+    id: ID!
+    type: PostType!
+    "Profile of the user that created this post."
+    createdBy: PublicProfile!
+    "Profile of the user that is receiver of this post. For requests, this is the same as `createdBy`."
+    receiver: PublicProfile
+    "Profile of the user that is the provider for this post. For offers, this is the same as `createdBy`."
+    provider: PublicProfile
+    potentialProviders: [PublicProfile!]
+    "Organization associated with this post."
+    organization: Organization
+    "Short description of item"
+    title: String!
+    "Optional, longer description of the item."
+    description: String
+    "Geographic location where item is needed"
+    destination: Location!
+    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
+    neededBefore: Date
+    "Date (yyyy-mm-dd) on which the request moved into the COMPLETED status"
+    completedOn: Date
+    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
+    origin: Location
+    "Broad category of the size of item"
+    size: PostSize!
+    "Status of the post. Use mutation `updatePostStatus` to change the status."
+    status: PostStatus!
+    "List of message threads associated with this post"
+    threads: [Thread!]!
+    "Date and time this post was created"
+    createdAt: Time!
+    "Date and time this post was last updated"
+    updatedAt: Time!
+    "Optional URL to further describe or point to detail about the item"
+    url: String
+    "Optional weight of the item, measured in kilograms"
+    kilograms: Float
+    "Photo of the item"
+    photo: File
+    "UUID of the photo of the item"
+    photoID: ID
+    "List of attached files. Does not include the post photo."
+    files: [File!]!
+    "Meeting associated with this post. Affects visibility of the post."
+    meeting: Meeting
+    "Dynamically set to indicate if the current user is allowed to edit this post using the `updatePost` mutation"
+    isEditable: Boolean!
+    "Visibility restrictions for this post"
+    visibility: PostVisibility!
+}
+
+input CreatePostInput {
+    "ID of associated Organization. Affects visibility of the post, see also the `visibility` field."
+    orgID: String!
+    type: PostType!
+    "Short description, limited to 255 characters"
+    title: String!
+    "Optional, longer description, limited to 4096 characters"
+    description: String
+    "Geographic location where item is needed"
+    destination: LocationInput!
+    "Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date."
+    neededBefore: Date
+    "Optional geographic location where the item can be picked up, purchased, or otherwise obtained"
+    origin: LocationInput
+    "Broad category of the size of item"
+    size: PostSize!
+    "Optional URL to further describe or point to detail about the item"
+    url: String
+    "Optional weight of the item, measured in kilograms"
+    kilograms: Float
+    "Optional photo `file` ID. First upload a file using the `/upload` REST API and then submit its ID here."
+    photoID: ID
+    "Optional meeting ID. Affects visibility of the post."
+    meetingID: ID
+    "Visibility restrictions for this post"
+    visibility: PostVisibility
+}
+
+input UpdatePostInput {
+    "ID of the post to update"
+    id: ID!
+    "Short description, limited to 255 characters. If omitted or `null`, no change is made."
+    title: String
+    "Longer description, limited to 4096 characters. If omitted or `null`, the description is removed"
+    description: String
+    "Geographic location where item is needed. If omitted or `null`, no change is made."
+    destination: LocationInput
+    """
+    Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date. If
+    omitted or `null`, the date is removed.
+    """
+    neededBefore: Date
+    """
+    Optional geographic location where the item can be picked up, purchased, or otherwise obtained. If omitted or
+    `null`, the origin location is removed.
+    """
+    origin: LocationInput
+    "Broad category of the size of item. If omitted or `null`, no change is made."
+    size: PostSize
+    "Optional URL to further describe or point to detail about the item. If omitted or `null`, the URL is removed."
+    url: String
+    "Optional weight of the item, measured in kilograms. If omitted or `null`, the value is removed."
+    kilograms: Float
+    """
+    Optional photo `file` ID. First upload a file using the `/upload` REST API and then submit its ID here. Any
+    previously attached photo will be deleted. If omitted or `null`, no photo will be attached to this post.
+    """
+    photoID: ID
+    "Visibility restrictions for this post. If omitted or `null`, the visibility is set to `ALL`."
+    visibility: PostVisibility
+}
+
+input UpdatePostStatusInput {
+    id: ID!
+    status: PostStatus!
+    providerUserID: ID
+}
+
+type Thread {
+    id: ID!
+    participants: [PublicProfile!]!
+    messages: [Message!]!
+    postID: String!
+    post: Post!
+    lastViewedAt: Time!
+    createdAt: Time!
+    updatedAt: Time!
+    unreadMessageCount: Int!
+}
+
+input SetThreadLastViewedAtInput {
+    threadID: ID!
+    time: Time!
+}
+
+type User {
+    id: ID!
+    email: String!
+    nickname: String!
+    createdAt: Time!
+    updatedAt: Time!
+    adminRole: UserAdminRole
+    "avatarURL is generated from an attached photo if present, an external URL if present, or a Gravatar URL"
+    avatarURL: String
+    "`File` ID of the user's photo, if present"
+    photoID: String
+    preferences: UserPreferences
+    "user's home location"
+    location: Location
+    unreadMessageCount: Int!
+    organizations: [Organization!]!
+    posts(role: PostRole!): [Post!]!
+    "meetings in which the user is a participant"
+    meetingsAsParticipant: [Meeting!]!
+}
+
+"User fields that can safely be visible to any user in the system"
+type PublicProfile {
+    id: ID!
+    nickname: String!
+    avatarURL: String
+}
+
+"Input object for `updateUser`"
+input UpdateUserInput {
+    id: ID
+    nickname: String
+    "File ID of avatar photo. If omitted or `null`, the photo is removed from the profile."
+    photoID: String
+    """
+    Specify the user's "home" location. If omitted or `null`, the location is removed from the profile.
+    """
+    location: LocationInput
+    preferences: UpdateUserPreferencesInput
+}
+
+type UserPreferences {
+    language: String
+    timeZone: String
+    weightUnit: String
+}
+
+input UpdateUserPreferencesInput {
+    language: PreferredLanguage
+    timeZone: String
+    weightUnit: PreferredWeightUnit
+}
+
+type Watch {
+    id: ID!
+    owner: PublicProfile!
+    location: Location
+}
+
+input CreateWatchInput {
+    location: LocationInput
+}
+
+input RemoveWatchInput {
+    id: ID!
+}
+
+input UpdateWatchInput {
+    id: ID!
+    location: LocationInput
 }

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -198,6 +198,24 @@ type File {
     contentType: String!
 }
 
+"Describes a Geographic location"
+type Location {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
+"Specify a Geographic location"
+input LocationInput {
+    description: String!
+    # Country, ISO 3166-1 Alpha-2 code
+    country: String!
+    latitude: Float
+    longitude: Float
+}
+
 type Meeting {
     id: ID!
     name: String!
@@ -335,24 +353,6 @@ input CreateMessageInput {
     content: String!
     postID: String!
     threadID: String
-}
-
-"Describes a Geographic location"
-type Location {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
-}
-
-"Specify a Geographic location"
-input LocationInput {
-    description: String!
-    # Country, ISO 3166-1 Alpha-2 code
-    country: String!
-    latitude: Float
-    longitude: Float
 }
 
 type Organization {


### PR DESCRIPTION
No changes other than sorting of the `schema.graphql` and `gqlgen.yml` files (and generated files)
- group by queries, mutations, scalars, enums, then types
- in each group, sort by the model name