### PR TITLE
assortment of GraphQL cleanup

### DIFF
--- a/application/actions/organization_test.go
+++ b/application/actions/organization_test.go
@@ -17,21 +17,22 @@ import (
 
 // OrganizationResponse is for marshalling Organization query and mutation responses
 type OrganizationResponse struct {
-	Organization struct {
-		ID        string `json:"id"`
-		Name      string `json:"name"`
-		URL       string `json:"url"`
-		CreatedAt string `json:"createdAt"`
-		UpdatedAt string `json:"updatedAt"`
-		LogoURL   string `json:"logoURL"`
-		Domains   []struct {
-			Domain         string `json:"domain"`
-			OrganizationID string `json:"organizationID"`
-		} `json:"domains"`
-		TrustedOrganizations []struct {
-			ID string `json:"id"`
-		} `json:"trustedOrganizations"`
-	} `json:"organization"`
+	Organization Organization `json:"organization"`
+}
+
+type Organization struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	LogoURL   string `json:"logoURL"`
+	Domains   []struct {
+		Domain string `json:"domain"`
+	} `json:"domains"`
+	TrustedOrganizations []struct {
+		ID string `json:"id"`
+	} `json:"trustedOrganizations"`
 }
 
 // Test_CreateOrganization tests the CreateOrganization GraphQL mutation
@@ -40,7 +41,7 @@ func (as *ActionSuite) Test_CreateOrganization() {
 
 	var resp OrganizationResponse
 
-	allFieldsQuery := `id domains { domain organizationID } name url logoURL`
+	allFieldsQuery := `id domains { domain } name url logoURL`
 	allFieldsInput := fmt.Sprintf(
 		`name:"%s" url:"%s" authType:"%s" authConfig:"%s" logoFileID:"%s"`,
 		f.Organizations[1].Name,
@@ -416,7 +417,7 @@ func (as *ActionSuite) Test_UpdateOrganization() {
 	f := fixturesForUpdateOrganization(as)
 
 	var resp OrganizationResponse
-	allFieldsQuery := `id domains { domain organizationID } name url logoURL`
+	allFieldsQuery := `id domains { domain } name url logoURL`
 	allFieldsInput := fmt.Sprintf(
 		`id:"%s" name:"%s" url:"%s" authType:"%s" authConfig:"%s" logoFileID:"%s"`,
 		f.Organizations[0].UUID.String(),
@@ -440,7 +441,6 @@ func (as *ActionSuite) Test_UpdateOrganization() {
 	domains := make([]string, len(resp.Organization.Domains))
 	for i := range domains {
 		domains[i] = resp.Organization.Domains[i].Domain
-		as.Equal(f.Organizations[0].UUID.String(), resp.Organization.Domains[i].OrganizationID)
 	}
 	as.Contains(domains, f.OrganizationDomains[0].Domain)
 	as.Contains(domains, f.OrganizationDomains[1].Domain)

--- a/application/actions/organizationdomain_test.go
+++ b/application/actions/organizationdomain_test.go
@@ -13,8 +13,8 @@ type OrganizationDomainFixtures struct {
 
 type OrganizationDomainResponse struct {
 	OrganizationDomain []struct {
-		OrganizationID string `json:"organizationID"`
-		Domain         string `json:"domain"`
+		Organization Organization `json:"organization"`
+		Domain       string       `json:"domain"`
 	} `json:"domain"`
 }
 
@@ -22,7 +22,7 @@ func (as *ActionSuite) Test_CreateUpdateOrganizationDomain() {
 	f := fixturesForOrganizationDomain(as)
 
 	testDomain := "example.com"
-	allFieldsQuery := `organizationID domain authType authConfig`
+	allFieldsQuery := `organization { id } domain authType authConfig`
 	allFieldsInput := fmt.Sprintf(`organizationID:"%s" domain:"%s"`,
 		f.Organizations[0].UUID.String(), testDomain)
 
@@ -34,7 +34,7 @@ func (as *ActionSuite) Test_CreateUpdateOrganizationDomain() {
 
 	as.Equal(1, len(resp.OrganizationDomain), "wrong number of domains in response")
 	as.Equal(testDomain, resp.OrganizationDomain[0].Domain, "received wrong domain")
-	as.Equal(f.Organizations[0].UUID.String(), resp.OrganizationDomain[0].OrganizationID, "received wrong org ID")
+	as.Equal(f.Organizations[0].UUID.String(), resp.OrganizationDomain[0].Organization.ID, "received wrong org ID")
 
 	var orgs models.Organizations
 	err = as.DB.Where("name = ?", f.Organizations[0].Name).All(&orgs)

--- a/application/actions/thread_fixtures_test.go
+++ b/application/actions/thread_fixtures_test.go
@@ -19,10 +19,11 @@ func createFixturesForThreadQuery(as *ActionSuite) threadQueryFixtures {
 	org := userFixtures.Organization
 	users := userFixtures.Users
 
-	posts := test.CreatePostFixtures(as.DB, 1, false)
+	posts := test.CreatePostFixtures(as.DB, 2, false)
 
 	threads := models.Threads{
 		{UUID: domain.GetUUID(), PostID: posts[0].ID},
+		{UUID: domain.GetUUID(), PostID: posts[1].ID},
 	}
 	for i := range threads {
 		createFixture(as, &threads[i])

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -219,7 +219,6 @@ type ComplexityRoot struct {
 		Messages           func(childComplexity int) int
 		Participants       func(childComplexity int) int
 		Post               func(childComplexity int) int
-		PostID             func(childComplexity int) int
 		UnreadMessageCount func(childComplexity int) int
 		UpdatedAt          func(childComplexity int) int
 	}
@@ -378,7 +377,6 @@ type ThreadResolver interface {
 	ID(ctx context.Context, obj *models.Thread) (string, error)
 	Participants(ctx context.Context, obj *models.Thread) ([]PublicProfile, error)
 	Messages(ctx context.Context, obj *models.Thread) ([]models.Message, error)
-	PostID(ctx context.Context, obj *models.Thread) (string, error)
 	Post(ctx context.Context, obj *models.Thread) (*models.Post, error)
 	LastViewedAt(ctx context.Context, obj *models.Thread) (*time.Time, error)
 
@@ -1456,13 +1454,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Thread.Post(childComplexity), true
 
-	case "Thread.postID":
-		if e.complexity.Thread.PostID == nil {
-			break
-		}
-
-		return e.complexity.Thread.PostID(childComplexity), true
-
 	case "Thread.unreadMessageCount":
 		if e.complexity.Thread.UnreadMessageCount == nil {
 			break
@@ -2222,7 +2213,6 @@ type Thread {
     id: ID!
     participants: [PublicProfile!]!
     messages: [Message!]!
-    postID: String!
     post: Post!
     lastViewedAt: Time!
     createdAt: Time!
@@ -7608,43 +7598,6 @@ func (ec *executionContext) _Thread_messages(ctx context.Context, field graphql.
 	return ec.marshalNMessage2ᚕgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMessage(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Thread_postID(ctx context.Context, field graphql.CollectedField, obj *models.Thread) (ret graphql.Marshaler) {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-		ec.Tracer.EndFieldExecution(ctx)
-	}()
-	rctx := &graphql.ResolverContext{
-		Object:   "Thread",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Thread().PostID(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _Thread_post(ctx context.Context, field graphql.CollectedField, obj *models.Thread) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -11963,20 +11916,6 @@ func (ec *executionContext) _Thread(ctx context.Context, sel ast.SelectionSet, o
 					}
 				}()
 				res = ec._Thread_messages(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "postID":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Thread_postID(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -155,10 +155,10 @@ type ComplexityRoot struct {
 	}
 
 	OrganizationDomain struct {
-		AuthConfig     func(childComplexity int) int
-		AuthType       func(childComplexity int) int
-		Domain         func(childComplexity int) int
-		OrganizationID func(childComplexity int) int
+		AuthConfig   func(childComplexity int) int
+		AuthType     func(childComplexity int) int
+		Domain       func(childComplexity int) int
+		Organization func(childComplexity int) int
 	}
 
 	Post struct {
@@ -331,7 +331,7 @@ type OrganizationResolver interface {
 	TrustedOrganizations(ctx context.Context, obj *models.Organization) ([]models.Organization, error)
 }
 type OrganizationDomainResolver interface {
-	OrganizationID(ctx context.Context, obj *models.OrganizationDomain) (string, error)
+	Organization(ctx context.Context, obj *models.OrganizationDomain) (*models.Organization, error)
 }
 type PostResolver interface {
 	ID(ctx context.Context, obj *models.Post) (string, error)
@@ -1076,12 +1076,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrganizationDomain.Domain(childComplexity), true
 
-	case "OrganizationDomain.organizationID":
-		if e.complexity.OrganizationDomain.OrganizationID == nil {
+	case "OrganizationDomain.organization":
+		if e.complexity.OrganizationDomain.Organization == nil {
 			break
 		}
 
-		return e.complexity.OrganizationDomain.OrganizationID(childComplexity), true
+		return e.complexity.OrganizationDomain.Organization(childComplexity), true
 
 	case "Post.completedOn":
 		if e.complexity.Post.CompletedOn == nil {
@@ -2062,7 +2062,7 @@ input UpdateOrganizationInput {
 
 type OrganizationDomain {
     domain: String!
-    organizationID: ID!
+    organization: Organization!
     authType: String!
     authConfig: String!
 }
@@ -5749,7 +5749,7 @@ func (ec *executionContext) _OrganizationDomain_domain(ctx context.Context, fiel
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _OrganizationDomain_organizationID(ctx context.Context, field graphql.CollectedField, obj *models.OrganizationDomain) (ret graphql.Marshaler) {
+func (ec *executionContext) _OrganizationDomain_organization(ctx context.Context, field graphql.CollectedField, obj *models.OrganizationDomain) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
 		if r := recover(); r != nil {
@@ -5768,7 +5768,7 @@ func (ec *executionContext) _OrganizationDomain_organizationID(ctx context.Conte
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.OrganizationDomain().OrganizationID(rctx, obj)
+		return ec.resolvers.OrganizationDomain().Organization(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5780,10 +5780,10 @@ func (ec *executionContext) _OrganizationDomain_organizationID(ctx context.Conte
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*models.Organization)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐOrganization(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _OrganizationDomain_authType(ctx context.Context, field graphql.CollectedField, obj *models.OrganizationDomain) (ret graphql.Marshaler) {
@@ -11312,7 +11312,7 @@ func (ec *executionContext) _OrganizationDomain(ctx context.Context, sel ast.Sel
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "organizationID":
+		case "organization":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
 				defer func() {
@@ -11320,7 +11320,7 @@ func (ec *executionContext) _OrganizationDomain(ctx context.Context, sel ast.Sel
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._OrganizationDomain_organizationID(ctx, field, obj)
+				res = ec._OrganizationDomain_organization(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/application/gqlgen/gqlgen.yml
+++ b/application/gqlgen/gqlgen.yml
@@ -78,7 +78,7 @@ models:
   OrganizationDomain:
     model: models.OrganizationDomain
     fields:
-      organizationID:
+      organization:
         resolver: true
   Post:
     model: models.Post

--- a/application/gqlgen/organizationdomain.go
+++ b/application/gqlgen/organizationdomain.go
@@ -14,16 +14,18 @@ func (r *Resolver) OrganizationDomain() OrganizationDomainResolver {
 
 type organizationDomainResolver struct{ *Resolver }
 
-// OrganizationID converts the organization's autoincrement ID to its UUID
-func (r *organizationDomainResolver) OrganizationID(ctx context.Context, obj *models.OrganizationDomain) (string, error) {
+// Organization associated with the domain
+func (r *organizationDomainResolver) Organization(ctx context.Context, obj *models.OrganizationDomain) (
+	*models.Organization, error) {
+
 	if obj == nil {
-		return "", nil
+		return nil, nil
 	}
 
-	id, err := obj.GetOrganizationUUID()
+	organization, err := obj.Organization()
 	if err != nil {
-		return "", domain.ReportError(ctx, err, "GetOrganizationDomainOrganizationID")
+		return nil, domain.ReportError(ctx, err, "GetOrganizationDomainOrganization")
 	}
 
-	return id, nil
+	return &organization, nil
 }

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -536,7 +536,6 @@ type Thread {
     id: ID!
     participants: [PublicProfile!]!
     messages: [Message!]!
-    postID: String!
     post: Post!
     lastViewedAt: Time!
     createdAt: Time!

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -560,7 +560,7 @@ type User {
     avatarURL: String
     "`File` ID of the user's photo, if present"
     photoID: String
-    preferences: UserPreferences
+    preferences: UserPreferences!
     "user's home location"
     location: Location
     unreadMessageCount: Int!
@@ -591,9 +591,9 @@ input UpdateUserInput {
 }
 
 type UserPreferences {
-    language: String
+    language: PreferredLanguage
     timeZone: String
-    weightUnit: String
+    weightUnit: PreferredWeightUnit
 }
 
 input UpdateUserPreferencesInput {

--- a/application/gqlgen/schema.graphql
+++ b/application/gqlgen/schema.graphql
@@ -385,7 +385,7 @@ input UpdateOrganizationInput {
 
 type OrganizationDomain {
     domain: String!
-    organizationID: ID!
+    organization: Organization!
     authType: String!
     authConfig: String!
 }

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -113,11 +113,13 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 	return count, nil
 }
 
-// Threads retrieves the all of the threads
+// Threads retrieves all of the threads for the current user. It is a placeholder for an admin tool for retrieving
+// all threads for a specified user.
 func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
-	threads := models.Threads{}
+	currentUser := models.CurrentUser(ctx)
 
-	if err := threads.All(); err != nil {
+	threads, err := currentUser.GetThreads()
+	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreads")
 	}
 
@@ -130,10 +132,7 @@ func (r *queryResolver) MyThreads(ctx context.Context) ([]models.Thread, error) 
 
 	threads, err := currentUser.GetThreads()
 	if err != nil {
-		extras := map[string]interface{}{
-			"user": currentUser.UUID,
-		}
-		return nil, domain.ReportError(ctx, err, "GetMyThreads", extras)
+		return nil, domain.ReportError(ctx, err, "GetMyThreads")
 	}
 
 	return threads, nil

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -72,20 +72,6 @@ func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]mo
 	return messages, nil
 }
 
-// PostID retrieves the UUID of the post to which the queried thread belongs.
-func (r *threadResolver) PostID(ctx context.Context, obj *models.Thread) (string, error) {
-	if obj == nil {
-		return "", nil
-	}
-
-	post, err := obj.GetPost()
-	if err != nil {
-		return "", domain.ReportError(ctx, err, "GetThreadPostID")
-	}
-
-	return post.UUID.String(), nil
-}
-
 // Post retrieves the post to which the queried thread belongs.
 func (r *threadResolver) Post(ctx context.Context, obj *models.Thread) (*models.Post, error) {
 	if obj == nil {

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -242,18 +242,10 @@ func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*mode
 		return nil, nil
 	}
 
-	user := models.CurrentUser(ctx)
 	standardPrefs, err := obj.GetPreferences()
 	if err != nil {
-		extras := map[string]interface{}{
-			"user": user.UUID,
-		}
-		return nil, domain.ReportError(ctx, err, "GetUserPreferences", extras)
+		return nil, domain.ReportError(ctx, err, "GetUserPreferences")
 	}
-
-	// These have particular acceptable values, unlike TimeZone
-	standardPrefs.Language = strings.ToUpper(standardPrefs.Language)
-	standardPrefs.WeightUnit = strings.ToUpper(standardPrefs.WeightUnit)
 
 	return &standardPrefs, nil
 }
@@ -285,4 +277,20 @@ func getPublicProfile(ctx context.Context, user *models.User) *PublicProfile {
 		Nickname:  user.Nickname,
 		AvatarURL: url,
 	}
+}
+
+func (r *Resolver) UserPreferences() UserPreferencesResolver {
+	return &userPreferencesResolver{r}
+}
+
+type userPreferencesResolver struct{ *Resolver }
+
+func (u userPreferencesResolver) Language(ctx context.Context, obj *models.StandardPreferences) (*PreferredLanguage, error) {
+	language := PreferredLanguage(strings.ToUpper(obj.Language))
+	return &language, nil
+}
+
+func (u userPreferencesResolver) WeightUnit(ctx context.Context, obj *models.StandardPreferences) (*PreferredWeightUnit, error) {
+	unit := PreferredWeightUnit(strings.ToUpper(obj.WeightUnit))
+	return &unit, nil
 }

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -129,8 +129,8 @@
   translation: We had a problem finding the organization to remove a domain.
 - id: RemoveOrganizationDomain.Unauthorized
   translation: You are not allowed to remove domains from that organization.
-- id: GetOrganizationDomainOrganizationID
-  translation: We had a problem finding the organization ID for that domain.
+- id: GetOrganizationDomainOrganization
+  translation: We had a problem finding the organization for that domain.
 - id: GetOrganizationDomains
   translation: We had a problem finding the list of domains for the organization.
 

--- a/application/models/organizationdomain.go
+++ b/application/models/organizationdomain.go
@@ -10,14 +10,13 @@ import (
 )
 
 type OrganizationDomain struct {
-	ID             int          `json:"id" db:"id"`
-	CreatedAt      time.Time    `json:"created_at" db:"created_at"`
-	UpdatedAt      time.Time    `json:"updated_at" db:"updated_at"`
-	OrganizationID int          `json:"organization_id" db:"organization_id"`
-	Domain         string       `json:"domain" db:"domain"`
-	AuthType       string       `json:"auth_type" db:"auth_type"`
-	AuthConfig     string       `json:"auth_config" db:"auth_config"`
-	Organization   Organization `belongs_to:"organizations"`
+	ID             int       `json:"id" db:"id"`
+	CreatedAt      time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at" db:"updated_at"`
+	OrganizationID int       `json:"organization_id" db:"organization_id"`
+	Domain         string    `json:"domain" db:"domain"`
+	AuthType       string    `json:"auth_type" db:"auth_type"`
+	AuthConfig     string    `json:"auth_config" db:"auth_config"`
 }
 
 type OrganizationDomains []OrganizationDomain
@@ -35,15 +34,16 @@ func (o *OrganizationDomain) ValidateCreate(tx *pop.Connection) (*validate.Error
 	return validate.NewErrors(), nil
 }
 
-// GetOrganizationUUID loads the Organization record and converts its UUID to its string representation.
-func (o *OrganizationDomain) GetOrganizationUUID() (string, error) {
+// Organization loads the Organization record
+func (o *OrganizationDomain) Organization() (Organization, error) {
 	if o.OrganizationID <= 0 {
-		return "", errors.New("OrganizationID is not valid")
+		return Organization{}, errors.New("OrganizationID is not valid")
 	}
-	if err := DB.Load(o, "Organization"); err != nil {
-		return "", err
+	var organization Organization
+	if err := DB.Find(&organization, o.OrganizationID); err != nil {
+		return Organization{}, err
 	}
-	return o.Organization.UUID.String(), nil
+	return organization, nil
 }
 
 // Create stores the OrganizationDomain data as a new record in the database.

--- a/application/models/organizationdomain_test.go
+++ b/application/models/organizationdomain_test.go
@@ -2,15 +2,12 @@ package models
 
 import (
 	"testing"
-
-	"github.com/silinternational/wecarry-api/domain"
 )
 
-func (ms *ModelSuite) TestOrganizationDomain_GetOrganizationUUID() {
+func (ms *ModelSuite) TestOrganizationDomain_Organization() {
 	t := ms.T()
 
-	org := Organization{UUID: domain.GetUUID(), AuthConfig: "{}"}
-	createFixture(ms, &org)
+	org := createOrganizationFixtures(ms.DB, 1)[0]
 
 	orgDomain := OrganizationDomain{OrganizationID: org.ID, Domain: "example.com"}
 	createFixture(ms, &orgDomain)
@@ -18,13 +15,13 @@ func (ms *ModelSuite) TestOrganizationDomain_GetOrganizationUUID() {
 	tests := []struct {
 		name      string
 		orgDomain OrganizationDomain
-		want      string
+		want      Organization
 		wantErr   bool
 	}{
 		{
 			name:      "valid",
 			orgDomain: orgDomain,
-			want:      org.UUID.String(),
+			want:      org,
 		},
 		{
 			name:      "error",
@@ -35,7 +32,7 @@ func (ms *ModelSuite) TestOrganizationDomain_GetOrganizationUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			o := test.orgDomain
-			got, err := o.GetOrganizationUUID()
+			got, err := o.Organization()
 
 			if test.wantErr {
 				ms.Error(err)
@@ -43,7 +40,13 @@ func (ms *ModelSuite) TestOrganizationDomain_GetOrganizationUUID() {
 			}
 
 			ms.NoError(err)
-			ms.Equal(test.want, got)
+			ms.Equal(test.want.ID, got.ID)
+			ms.Equal(test.want.UUID, got.UUID)
+			ms.Equal(test.want.Name, got.Name)
+			ms.Equal(test.want.Url, got.Url)
+			ms.Equal(test.want.LogoFileID, got.LogoFileID)
+			ms.Equal(test.want.AuthType, got.AuthType)
+			ms.Equal(test.want.AuthConfig, got.AuthConfig)
 		})
 	}
 }

--- a/application/models/thread.go
+++ b/application/models/thread.go
@@ -56,11 +56,6 @@ func (t *Thread) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
-// All retrieves all Threads from the database.
-func (t *Threads) All() error {
-	return DB.Order("updated_at desc").All(t)
-}
-
 func (t *Thread) FindByUUID(uuid string) error {
 	if uuid == "" {
 		return errors.New("error: thread uuid must not be blank")


### PR DESCRIPTION
- Protect `threads` query with authorization so users only see their threads. Effectively makes `threads` and `myThreads` the same. Decided to keep them both, so `threads` can eventually be an admin tool.
- Change `organizationID` to `organization` on `OrganizationDomain` for consistency with other types
- Remove `postID` from `Thread`. It wasn't used and was redundant with `post`.
- Use enums for user preferences (language and weight units)