### PR TITLE
test optimization

### DIFF
--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -1,26 +1,125 @@
 package actions
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
-	"github.com/gobuffalo/packr/v2"
-	"github.com/gobuffalo/suite/v3"
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/httptest"
+	"github.com/gobuffalo/pop/v5"
+	"github.com/gorilla/sessions"
+	"github.com/silinternational/wecarry-api/domain"
+	"github.com/silinternational/wecarry-api/models"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 type ActionSuite struct {
-	*suite.Action
+	suite.Suite
+	*require.Assertions
+	App     *buffalo.App
+	DB      *pop.Connection
+	Session *buffalo.Session
+}
+
+// HTML creates an httptest.Request with HTML content type.
+func (as *ActionSuite) HTML(u string, args ...interface{}) *httptest.Request {
+	return httptest.New(as.App).HTML(u, args...)
+}
+
+// JSON creates an httptest.JSON request
+func (as *ActionSuite) JSON(u string, args ...interface{}) *httptest.JSON {
+	return httptest.New(as.App).JSON(u, args...)
 }
 
 func Test_ActionSuite(t *testing.T) {
-	action, err := suite.NewActionWithFixtures(App(), packr.New("Test_ActionSuite", "../fixtures"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	as := &ActionSuite{
-		Action: action,
+		App: App(),
+	}
+	c, err := pop.Connect("test")
+	if err == nil {
+		as.DB = c
 	}
 	suite.Run(t, as)
+}
+
+// SetupTest sets the test suite to abort on first failure and sets the session store
+func (as *ActionSuite) SetupTest() {
+	as.Assertions = require.New(as.T())
+
+	as.App.SessionStore = newSessionStore()
+	s, _ := as.App.SessionStore.New(nil, as.App.SessionName)
+	as.Session = &buffalo.Session{
+		Session: s,
+	}
+
+	as.DestroyAll()
+}
+
+func (as *ActionSuite) DestroyAll() {
+	// delete all Requests, RequestHistories, RequestFiles, PotentialProviders, Threads, and ThreadParticipants
+	var requests models.Requests
+	as.NoError(as.DB.All(&requests))
+	as.NoError(as.DB.Destroy(&requests))
+
+	// delete all Meetings, MeetingParticipants, and MeetingInvites
+	var meetings models.Meetings
+	as.NoError(as.DB.All(&meetings))
+	as.NoError(as.DB.Destroy(&meetings))
+
+	// delete all Organizations, OrganizationDomains, OrganizationTrusts, and UserOrganizations
+	var organizations models.Organizations
+	as.NoError(as.DB.All(&organizations))
+	as.NoError(as.DB.Destroy(&organizations))
+
+	// delete all Users, Messages, UserAccessTokens, and Watches
+	var users models.Users
+	as.NoError(as.DB.All(&users))
+	as.NoError(as.DB.Destroy(&users))
+
+	// delete all Files
+	var files models.Files
+	as.NoError(as.DB.All(&files))
+	as.NoError(as.DB.Destroy(&files))
+
+	// delete all Locations
+	var locations models.Locations
+	as.NoError(as.DB.All(&locations))
+	as.NoError(as.DB.Destroy(&locations))
+}
+
+// sessionStore copied from gobuffalo/suite session.go
+type sessionStore struct {
+	sessions map[string]*sessions.Session
+}
+
+func (s *sessionStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	if s, ok := s.sessions[name]; ok {
+		return s, nil
+	}
+	return s.New(r, name)
+}
+
+func (s *sessionStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	sess := sessions.NewSession(s, name)
+	s.sessions[name] = sess
+	return sess, nil
+}
+
+func (s *sessionStore) Save(r *http.Request, w http.ResponseWriter, sess *sessions.Session) error {
+	if s.sessions == nil {
+		s.sessions = map[string]*sessions.Session{}
+	}
+	s.sessions[sess.Name()] = sess
+	return nil
+}
+
+// NewSessionStore for action suite
+func newSessionStore() sessions.Store {
+	return &sessionStore{
+		sessions: map[string]*sessions.Session{},
+	}
 }
 
 func createFixture(as *ActionSuite, f interface{}) {

--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/gobuffalo/httptest"
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gorilla/sessions"
-	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/application/gqlgen/request.go
+++ b/application/gqlgen/request.go
@@ -147,7 +147,7 @@ func (r *requestResolver) Origin(ctx context.Context, obj *models.Request) (*mod
 	return origin, nil
 }
 
-// Threads resolves the `threads` property of the request query, retrieving the related records from the database.
+// Actions resolves the `actions` property of the request query, retrieving the related records from the database.
 func (r *requestResolver) Actions(ctx context.Context, obj *models.Request) ([]string, error) {
 	if obj == nil {
 		return []string{}, nil

--- a/application/internal/test/test.go
+++ b/application/internal/test/test.go
@@ -227,6 +227,12 @@ func CreatePotentialProvidersFixtures(tx *pop.Connection) PotentialProvidersFixt
 	requests := CreateRequestFixtures(tx, 3, false)
 	providers := models.PotentialProviders{}
 
+	// ensure the first user is actually the creator (timing issues tend to make this unreliable otherwise)
+	for i := range requests {
+		requests[i].CreatedByID = uf.Users[0].ID
+	}
+	tx.Update(&requests)
+
 	for i, r := range requests[:2] {
 		for _, u := range uf.Users[i+1 : 4] {
 			c := models.PotentialProvider{RequestID: r.ID, UserID: u.ID}

--- a/application/models/file_test.go
+++ b/application/models/file_test.go
@@ -240,7 +240,7 @@ func (ms *ModelSuite) TestFiles_FindByIDs() {
 			for i, ff := range f {
 				fileNames[i] = ff.Name
 			}
-			ms.Equal(tt.want, fileNames, "incorrect file names")
+			ms.ElementsMatch(tt.want, fileNames, "incorrect file names")
 		})
 	}
 }

--- a/application/models/testutils_test.go
+++ b/application/models/testutils_test.go
@@ -251,6 +251,12 @@ func createPotentialProvidersFixtures(ms *ModelSuite) potentialProvidersFixtures
 	requests := createRequestFixtures(ms.DB, 3, false)
 	providers := PotentialProviders{}
 
+	// ensure the first user is actually the creator (timing issues tend to make this unreliable otherwise)
+	for i := range requests {
+		requests[i].CreatedByID = uf.Users[0].ID
+	}
+	ms.DB.Update(&requests)
+
 	for i, p := range requests[:2] {
 		for _, u := range uf.Users[i+1:] {
 			c := PotentialProvider{RequestID: p.ID, UserID: u.ID}


### PR DESCRIPTION
Use custom test suites in `actions` and `models`. On my machine, it reduced test time from 103 seconds to 14 seconds on `actions` and from 386 seconds to 31 seconds on `models`. In the process, found a test issue that may come back to bite later. Should probably redesign the test fixture creation to look a bit more like TF. Specifically, pass users into request fixture generation functions to make sure that requests (etc.) are actually created by that user.