### PR TITLE
fix notification process for rejected potential providers

### DIFF
--- a/application/internal/test/test.go
+++ b/application/internal/test/test.go
@@ -218,7 +218,7 @@ type PotentialProvidersFixtures struct {
 // CreatePotentialProviderFixtures generates five PotentialProvider records for testing.
 // Five User and three Post fixtures will also be created.  The Posts will
 // all be created by the first user.
-// The first Post will have all but the first user as a potential provider.
+// The first Post will have all but the first and fifth user as a potential provider.
 // The second Post will have the last two users as potential providers.
 // The third Post won't have any potential providers.
 // The Fifth User will be with a different Organization.

--- a/application/listeners/posthelpers.go
+++ b/application/listeners/posthelpers.go
@@ -196,13 +196,19 @@ func sendRejectionToPotentialProvider(potentialProvider models.User, post models
 		ppEmail = "Missing Email"
 	}
 
+	receiver, err := post.GetReceiver()
+	if err != nil {
+		domain.ErrLogger.Printf("error getting Post Receiver for email data, %s", err)
+	}
+
 	data := map[string]interface{}{
-		"uiURL":      domain.Env.UIURL,
-		"appName":    domain.Env.AppName,
-		"postURL":    domain.GetPostUIURL(post.UUID.String()),
-		"postTitle":  domain.Truncate(post.Title, "...", 16),
-		"ppNickname": ppNickname,
-		"ppEmail":    ppEmail,
+		"uiURL":            domain.Env.UIURL,
+		"appName":          domain.Env.AppName,
+		"postURL":          domain.GetPostUIURL(post.UUID.String()),
+		"postTitle":        domain.Truncate(post.Title, "...", 16),
+		"ppNickname":       ppNickname,
+		"ppEmail":          ppEmail,
+		"receiverNickname": receiver.Nickname,
 	}
 
 	subject := "Email.Subject.Request.OfferRejected"
@@ -224,7 +230,6 @@ func sendRejectionToPotentialProvider(potentialProvider models.User, post models
 
 func sendNotificationRequestFromOpenToAccepted(params senderParams) {
 	sendNotificationRequestToProvider(params)
-
 	post := params.post
 
 	var providers models.PotentialProviders
@@ -235,7 +240,9 @@ func sendNotificationRequestFromOpenToAccepted(params senderParams) {
 	}
 
 	for _, u := range users {
-		sendRejectionToPotentialProvider(u, post)
+		if u.ID != post.ProviderID.Int {
+			sendRejectionToPotentialProvider(u, post)
+		}
 	}
 
 }
@@ -423,17 +430,17 @@ func sendPotentialProviderSelfDestroyedNotification(providerNickname string, req
 func sendPotentialProviderRejectedNotification(provider models.User, requester string, post models.Post) error {
 	msg := notifications.Message{
 		Subject: domain.GetTranslatedSubject(provider.GetLanguagePreference(),
-			"Email.Subject.Request.NewOffer", map[string]string{}),
+			"Email.Subject.Request.OfferRejected", map[string]string{}),
 		Template:  domain.MessageTemplatePotentialProviderRejected,
 		ToName:    provider.GetRealName(),
 		ToEmail:   provider.Email,
 		FromEmail: domain.EmailFromAddress(nil),
 		Data: map[string]interface{}{
-			"appName":           domain.Env.AppName,
-			"uiURL":             domain.Env.UIURL,
-			"postURL":           domain.GetPostUIURL(post.UUID.String()),
-			"postTitle":         domain.Truncate(post.Title, "...", 16),
-			"requesterNickname": requester,
+			"appName":          domain.Env.AppName,
+			"uiURL":            domain.Env.UIURL,
+			"postURL":          domain.GetPostUIURL(post.UUID.String()),
+			"postTitle":        domain.Truncate(post.Title, "...", 16),
+			"receiverNickname": requester,
 		},
 	}
 	return notifications.Send(msg)

--- a/application/notifications/dummy.go
+++ b/application/notifications/dummy.go
@@ -22,6 +22,10 @@ type dummyTemplate struct {
 	subject, body string
 }
 
+type DummyMessageInfo struct {
+	Subject, ToName, ToEmail string
+}
+
 var dummyTemplates = map[string]dummyTemplate{
 	domain.MessageTemplateNewRequest: {
 		subject: "new request",
@@ -165,4 +169,16 @@ func (t *DummyEmailService) GetLastBody() string {
 	}
 
 	return t.sentMessages[len(t.sentMessages)-1].body
+}
+
+func (t *DummyEmailService) GetSentMessages() []DummyMessageInfo {
+	messages := make([]DummyMessageInfo, len(t.sentMessages))
+	for i, m := range t.sentMessages {
+		messages[i] = DummyMessageInfo{
+			Subject: m.subject,
+			ToName:  m.toName,
+			ToEmail: m.toEmail,
+		}
+	}
+	return messages
 }

--- a/application/templates/mail/request_potentialprovider_rejected.plush.html
+++ b/application/templates/mail/request_potentialprovider_rejected.plush.html
@@ -1,5 +1,5 @@
 <h4><a href="<%= postURL %>"><%= postTitle %></a></h4>
 <p>
-    The requester, <%= requesterNickname %>, is not prepared to have you fulfill their request.
+    The requester, <%= receiverNickname %>, is not prepared to have you fulfill their request.
     You can send them a message at <a href="<%= postURL %>"><%= postURL %></a>, if you need clarification.
 </p>


### PR DESCRIPTION
Unfortunately, the emails getting created for the fixtures get leaked into the sent emails list after the sentEmails are emptied out. So, I had to check the results in a round-about way.