### PR TITLE
Remove omitted user preferences

### DIFF
--- a/application/actions/user_test.go
+++ b/application/actions/user_test.go
@@ -245,12 +245,10 @@ func (as *ActionSuite) TestUpdateUser() {
 				as.Equal("Paris, France", resp.User.Location.Description, "incorrect location")
 				as.Equal("FR", resp.User.Location.Country, "incorrect country")
 
-				as.Equal(strings.ToUpper(f.UserPreferences[0].Value), *resp.User.Preferences.Language,
-					"incorrect preference - language")
 				as.Equal(strings.ToUpper(domain.UserPreferenceWeightUnitKGs), *resp.User.Preferences.WeightUnit,
 					"incorrect preference - weightUnit")
-				as.Equal("America/New_York", *resp.User.Preferences.TimeZone,
-					"incorrect preference - timeZone")
+				as.Equal(strings.ToUpper(""), *resp.User.Preferences.Language, "incorrect preference - language")
+				as.Equal("", *resp.User.Preferences.TimeZone, "incorrect preference - timeZone")
 			},
 		},
 		{

--- a/application/actions/user_test.go
+++ b/application/actions/user_test.go
@@ -247,7 +247,7 @@ func (as *ActionSuite) TestUpdateUser() {
 
 				as.Equal(strings.ToUpper(domain.UserPreferenceWeightUnitKGs), *resp.User.Preferences.WeightUnit,
 					"incorrect preference - weightUnit")
-				as.Equal(strings.ToUpper(""), *resp.User.Preferences.Language, "incorrect preference - language")
+				as.Equal("", *resp.User.Preferences.Language, "incorrect preference - language")
 				as.Equal("", *resp.User.Preferences.TimeZone, "incorrect preference - timeZone")
 			},
 		},

--- a/application/actions/user_test.go
+++ b/application/actions/user_test.go
@@ -253,16 +253,16 @@ func (as *ActionSuite) TestUpdateUser() {
 		},
 		{
 			Name: "not allowed",
-			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v", location: %v}) {nickname}}`,
-				f.Users[0].UUID, location),
+			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v", location: %v}) {%s}}`,
+				f.Users[0].UUID, location, allUserFields),
 			TestUser:    f.Users[1],
 			Test:        func(t *testing.T) {},
 			ExpectError: "not allowed",
 		},
 		{
 			Name: "remove photo",
-			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v", location: %v}) {avatarURL}}`,
-				f.Users[1].UUID, location),
+			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v", location: %v, preferences: %s}) {%s}}`,
+				f.Users[1].UUID, location, preferences, allUserFields),
 			TestUser: f.Users[0],
 			Test: func(t *testing.T) {
 				as.Equal(f.Users[1].AuthPhotoURL.String, resp.User.AvatarURL, "expected photo to be deleted")
@@ -270,11 +270,20 @@ func (as *ActionSuite) TestUpdateUser() {
 		},
 		{
 			Name: "remove location",
-			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v"}) {location{description}}}`,
-				f.Users[1].UUID),
+			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v", preferences: %s}) {%s}}`,
+				f.Users[1].UUID, preferences, allUserFields),
 			TestUser: f.Users[0],
 			Test: func(t *testing.T) {
 				as.Nil(resp.User.Location, "expected location to be deleted")
+			},
+		},
+		{
+			Name: "remove preferences",
+			Payload: fmt.Sprintf(`mutation {user: updateUser(input:{id: "%v"}) {%s}}`,
+				f.Users[1].UUID, allUserFields),
+			TestUser: f.Users[0],
+			Test: func(t *testing.T) {
+				as.Equal("", *resp.User.Preferences.WeightUnit, "expected preferences to be deleted")
 			},
 		},
 	}

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -229,7 +229,6 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 		return nil, domain.ReportError(ctx, err, "UpdateUser.SetLocationError")
 	}
 
-	// No deleting of preferences supported at this time
 	if input.Preferences != nil {
 		standardPrefs, err := convertUserPreferencesToStandardPreferences(input.Preferences)
 
@@ -239,6 +238,10 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 
 		if _, err = user.UpdateStandardPreferences(standardPrefs); err != nil {
 			return nil, domain.ReportError(ctx, err, "UpdateUser.Preferences")
+		}
+	} else {
+		if err := user.RemovePreferences(); err != nil {
+			return nil, domain.ReportError(ctx, err, "UpdateUser.RemovePreferences")
 		}
 	}
 

--- a/application/gqlgen/user.go
+++ b/application/gqlgen/user.go
@@ -125,6 +125,21 @@ func (r *userResolver) UnreadMessageCount(ctx context.Context, obj *models.User)
 	return total, nil
 }
 
+// Preferences resolves the `preferences` property of the user query, retrieving the related records from the database
+// and using them to hydrate a StandardPreferences struct.
+func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*models.StandardPreferences, error) {
+	if obj == nil {
+		return nil, nil
+	}
+
+	standardPrefs, err := obj.GetPreferences()
+	if err != nil {
+		return nil, domain.ReportError(ctx, err, "GetUserPreferences")
+	}
+
+	return &standardPrefs, nil
+}
+
 // Users retrieves a list of users
 func (r *queryResolver) Users(ctx context.Context) ([]models.User, error) {
 	currentUser := models.CurrentUser(ctx)
@@ -238,21 +253,6 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input UpdateUserInput
 	}
 
 	return &user, nil
-}
-
-// Preferences resolves the `preferences` property of the user query, retrieving the related records from the database
-// and using them to hydrate a StandardPreferences struct.
-func (r *userResolver) Preferences(ctx context.Context, obj *models.User) (*models.StandardPreferences, error) {
-	if obj == nil {
-		return nil, nil
-	}
-
-	standardPrefs, err := obj.GetPreferences()
-	if err != nil {
-		return nil, domain.ReportError(ctx, err, "GetUserPreferences")
-	}
-
-	return &standardPrefs, nil
 }
 
 // getPublicProfiles converts a list of models.User to PublicProfile, hiding private profile information

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -263,6 +263,10 @@
   translation: Your user nickname must contain at least one visible character.
 - id: UpdateUser.DuplicateNickname
   translation: That user nickname is already taken.
+- id: UpdateUser.Preferences
+  translation: We had a problem while updating user preferences.
+- id: UpdateUser.RemovePreferences
+  translation: We had a problem while removing user preferences.
 
 # Request Post Status Transition email subjects
 - id: Email.Subject.Request.FromAcceptedToDelivered

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -790,3 +790,12 @@ func (u *User) CanCreateMeetingParticipant(ctx buffalo.Context, meeting Meeting)
 func (u *User) CanRemoveMeetingParticipant(ctx buffalo.Context, meeting Meeting) bool {
 	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }
+
+// RemovePreferences removes all of the users's preferences
+func (u *User) RemovePreferences() error {
+	if u == nil || u.ID < 1 {
+		return nil
+	}
+	var p UserPreference
+	return p.removeAll(u.ID)
+}

--- a/application/models/userpreference.go
+++ b/application/models/userpreference.go
@@ -185,6 +185,10 @@ func updateUsersStandardPreferences(user User, prefs StandardPreferences) error 
 	return nil
 }
 
+func (p *UserPreference) removeAll(userID int) error {
+	return DB.RawQuery("DELETE FROM user_preferences WHERE user_id = ?", userID).Exec()
+}
+
 func (p *UserPreference) remove(user User, key string) error {
 	if err := p.getForUser(user, key); err != nil {
 		return err

--- a/application/models/userpreference.go
+++ b/application/models/userpreference.go
@@ -36,8 +36,8 @@ type UserPreference struct {
 }
 
 // String can be helpful for serializing the model
-func (s UserPreference) String() string {
-	jm, _ := json.Marshal(s)
+func (p UserPreference) String() string {
+	jm, _ := json.Marshal(p)
 	return string(jm)
 }
 
@@ -163,15 +163,18 @@ func (p *UserPreference) updateForUserByKey(user User, key, value string) error 
 func updateUsersStandardPreferences(user User, prefs StandardPreferences) error {
 	fieldAndValidators := getPreferencesFieldsAndValidators(prefs)
 	for fieldName, fV := range fieldAndValidators {
+		var p UserPreference
+
 		if fV.fieldValue == "" {
+			if err := p.remove(user, fieldName); err != nil {
+				return fmt.Errorf("error removing preference %s, %s", fieldName, err)
+			}
 			continue
 		}
 
 		if !fV.validator(fV.fieldValue) {
 			return fmt.Errorf("unexpected UserPreference %s ... %s", fieldName, fV.fieldValue)
 		}
-
-		var p UserPreference
 
 		err := p.updateForUserByKey(user, fieldName, fV.fieldValue)
 		if err != nil {
@@ -180,4 +183,15 @@ func updateUsersStandardPreferences(user User, prefs StandardPreferences) error 
 	}
 
 	return nil
+}
+
+func (p *UserPreference) remove(user User, key string) error {
+	if err := p.getForUser(user, key); err != nil {
+		if domain.IsOtherThanNoRows(err) {
+			return err
+		}
+		return nil
+	}
+
+	return DB.Destroy(p)
 }

--- a/application/models/userpreference.go
+++ b/application/models/userpreference.go
@@ -187,11 +187,7 @@ func updateUsersStandardPreferences(user User, prefs StandardPreferences) error 
 
 func (p *UserPreference) remove(user User, key string) error {
 	if err := p.getForUser(user, key); err != nil {
-		if domain.IsOtherThanNoRows(err) {
-			return err
-		}
-		return nil
+		return err
 	}
-
 	return DB.Destroy(p)
 }


### PR DESCRIPTION
In keeping with project policy to remove properties omitted from mutation input, user preferences not specified will be removed. 