### PR TITLE
fix: can't send first message on a request

### DIFF
--- a/application/models/message.go
+++ b/application/models/message.go
@@ -157,7 +157,7 @@ func (m *Message) Create(ctx context.Context, postUUID string, threadUUID *strin
 	}
 
 	var thread Thread
-	if threadUUID != nil {
+	if threadUUID != nil && *threadUUID != "" {
 		err := thread.FindByUUID(*threadUUID)
 		if err != nil {
 			return errors.New("failed to find thread, " + err.Error())


### PR DESCRIPTION
The UI sends an empty string instead of null for the thread ID on the first message. This prevents creation of a new thread.