### PR TITLE
remove Eager() in UserAccessToken.FindByBearerToken

### DIFF
--- a/application/actions/auth.go
+++ b/application/actions/auth.go
@@ -637,13 +637,13 @@ func authDestroy(c buffalo.Context) error {
 		return logErrorAndRedirect(c, domain.ErrorFindingOrgForAccessToken, err.Error())
 	}
 
-	// set person on rollbar session
-	domain.RollbarSetPerson(c, uat.User.UUID.String(), uat.User.Nickname, uat.User.Email)
-
 	authUser, err := uat.GetUser()
 	if err != nil {
 		return logErrorAndRedirect(c, domain.ErrorAuthProvidersLogout, err.Error())
 	}
+
+	// set person on rollbar session
+	domain.RollbarSetPerson(c, authUser.UUID.String(), authUser.Nickname, authUser.Email)
 
 	authPro, err := org.GetAuthProvider(authUser.Email)
 	if err != nil {

--- a/application/models/useraccesstoken.go
+++ b/application/models/useraccesstoken.go
@@ -67,7 +67,7 @@ func (u *UserAccessToken) DeleteByBearerToken(bearerToken string) error {
 }
 
 func (u *UserAccessToken) FindByBearerToken(bearerToken string) error {
-	if err := DB.Eager().Where("access_token = ?", HashClientIdAccessToken(bearerToken)).First(u); err != nil {
+	if err := DB.Where("access_token = ?", HashClientIdAccessToken(bearerToken)).First(u); err != nil {
 		l := len(bearerToken)
 		if l > 5 {
 			l = 5

--- a/application/models/useraccesstoken_test.go
+++ b/application/models/useraccesstoken_test.go
@@ -88,16 +88,16 @@ func (ms *ModelSuite) TestUserAccessToken_DeleteByBearerToken() {
 func (ms *ModelSuite) TestUserAccessToken_FindByBearerToken() {
 	t := ms.T()
 
-	tokens, user := CreateUserAccessTokenFixtures(ms)
+	rawTokens, tokens := CreateUserAccessTokenFixtures(ms)
 
 	tests := []struct {
 		name    string
 		token   string
-		want    User
+		want    UserAccessToken
 		wantErr bool
 	}{
-		{name: "valid0", token: tokens[0], want: user},
-		{name: "valid1", token: tokens[1], want: user},
+		{name: "valid0", token: rawTokens[0], want: tokens[0]},
+		{name: "valid1", token: rawTokens[1], want: tokens[1]},
 		{name: "invalid", token: "000000", wantErr: true},
 		{name: "empty", token: "", wantErr: true},
 	}
@@ -106,21 +106,17 @@ func (ms *ModelSuite) TestUserAccessToken_FindByBearerToken() {
 			var u UserAccessToken
 			err := u.FindByBearerToken(test.token)
 			if test.wantErr {
-				if err == nil {
-					t.Errorf("Expected an error, but did not get one")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("FindByAccessToken() returned an error: %v", err)
-				} else if u.User.UUID != test.want.UUID {
-					t.Errorf("found %v, expected %v", u, test.want)
-				}
+				ms.Error(err)
+				return
 			}
+			ms.NoError(err)
+
+			ms.Equal(test.want.ID, u.ID)
 		})
 	}
 }
 
-func CreateUserAccessTokenFixtures(ms *ModelSuite) ([]string, User) {
+func CreateUserAccessTokenFixtures(ms *ModelSuite) ([]string, UserAccessTokens) {
 	uf := createUserFixtures(ms.DB, 1)
 	user := uf.Users[0]
 	userOrgs := uf.UserOrganizations
@@ -146,7 +142,7 @@ func CreateUserAccessTokenFixtures(ms *ModelSuite) ([]string, User) {
 		createFixture(ms, &tokens[i])
 	}
 
-	return rawTokens, user
+	return rawTokens, tokens
 }
 
 func CreateUserFixtures_GetOrg(ms *ModelSuite, t *testing.T) ([]Organization, Users, UserOrganizations) {


### PR DESCRIPTION
Only one of the two database queries was used, and in only one of the three places the function was called. This code executes at least once for every API query.