### PR TITLE
add tx into call chain

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -2,14 +2,15 @@ package actions
 
 import (
 	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo-pop/v2/pop/popmw"
 	i18n "github.com/gobuffalo/mw-i18n"
 	paramlogger "github.com/gobuffalo/mw-paramlogger"
 	"github.com/gobuffalo/packr/v2"
 	"github.com/gorilla/sessions"
 	"github.com/rs/cors"
-
 	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/listeners"
+	"github.com/silinternational/wecarry-api/models"
 )
 
 var app *buffalo.App
@@ -44,6 +45,9 @@ func App() *buffalo.App {
 		})
 
 		registerCustomErrorHandler(app)
+
+		// Wraps each request in a transaction.
+		app.Use(popmw.Transaction(models.DB))
 
 		// Initialize and attach "rollbar" to context
 		app.Use(domain.RollbarMiddleware)

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"github.com/gobuffalo/buffalo"
-	"github.com/gobuffalo/buffalo-pop/v2/pop/popmw"
 	i18n "github.com/gobuffalo/mw-i18n"
 	paramlogger "github.com/gobuffalo/mw-paramlogger"
 	"github.com/gobuffalo/packr/v2"
@@ -10,7 +9,6 @@ import (
 	"github.com/rs/cors"
 	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/listeners"
-	"github.com/silinternational/wecarry-api/models"
 )
 
 var app *buffalo.App
@@ -45,9 +43,6 @@ func App() *buffalo.App {
 		})
 
 		registerCustomErrorHandler(app)
-
-		// Wraps each request in a transaction.
-		app.Use(popmw.Transaction(models.DB))
 
 		// Initialize and attach "rollbar" to context
 		app.Use(domain.RollbarMiddleware)

--- a/application/actions/auth_fixtures_test.go
+++ b/application/actions/auth_fixtures_test.go
@@ -34,7 +34,7 @@ func createFixturesForAuthInvite(as *ActionSuite) meetingFixtures {
 	err := aws.CreateS3Bucket()
 	as.NoError(err, "failed to create S3 bucket, %s", err)
 
-	fileFixture := test.CreateFileFixture()
+	fileFixture := test.CreateFileFixture(as.DB)
 
 	meetings := make(models.Meetings, 2)
 	meetings[1].FileID = nulls.NewInt(fileFixture.ID)
@@ -222,7 +222,7 @@ func createFixturesForEnsureMeetingParticipant(as *ActionSuite) meetingFixtures 
 	err := aws.CreateS3Bucket()
 	as.NoError(err, "failed to create S3 bucket, %s", err)
 
-	fileFixture := test.CreateFileFixture()
+	fileFixture := test.CreateFileFixture(as.DB)
 
 	meetings := make(models.Meetings, 2)
 	meetings[1].FileID = nulls.NewInt(fileFixture.ID)

--- a/application/actions/auth_test.go
+++ b/application/actions/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/logger"
+	"github.com/silinternational/wecarry-api/internal/test"
 
 	"github.com/silinternational/wecarry-api/auth"
 	"github.com/silinternational/wecarry-api/domain"
@@ -410,13 +411,13 @@ func (as *ActionSuite) Test_newAuthUser() {
 	}
 
 	var user models.User
-	err := user.FindOrCreateFromAuthUser(orgFixture.ID, &authUser)
+	err := user.FindOrCreateFromAuthUser(test.Ctx(), orgFixture.ID, &authUser)
 	if err != nil {
 		t.Errorf("could not run test because of error calling user.FindOrCreateFromAuthUser ...\n %v", err)
 		return
 	}
 
-	resultsAuthUser, err := newOrgBasedAuthUser("12345678", user, orgFixture)
+	resultsAuthUser, err := newOrgBasedAuthUser(test.Ctx(), "12345678", user, orgFixture)
 	if err != nil {
 		t.Errorf("unexpected error ... %v", err)
 		return

--- a/application/actions/authsocial.go
+++ b/application/actions/authsocial.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -132,7 +133,7 @@ func getSocialAuthOptions(authConfigs map[string]SocialAuthConfig) []authOption 
 // For non invite based ... based on a User in the database with a SocialAuthProvider value
 func finishAuthRequestForSocialUser(c buffalo.Context, authEmail string) error {
 	var user models.User
-	if err := user.FindByEmail(models.DB, authEmail); err != nil {
+	if err := user.FindByEmail(models.Tx(c), authEmail); err != nil {
 		authErr := authError{
 			httpStatus: http.StatusInternalServerError,
 			errorKey:   domain.ErrorFindingUserByEmail,
@@ -280,7 +281,7 @@ func socialLoginNonInviteBasedAuthCallback(c buffalo.Context, authEmail, authTyp
 	domain.NewExtra(c, "authType", authType)
 
 	var user models.User
-	if err := user.FindByEmailAndSocialAuthProvider(models.DB, authEmail, authType); err != nil {
+	if err := user.FindByEmailAndSocialAuthProvider(models.Tx(c), authEmail, authType); err != nil {
 		return logErrorAndRedirect(c, domain.ErrorGettingSocialAuthUser,
 			fmt.Sprintf("error loading social auth user for '%s' ... %v", authType, err))
 	}
@@ -290,7 +291,7 @@ func socialLoginNonInviteBasedAuthCallback(c buffalo.Context, authEmail, authTyp
 		return logErrorAndRedirect(c, callbackValues.errCode, callbackValues.errMsg)
 	}
 
-	authUser, err := newOrglessAuthUser(clientID, user)
+	authUser, err := newOrglessAuthUser(c, clientID, user)
 	if err != nil {
 		return err
 	}
@@ -338,7 +339,7 @@ func socialLoginBasedAuthCallback(c buffalo.Context, authEmail, clientID string)
 		dealWithInviteFromCallback(c, inviteType, inviteObjectUUID, user)
 	}
 
-	authUser, err := newOrglessAuthUser(clientID, user)
+	authUser, err := newOrglessAuthUser(c, clientID, user)
 	if err != nil {
 		return err
 	}
@@ -350,8 +351,8 @@ func socialLoginBasedAuthCallback(c buffalo.Context, authEmail, clientID string)
 }
 
 // Hydrates an AuthUser struct based on a User without an Org
-func newOrglessAuthUser(clientID string, user models.User) (AuthUser, error) {
-	accessToken, expiresAt, err := user.CreateOrglessAccessToken(models.DB, clientID)
+func newOrglessAuthUser(ctx context.Context, clientID string, user models.User) (AuthUser, error) {
+	accessToken, expiresAt, err := user.CreateOrglessAccessToken(models.Tx(ctx), clientID)
 	if err != nil {
 		return AuthUser{}, err
 	}

--- a/application/actions/authsocial_test.go
+++ b/application/actions/authsocial_test.go
@@ -143,7 +143,7 @@ func (as *ActionSuite) Test_newOrglessAuthUser() {
 	uf := test.CreateUserFixtures(as.DB, 2)
 	user := uf.Users[0]
 
-	resultsAuthUser, err := newOrglessAuthUser("12345678", user)
+	resultsAuthUser, err := newOrglessAuthUser(test.Ctx(), "12345678", user)
 	as.NoError(err)
 
 	got := resultsAuthUser

--- a/application/actions/gql.go
+++ b/application/actions/gql.go
@@ -7,7 +7,6 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/gobuffalo/buffalo"
-	"github.com/gobuffalo/pop/v5"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"github.com/silinternational/wecarry-api/dataloader"
@@ -16,8 +15,6 @@ import (
 )
 
 func gqlHandler(c buffalo.Context) error {
-	gqlSuccess := true
-
 	body, err := ioutil.ReadAll(c.Request().Body)
 	if err == nil {
 		c.Logger().Debugf("request body: %s", body)
@@ -30,24 +27,10 @@ func gqlHandler(c buffalo.Context) error {
 	server.SetErrorPresenter(func(ctx context.Context, e error) *gqlerror.Error {
 		err := graphql.DefaultErrorPresenter(ctx, e)
 		domain.Error(c, "graphql error: "+err.Error())
-		gqlSuccess = false
 		return err
 	})
 
 	server.ServeHTTP(c.Response(), c.Request().WithContext(newCtx))
-
-	if !gqlSuccess {
-		domain.ErrLogger.Printf("error, rolling back tx in GQLHandler")
-		return nil
-	}
-
-	tx, ok := c.Value("tx").(*pop.Connection)
-	if !ok {
-		domain.ErrLogger.Printf("no transaction found in GQLHandler")
-	}
-	if err := tx.TX.Commit(); err != nil {
-		domain.ErrLogger.Printf("database commit failed, %s", err)
-	}
 
 	return nil
 }

--- a/application/actions/meeting_fixtures_test.go
+++ b/application/actions/meeting_fixtures_test.go
@@ -95,7 +95,7 @@ func createFixturesForMeetings(as *ActionSuite) meetingQueryFixtures {
 		},
 	}
 	for i := range invites {
-		as.NoError(invites[i].Create())
+		as.NoError(invites[i].Create(test.Ctx()))
 	}
 
 	participants := models.MeetingParticipants{

--- a/application/actions/meeting_fixtures_test.go
+++ b/application/actions/meeting_fixtures_test.go
@@ -26,7 +26,7 @@ func createFixturesForMeetings(as *ActionSuite) meetingQueryFixtures {
 	err := aws.CreateS3Bucket()
 	as.NoError(err, "failed to create S3 bucket, %s", err)
 
-	fileFixture := test.CreateFileFixture()
+	fileFixture := test.CreateFileFixture(as.DB)
 
 	meetings := models.Meetings{
 		{

--- a/application/actions/meeting_test.go
+++ b/application/actions/meeting_test.go
@@ -122,7 +122,7 @@ func (as *ActionSuite) Test_MeetingQuery() {
 	as.Equal(testMtg.EndDate.Format(domain.DateFormat), gotMtg.EndDate,
 		"incorrect meeting EndDate")
 
-	image, err := testMtg.ImageFile()
+	image, err := testMtg.ImageFile(as.DB)
 	as.NoError(err, "unexpected error getting ImageFile")
 	wantUUID := ""
 	if image != nil {
@@ -177,7 +177,7 @@ func (as *ActionSuite) Test_MeetingsQuery() {
 		as.Equal(wantMtg.EndDate.Format(domain.DateFormat), gotMtg.EndDate,
 			"incorrect meeting EndDate")
 
-		image, err := wantMtg.ImageFile()
+		image, err := wantMtg.ImageFile(as.DB)
 		as.NoError(err, "unexpected error getting ImageFile")
 		wantUUID := ""
 		if image != nil {

--- a/application/actions/message_test.go
+++ b/application/actions/message_test.go
@@ -1,5 +1,7 @@
 package actions
 
+import "github.com/silinternational/wecarry-api/internal/test"
+
 type messageResponse struct {
 	Message struct {
 		ID      string `json:"id"`
@@ -29,10 +31,10 @@ func (as *ActionSuite) TestMessageQuery() {
 	err := as.testGqlQuery(query, f.Users[0].Nickname, &resp)
 	as.NoError(err)
 
-	thread, err := f.Messages[0].GetThread()
+	thread, err := f.Messages[0].GetThread(as.DB)
 	as.NoError(err)
 
-	participants, err := thread.GetParticipants()
+	participants, err := thread.GetParticipants(as.DB)
 	as.NoError(err)
 	as.Equal(2, len(participants), "incorrect number of thread participants")
 
@@ -59,10 +61,10 @@ func (as *ActionSuite) TestCreateMessage() {
 	err := as.testGqlQuery(query, f.Users[0].Nickname, &resp)
 	as.NoError(err)
 
-	thread, err := f.Messages[0].GetThread()
+	thread, err := f.Messages[0].GetThread(as.DB)
 	as.NoError(err)
 
-	messages, err := thread.Messages()
+	messages, err := thread.Messages(test.Ctx())
 	as.NoError(err)
 	as.Equal(3, len(messages), "incorrect number of thread messages")
 

--- a/application/actions/organization_fixtures_test.go
+++ b/application/actions/organization_fixtures_test.go
@@ -43,7 +43,7 @@ func fixturesForCreateOrganization(as *ActionSuite) OrganizationFixtures {
 	users[0].AdminRole = models.UserAdminRoleSuperAdmin
 	as.NoError(as.DB.Save(&users[0]))
 
-	file := test.CreateFileFixture()
+	file := test.CreateFileFixture(as.DB)
 
 	return OrganizationFixtures{
 		Users:         users,
@@ -263,7 +263,7 @@ func fixturesForUpdateOrganization(as *ActionSuite) OrganizationFixtures {
 	users[0].AdminRole = models.UserAdminRoleSuperAdmin
 	as.NoError(as.DB.Save(&users[0]))
 
-	file := test.CreateFileFixture()
+	file := test.CreateFileFixture(as.DB)
 
 	return OrganizationFixtures{
 		Users:               users,
@@ -295,7 +295,7 @@ func fixturesForCreateTrust(as *ActionSuite) OrganizationFixtures {
 	users[1].AdminRole = models.UserAdminRoleAdmin
 	as.NoError(as.DB.Save(&users[1]))
 
-	file := test.CreateFileFixture()
+	file := test.CreateFileFixture(as.DB)
 
 	return OrganizationFixtures{
 		Users:         users,
@@ -330,7 +330,7 @@ func fixturesForRemoveTrust(as *ActionSuite) OrganizationFixtures {
 	users[1].AdminRole = models.UserAdminRoleAdmin
 	as.NoError(as.DB.Save(&users[1]))
 
-	file := test.CreateFileFixture()
+	file := test.CreateFileFixture(as.DB)
 
 	return OrganizationFixtures{
 		Users:         users,

--- a/application/actions/organization_fixtures_test.go
+++ b/application/actions/organization_fixtures_test.go
@@ -286,7 +286,7 @@ func fixturesForCreateTrust(as *ActionSuite) OrganizationFixtures {
 	}
 
 	trust := models.OrganizationTrust{PrimaryID: orgs[0].ID, SecondaryID: orgs[1].ID}
-	as.NoError(trust.CreateSymmetric())
+	as.NoError(trust.CreateSymmetric(as.DB))
 
 	userFixtures := test.CreateUserFixtures(as.DB, 2)
 	users := userFixtures.Users
@@ -320,8 +320,8 @@ func fixturesForRemoveTrust(as *ActionSuite) OrganizationFixtures {
 		{PrimaryID: orgs[0].ID, SecondaryID: orgs[1].ID},
 		{PrimaryID: orgs[0].ID, SecondaryID: orgs[2].ID},
 	}
-	as.NoError(trusts[0].CreateSymmetric())
-	as.NoError(trusts[1].CreateSymmetric())
+	as.NoError(trusts[0].CreateSymmetric(as.DB))
+	as.NoError(trusts[1].CreateSymmetric(as.DB))
 
 	userFixtures := test.CreateUserFixtures(as.DB, 2)
 	users := userFixtures.Users

--- a/application/actions/organization_test.go
+++ b/application/actions/organization_test.go
@@ -70,7 +70,7 @@ func (as *ActionSuite) Test_CreateOrganization() {
 	as.Equal(f.Organizations[1].AuthType, orgs[0].AuthType, "AuthType doesn't match")
 	as.Equal(f.Organizations[1].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
 
-	domains, _ := orgs[0].Domains()
+	domains, _ := orgs[0].Domains(test.Ctx())
 	as.Equal(0, len(domains), "new organization has unexpected domains")
 
 	as.Equal(resp.Organization.ID, orgs[0].UUID.String(), "UUID doesn't match")
@@ -453,7 +453,7 @@ func (as *ActionSuite) Test_UpdateOrganization() {
 	as.Equal(f.Organizations[0].Url, orgs[0].Url, "URL doesn't match")
 	as.Equal(f.Organizations[0].AuthType, orgs[0].AuthType, "AuthType doesn't match")
 	as.Equal(f.Organizations[0].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
-	dbDomains, _ := orgs[0].Domains()
+	dbDomains, _ := orgs[0].Domains(test.Ctx())
 	as.Equal(2, len(dbDomains), "updated organization has unexpected domains")
 	as.Equal(resp.Organization.ID, orgs[0].UUID.String(), "UUID from query doesn't match database")
 }

--- a/application/actions/organizationdomain_test.go
+++ b/application/actions/organizationdomain_test.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 
+	"github.com/silinternational/wecarry-api/internal/test"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -41,7 +42,7 @@ func (as *ActionSuite) Test_CreateUpdateOrganizationDomain() {
 	as.NoError(err)
 
 	as.GreaterOrEqual(1, len(orgs), "no Organization found")
-	domains, err := orgs[0].Domains()
+	domains, err := orgs[0].Domains(test.Ctx())
 	as.NoError(err)
 	as.Equal(1, len(domains), "wrong number of domains in DB")
 	as.Equal(testDomain, domains[0].Domain, "wrong domain in DB")

--- a/application/actions/request_fixtures_test.go
+++ b/application/actions/request_fixtures_test.go
@@ -70,7 +70,7 @@ func createFixturesForRequestQuery(as *ActionSuite) RequestQueryFixtures {
 
 	fileFixture := test.CreateFileFixture()
 
-	if _, err := requests[0].AttachFile(fileFixture.UUID.String()); err != nil {
+	if _, err := requests[0].AttachFile(as.DB, fileFixture.UUID.String()); err != nil {
 		t.Errorf("failed to attach file to request, %s", err)
 		t.FailNow()
 	}

--- a/application/actions/request_fixtures_test.go
+++ b/application/actions/request_fixtures_test.go
@@ -68,7 +68,7 @@ func createFixturesForRequestQuery(as *ActionSuite) RequestQueryFixtures {
 		t.FailNow()
 	}
 
-	fileFixture := test.CreateFileFixture()
+	fileFixture := test.CreateFileFixture(as.DB)
 
 	if _, err := requests[0].AttachFile(as.DB, fileFixture.UUID.String()); err != nil {
 		t.Errorf("failed to attach file to request, %s", err)
@@ -107,7 +107,7 @@ func createFixturesForUpdateRequest(as *ActionSuite) UpdateRequestFixtures {
 	requests[0].OriginID = nulls.Int{}
 	as.NoError(as.DB.Save(&requests[0]))
 
-	fileFixture := test.CreateFileFixture()
+	fileFixture := test.CreateFileFixture(as.DB)
 
 	return UpdateRequestFixtures{
 		Requests: requests,
@@ -127,7 +127,7 @@ func createFixturesForCreateRequest(as *ActionSuite) CreateRequestFixtures {
 		t.FailNow()
 	}
 
-	fileFixture := test.CreateFileFixture()
+	fileFixture := test.CreateFileFixture(as.DB)
 
 	meetingLocations := test.CreateLocationFixtures(as.DB, 1)
 

--- a/application/actions/thread_test.go
+++ b/application/actions/thread_test.go
@@ -50,10 +50,10 @@ func testThreadsQuery(as *ActionSuite, f threadQueryFixtures, query string) {
 	as.Equal(f.Users[1].Nickname, resp.Threads[0].Messages[0].Sender.Nickname)
 
 	thread := f.Threads[0]
-	err = thread.Load("Participants")
+	err = thread.Load(as.DB, "Participants")
 	as.NoError(err)
 
-	participants, err := thread.GetParticipants()
+	participants, err := thread.GetParticipants(as.DB)
 	as.NoError(err)
 	as.Equal(2, len(participants), "incorrect number of thread participants")
 

--- a/application/actions/upload.go
+++ b/application/actions/upload.go
@@ -61,7 +61,7 @@ func uploadHandler(c buffalo.Context) error {
 		Name:    f.Filename,
 		Content: content,
 	}
-	if fErr := fileObject.Store(); fErr != nil {
+	if fErr := fileObject.Store(models.Tx(c)); fErr != nil {
 		domain.Error(c, fmt.Sprintf("error storing uploaded file ... %v", fErr))
 		return c.Render(fErr.HttpStatus, render.JSON(domain.AppError{
 			Code: fErr.HttpStatus,

--- a/application/actions/user_fixtures_test.go
+++ b/application/actions/user_fixtures_test.go
@@ -75,7 +75,7 @@ func fixturesForUserQuery(as *ActionSuite) UserQueryFixtures {
 
 	f := test.CreateFileFixture()
 
-	_, err := users[1].AttachPhoto(f.UUID.String())
+	_, err := users[1].AttachPhoto(test.Ctx(), f.UUID.String())
 	as.NoError(err, "unexpected error attaching photo to user")
 
 	meetings := models.Meetings{

--- a/application/actions/user_fixtures_test.go
+++ b/application/actions/user_fixtures_test.go
@@ -73,7 +73,7 @@ func fixturesForUserQuery(as *ActionSuite) UserQueryFixtures {
 
 	as.NoError(aws.CreateS3Bucket(), "unexpected error creating S3 bucket")
 
-	f := test.CreateFileFixture()
+	f := test.CreateFileFixture(as.DB)
 
 	_, err := users[1].AttachPhoto(test.Ctx(), f.UUID.String())
 	as.NoError(err, "unexpected error attaching photo to user")

--- a/application/dataloader/loaders.go
+++ b/application/dataloader/loaders.go
@@ -2,6 +2,7 @@ package dataloader
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
@@ -47,7 +48,7 @@ func getFetchFileCallback() func([]int) ([]*models.File, []error) {
 
 		for i, id := range ids {
 			if obj, ok := objMap[id]; ok {
-				if err := obj.RefreshURL(); err != nil {
+				if err := obj.RefreshURL(models.DB); err != nil {
 					foundErr = true
 					errors[i] = err
 					continue
@@ -68,7 +69,7 @@ func getFetchFileCallback() func([]int) ([]*models.File, []error) {
 func getFetchLocationCallback() func([]int) ([]*models.Location, []error) {
 	return func(ids []int) ([]*models.Location, []error) {
 		objects := models.Locations{}
-		err := objects.FindByIDs(ids)
+		err := objects.FindByIDs(models.DB, ids)
 		if len(objects) == 0 {
 			return []*models.Location{}, convertErrToSlice(err)
 		}
@@ -93,7 +94,7 @@ func getFetchLocationCallback() func([]int) ([]*models.Location, []error) {
 func getFetchMeetingCallback() func([]int) ([]*models.Meeting, []error) {
 	return func(ids []int) ([]*models.Meeting, []error) {
 		objects := models.Meetings{}
-		err := objects.FindByIDs(ids)
+		err := objects.FindByIDs(models.DB, ids)
 		if len(objects) == 0 {
 			return []*models.Meeting{}, convertErrToSlice(err)
 		}
@@ -118,7 +119,7 @@ func getFetchMeetingCallback() func([]int) ([]*models.Meeting, []error) {
 func getFetchOrganizationCallback() func([]int) ([]*models.Organization, []error) {
 	return func(ids []int) ([]*models.Organization, []error) {
 		objects := models.Organizations{}
-		err := objects.FindByIDs(ids)
+		err := objects.FindByIDs(models.DB, ids)
 		if len(objects) == 0 {
 			return []*models.Organization{}, convertErrToSlice(err)
 		}
@@ -143,7 +144,7 @@ func getFetchOrganizationCallback() func([]int) ([]*models.Organization, []error
 func getFetchUserCallback() func([]int) ([]*models.User, []error) {
 	return func(ids []int) ([]*models.User, []error) {
 		objects := models.Users{}
-		err := objects.FindByIDs(ids)
+		err := objects.FindByIDs(models.DB, ids)
 		if len(objects) == 0 {
 			return []*models.User{}, convertErrToSlice(err)
 		}
@@ -198,5 +199,6 @@ func GetDataLoaderContext(c context.Context) context.Context {
 }
 
 func For(ctx context.Context) *Loaders {
+	fmt.Printf("---------------- For")
 	return ctx.Value(loadersKey).(*Loaders)
 }

--- a/application/dataloader/loaders.go
+++ b/application/dataloader/loaders.go
@@ -2,7 +2,6 @@ package dataloader
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/models"
@@ -199,6 +198,5 @@ func GetDataLoaderContext(c context.Context) context.Context {
 }
 
 func For(ctx context.Context) *Loaders {
-	fmt.Printf("---------------- For")
 	return ctx.Value(loadersKey).(*Loaders)
 }

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -446,7 +446,7 @@ func Error(ctx context.Context, msg string) {
 	// Doesn't have a BuffaloContext value, so it must be the actual BuffaloContext
 	bc = ctx.(buffalo.Context)
 
-	// Avoid panics running tests when c doesn't have the necessary nested methods
+	// Avoid panics running tests when bc doesn't have the necessary nested methods
 	logger := bc.Logger()
 	if logger == nil {
 		return

--- a/application/go.mod
+++ b/application/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-acme/lego v2.7.2+incompatible
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gobuffalo/buffalo v0.16.23
+	github.com/gobuffalo/buffalo-pop/v2 v2.0.4
 	github.com/gobuffalo/envy v1.9.0
 	github.com/gobuffalo/events v1.4.1
 	github.com/gobuffalo/fizz v1.13.0 // indirect

--- a/application/go.sum
+++ b/application/go.sum
@@ -366,7 +366,9 @@ github.com/gobuffalo/buffalo-pop v1.13.0/go.mod h1:h+zfyXCUFwihFqz6jmo9xsdsZ1Tm9
 github.com/gobuffalo/buffalo-pop v1.16.0/go.mod h1:XYA72cNFvL6m1o7PZ+Z7Yd/WDQTPcOiuDukiHvEo2KY=
 github.com/gobuffalo/buffalo-pop v1.17.2/go.mod h1:nyOm0mtmp9/+m2NaXrp+9SqtuKZslA7Ys2DBaT/t2n4=
 github.com/gobuffalo/buffalo-pop v1.22.0/go.mod h1:S8uJpbC9PUMFA6ZWbPnbk3c32n4vJ32p5NLsREcz+H8=
+github.com/gobuffalo/buffalo-pop v1.23.1 h1:AnxJQZu/ZN7HCm3L8YBJoNWc2UiwSe6UHv5S4DfXUDA=
 github.com/gobuffalo/buffalo-pop v1.23.1/go.mod h1:Sb+fy/hLtxfhOrtLAJiL7JsKqazydmAVqp5rcHio/yg=
+github.com/gobuffalo/buffalo-pop/v2 v2.0.4 h1:6vNx2vxKxkyDKcz1v5bVAfqknPqPmW3O92/XsSlvSwI=
 github.com/gobuffalo/buffalo-pop/v2 v2.0.4/go.mod h1:92Pr10dTvyrYR0YWUr0FLJLQDy3E4iliugKRpHPDDOc=
 github.com/gobuffalo/clara v0.4.1/go.mod h1:3QgAPqYgPqAzhfGbNLlp4UztaZRi2SOg+ZrZwaq9L94=
 github.com/gobuffalo/clara v0.6.0/go.mod h1:RKZxkcH80pLykRi2hLkoxGMxA8T06Dc9fN/pFvutMFY=

--- a/application/gqlgen/meeting.go
+++ b/application/gqlgen/meeting.go
@@ -156,7 +156,7 @@ func (r *meetingResolver) Organizers(ctx context.Context, obj *models.Meeting) (
 // end date in the future
 func (r *queryResolver) Meetings(ctx context.Context, endAfter, endBefore, startAfter, startBefore *string) ([]models.Meeting, error) {
 	meetings := models.Meetings{}
-	if err := meetings.FindOnOrAfterDate(ctx, time.Now()); err != nil {
+	if err := meetings.FindOnOrAfterDate(models.Tx(ctx), time.Now()); err != nil {
 		return nil, domain.ReportError(ctx, err, "GetMeetings")
 	}
 
@@ -167,7 +167,7 @@ func (r *queryResolver) Meetings(ctx context.Context, endAfter, endBefore, start
 // end date in the last <domain.RecentMeetingDelay> time period
 func (r *queryResolver) RecentMeetings(ctx context.Context) ([]models.Meeting, error) {
 	meetings := models.Meetings{}
-	if err := meetings.FindRecent(ctx, time.Now()); err != nil {
+	if err := meetings.FindRecent(models.Tx(ctx), time.Now()); err != nil {
 		return nil, domain.ReportError(ctx, err, "GetRecentMeetings")
 	}
 

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -43,7 +43,7 @@ func (r *messageResolver) Thread(ctx context.Context, obj *models.Message) (*mod
 		return &models.Thread{}, nil
 	}
 
-	thread, err := obj.GetThread()
+	thread, err := obj.GetThread(models.Tx(ctx))
 	if err != nil {
 		return &models.Thread{}, domain.ReportError(ctx, err, "GetMessageThread")
 	}
@@ -59,7 +59,7 @@ func (r *queryResolver) Message(ctx context.Context, id *string) (*models.Messag
 	currentUser := models.CurrentUser(ctx)
 	var message models.Message
 
-	if err := message.FindByUserAndUUID(currentUser, *id); err != nil {
+	if err := message.FindByUserAndUUID(ctx, currentUser, *id); err != nil {
 		return &models.Message{}, domain.ReportError(ctx, err, "GetMessage")
 	}
 

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -20,7 +20,7 @@ func (r *queryResolver) Organizations(ctx context.Context) ([]models.Organizatio
 
 	// get list of orgs that cUser is allowed to see
 	orgs := models.Organizations{}
-	if err := orgs.AllWhereUserIsOrgAdmin(cUser); err != nil {
+	if err := orgs.AllWhereUserIsOrgAdmin(ctx, cUser); err != nil {
 		return orgs, domain.ReportError(ctx, err, "ListOrganizations.Error")
 	}
 
@@ -32,11 +32,11 @@ func (r *queryResolver) Organization(ctx context.Context, id *string) (*models.O
 	domain.NewExtra(ctx, "orgUUID", *id)
 
 	org := &models.Organization{}
-	if err := org.FindByUUID(*id); err != nil {
+	if err := org.FindByUUID(models.Tx(ctx), *id); err != nil {
 		return org, domain.ReportError(ctx, err, "ViewOrganization.Error")
 	}
 
-	if org.ID != 0 && cUser.CanViewOrganization(org.ID) {
+	if org.ID != 0 && cUser.CanViewOrganization(ctx, org.ID) {
 		return org, nil
 	}
 
@@ -66,7 +66,7 @@ func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organiza
 		return nil, nil
 	}
 
-	domains, err := obj.Domains()
+	domains, err := obj.Domains(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationDomains")
 	}
@@ -80,7 +80,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *models.Organiza
 		return nil, nil
 	}
 
-	logoURL, err := obj.LogoURL()
+	logoURL, err := obj.LogoURL(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationLogoURL")
 	}
@@ -94,7 +94,7 @@ func (r *organizationResolver) TrustedOrganizations(ctx context.Context, obj *mo
 		return nil, nil
 	}
 
-	organizations, err := obj.TrustedOrganizations()
+	organizations, err := obj.TrustedOrganizations(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationTrustedOrganizations")
 	}

--- a/application/gqlgen/organizationdomain.go
+++ b/application/gqlgen/organizationdomain.go
@@ -22,7 +22,7 @@ func (r *organizationDomainResolver) Organization(ctx context.Context, obj *mode
 		return &models.Organization{}, nil
 	}
 
-	organization, err := obj.Organization()
+	organization, err := obj.Organization(ctx)
 	if err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "GetOrganizationDomainOrganization")
 	}

--- a/application/gqlgen/request.go
+++ b/application/gqlgen/request.go
@@ -473,7 +473,6 @@ func (r *mutationResolver) UpdateRequest(ctx context.Context, input requestInput
 			"UpdateRequest.NotEditable")
 	}
 
-	// TODO: move this to the end of the function? I did it back in 2019 but didn't make any not as to the reason
 	if err := request.Update(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest")
 	}

--- a/application/gqlgen/request.go
+++ b/application/gqlgen/request.go
@@ -26,11 +26,11 @@ func (r *queryResolver) Request(ctx context.Context, id *string) (*models.Reques
 	domain.NewExtra(ctx, "requestUUID", *id)
 
 	request := models.Request{}
-	if err := request.FindByUUID(*id); err != nil {
+	if err := request.FindByUUID(models.Tx(ctx), *id); err != nil {
 		return &request, domain.ReportError(ctx, err, "ViewRequest.Error")
 	}
 
-	if request.ID != 0 && cUser.CanViewRequest(request) {
+	if request.ID != 0 && cUser.CanViewRequest(ctx, request) {
 		return &request, nil
 	}
 
@@ -87,7 +87,7 @@ func (r *requestResolver) PotentialProviders(ctx context.Context, obj *models.Re
 		return nil, nil
 	}
 
-	providers, err := obj.GetPotentialProviders(models.CurrentUser(ctx))
+	providers, err := obj.GetPotentialProviders(ctx, models.CurrentUser(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetPotentialProviders")
 	}
@@ -176,7 +176,7 @@ func (r *requestResolver) Actions(ctx context.Context, obj *models.Request) ([]s
 
 	user := models.CurrentUser(ctx)
 
-	actions, err := obj.GetCurrentActions(user)
+	actions, err := obj.GetCurrentActions(ctx, user)
 	if err != nil {
 		return actions, domain.ReportError(ctx, err, "GetRequestActions")
 	}
@@ -191,7 +191,7 @@ func (r *requestResolver) Threads(ctx context.Context, obj *models.Request) ([]m
 	}
 
 	user := models.CurrentUser(ctx)
-	threads, err := obj.GetThreads(user)
+	threads, err := obj.GetThreads(ctx, user)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetRequestThreads")
 	}
@@ -247,7 +247,7 @@ func (r *requestResolver) PhotoID(ctx context.Context, obj *models.Request) (*st
 		return nil, nil
 	}
 
-	photoID, err := obj.GetPhotoID()
+	photoID, err := obj.GetPhotoID(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetUserPhotoID")
 	}
@@ -260,7 +260,7 @@ func (r *requestResolver) Files(ctx context.Context, obj *models.Request) ([]mod
 	if obj == nil {
 		return nil, nil
 	}
-	files, err := obj.GetFiles()
+	files, err := obj.GetFiles(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetRequestFiles")
 	}
@@ -291,7 +291,7 @@ func (r *requestResolver) IsEditable(ctx context.Context, obj *models.Request) (
 		return false, nil
 	}
 	cUser := models.CurrentUser(ctx)
-	return obj.IsEditable(cUser)
+	return obj.IsEditable(ctx, cUser)
 }
 
 // Requests resolves the `requests` query
@@ -338,7 +338,7 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 	request := models.Request{}
 
 	if input.ID != nil {
-		if err := request.FindByUUID(*input.ID); err != nil {
+		if err := request.FindByUUID(models.Tx(ctx), *input.ID); err != nil {
 			return request, err
 		}
 	} else {
@@ -349,7 +349,7 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 
 	if input.OrgID != nil {
 		var org models.Organization
-		err := org.FindByUUID(*input.OrgID)
+		err := org.FindByUUID(models.Tx(ctx), *input.OrgID)
 		if err != nil {
 			return models.Request{}, err
 		}
@@ -385,12 +385,12 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 
 	if input.PhotoID == nil {
 		if request.ID > 0 {
-			if err := request.RemoveFile(); err != nil {
+			if err := request.RemoveFile(ctx); err != nil {
 				return models.Request{}, err
 			}
 		}
 	} else {
-		if _, err := request.AttachPhoto(*input.PhotoID); err != nil {
+		if _, err := request.AttachPhoto(ctx, *input.PhotoID); err != nil {
 			return models.Request{}, err
 		}
 	}
@@ -399,7 +399,7 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 		request.MeetingID = nulls.Int{}
 	} else {
 		var meeting models.Meeting
-		if err := meeting.FindByUUID(*input.MeetingID); err != nil {
+		if err := meeting.FindByUUID(models.Tx(ctx), *input.MeetingID); err != nil {
 			return models.Request{}, fmt.Errorf("invalid meetingID, %s", err)
 		}
 		request.MeetingID = nulls.NewInt(meeting.ID)
@@ -436,18 +436,18 @@ func (r *mutationResolver) CreateRequest(ctx context.Context, input requestInput
 
 	if !request.MeetingID.Valid {
 		dest := convertLocation(*input.Destination)
-		if err = dest.Create(); err != nil {
+		if err = dest.Create(ctx); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest.SetDestination")
 		}
 		request.DestinationID = dest.ID
 	}
 
-	if err = request.Create(); err != nil {
+	if err = request.Create(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest")
 	}
 
 	if input.Origin != nil {
-		if err = request.SetOrigin(convertLocation(*input.Origin)); err != nil {
+		if err = request.SetOrigin(ctx, convertLocation(*input.Origin)); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest.SetOrigin")
 		}
 	}
@@ -465,30 +465,31 @@ func (r *mutationResolver) UpdateRequest(ctx context.Context, input requestInput
 	}
 
 	var dbRequest models.Request
-	_ = dbRequest.FindByID(request.ID)
-	if editable, err := dbRequest.IsEditable(cUser); err != nil {
+	_ = dbRequest.FindByID(models.Tx(ctx), request.ID)
+	if editable, err := dbRequest.IsEditable(ctx, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.GetEditable")
 	} else if !editable {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("attempt to update a non-editable request"),
 			"UpdateRequest.NotEditable")
 	}
 
-	if err := request.Update(); err != nil {
+	// TODO: move this to the end of the function? I did it back in 2019 but didn't make any not as to the reason
+	if err := request.Update(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest")
 	}
 
 	if input.Destination != nil {
-		if err := request.SetDestination(convertLocation(*input.Destination)); err != nil {
+		if err := request.SetDestination(ctx, convertLocation(*input.Destination)); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.SetDestination")
 		}
 	}
 
 	if input.Origin == nil {
-		if err := request.RemoveOrigin(); err != nil {
+		if err := request.RemoveOrigin(ctx); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.RemoveOrigin")
 		}
 	} else {
-		if err := request.SetOrigin(convertLocation(*input.Origin)); err != nil {
+		if err := request.SetOrigin(ctx, convertLocation(*input.Origin)); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.SetOrigin")
 		}
 	}
@@ -499,7 +500,7 @@ func (r *mutationResolver) UpdateRequest(ctx context.Context, input requestInput
 // UpdateRequestStatus resolves the `updateRequestStatus` mutation.
 func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input UpdateRequestStatusInput) (*models.Request, error) {
 	var request models.Request
-	if err := request.FindByUUID(input.ID); err != nil {
+	if err := request.FindByUUID(models.Tx(ctx), input.ID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequestStatus.FindRequest")
 	}
 
@@ -512,16 +513,16 @@ func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input Update
 			"UpdateRequestStatus.Unauthorized")
 	}
 
-	if err := request.SetProviderWithStatus(input.Status, input.ProviderUserID); err != nil {
+	if err := request.SetProviderWithStatus(ctx, input.Status, input.ProviderUserID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error setting provider with status: "+err.Error()),
 			"UpdateRequestStatus.SetProvider")
 	}
 
-	if err := request.Update(); err != nil {
+	if err := request.Update(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequestStatus")
 	}
 
-	if err := request.DestroyPotentialProviders(input.Status, cUser); err != nil {
+	if err := request.DestroyPotentialProviders(ctx, input.Status, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error destroying request's potential providers: "+err.Error()),
 			"UpdateRequestStatus.DestroyPotentialProviders")
 	}
@@ -531,9 +532,8 @@ func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input Update
 
 func (r *mutationResolver) AddMeAsPotentialProvider(ctx context.Context, requestID string) (*models.Request, error) {
 	cUser := models.CurrentUser(ctx)
-
 	var request models.Request
-	if err := request.FindByUUIDForCurrentUser(requestID, cUser); err != nil {
+	if err := request.FindByUUIDForCurrentUser(ctx, requestID, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "AddMeAsPotentialProvider.FindRequest")
 	}
 
@@ -544,12 +544,12 @@ func (r *mutationResolver) AddMeAsPotentialProvider(ctx context.Context, request
 	}
 
 	var provider models.PotentialProvider
-	if err := provider.NewWithRequestUUID(requestID, cUser.ID); err != nil {
+	if err := provider.NewWithRequestUUID(ctx, requestID, cUser.ID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error preparing potential provider: "+err.Error()),
 			"AddMeAsPotentialProvider")
 	}
 
-	if err := provider.Create(); err != nil {
+	if err := provider.Create(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error creating potential provider: "+err.Error()),
 			"AddMeAsPotentialProvider")
 	}
@@ -562,24 +562,24 @@ func (r *mutationResolver) RemoveMeAsPotentialProvider(ctx context.Context, requ
 
 	var provider models.PotentialProvider
 
-	if err := provider.FindWithRequestUUIDAndUserUUID(requestID, cUser.UUID.String(), cUser); err != nil {
+	if err := provider.FindWithRequestUUIDAndUserUUID(ctx, requestID, cUser.UUID.String(), cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
 			"RemoveMeAsPotentialProvider")
 	}
 
 	var request models.Request
-	if err := request.FindByUUID(requestID); err != nil {
+	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemoveMeAsPotentialProvider.FindRequest")
 	}
 
 	domain.NewExtra(ctx, "request", request.UUID)
 
-	if err := provider.Destroy(); err != nil {
+	if err := provider.Destroy(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error removing potential provider: "+err.Error()),
 			"RemoveMeAsPotentialProvider")
 	}
 
-	if err := request.FindByUUID(requestID); err != nil {
+	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemoveMeAsPotentialProvider.FindRequest")
 	}
 
@@ -588,27 +588,25 @@ func (r *mutationResolver) RemoveMeAsPotentialProvider(ctx context.Context, requ
 
 func (r *mutationResolver) RejectPotentialProvider(ctx context.Context, requestID, userID string) (*models.Request, error) {
 	cUser := models.CurrentUser(ctx)
-
 	var provider models.PotentialProvider
-
-	if err := provider.FindWithRequestUUIDAndUserUUID(requestID, userID, cUser); err != nil {
+	if err := provider.FindWithRequestUUIDAndUserUUID(ctx, requestID, userID, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
 			"RemovePotentialProvider")
 	}
 
 	var request models.Request
-	if err := request.FindByUUID(requestID); err != nil {
+	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemovePotentialProvider.FindRequest")
 	}
 
 	domain.NewExtra(ctx, "request", request.UUID)
 
-	if err := provider.Destroy(); err != nil {
+	if err := provider.Destroy(ctx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error removing potential provider: "+err.Error()),
 			"RemovePotentialProvider")
 	}
 
-	if err := request.FindByUUID(requestID); err != nil {
+	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemovePotentialProvider.FindRequest")
 	}
 

--- a/application/gqlgen/resolver.go
+++ b/application/gqlgen/resolver.go
@@ -43,7 +43,7 @@ func (m *meetingInviteResolver) Meeting(ctx context.Context, obj *models.Meeting
 		return nil, nil
 	}
 
-	mtg, err := obj.Meeting()
+	mtg, err := obj.Meeting(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "MeetingInvite.Meeting")
 	}
@@ -55,7 +55,7 @@ func (m *meetingInviteResolver) Inviter(ctx context.Context, obj *models.Meeting
 		return nil, nil
 	}
 
-	inviter, err := obj.Inviter()
+	inviter, err := obj.Inviter(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "MeetingInvite.Inviter")
 	}
@@ -76,7 +76,7 @@ func (m *meetingParticipantResolver) Meeting(ctx context.Context, obj *models.Me
 		return nil, nil
 	}
 
-	mtg, err := obj.Meeting()
+	mtg, err := obj.Meeting(ctx)
 	if err != nil {
 		domain.NewExtra(ctx, "meetingParticipant", *obj)
 		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Meeting")
@@ -89,7 +89,7 @@ func (m *meetingParticipantResolver) User(ctx context.Context, obj *models.Meeti
 		return nil, nil
 	}
 
-	user, err := obj.User()
+	user, err := obj.User(ctx)
 	if err != nil {
 		domain.NewExtra(ctx, "meetingParticipant", *obj)
 		return nil, domain.ReportError(ctx, err, "MeetingParticipant.User")
@@ -105,7 +105,7 @@ func (m *meetingParticipantResolver) Invite(ctx context.Context, obj *models.Mee
 		return nil, nil
 	}
 
-	inv, err := obj.Invite()
+	inv, err := obj.Invite(ctx)
 	if err != nil {
 		domain.NewExtra(ctx, "meetingParticipant", *obj)
 		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Invite")

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -23,7 +23,7 @@ func (r *threadResolver) Participants(ctx context.Context, obj *models.Thread) (
 		return nil, nil
 	}
 
-	participants, err := obj.GetParticipants()
+	participants, err := obj.GetParticipants(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreadParticipants")
 	}
@@ -46,7 +46,7 @@ func (r *threadResolver) LastViewedAt(ctx context.Context, obj *models.Thread) (
 	}
 
 	currentUser := models.CurrentUser(ctx)
-	lastViewedAt, err := obj.GetLastViewedAt(currentUser)
+	lastViewedAt, err := obj.GetLastViewedAt(ctx, currentUser)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreadLastViewedAt")
 	}
@@ -61,7 +61,7 @@ func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]mo
 		return nil, nil
 	}
 
-	messages, err := obj.Messages()
+	messages, err := obj.Messages(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreadMessages")
 	}
@@ -75,7 +75,7 @@ func (r *threadResolver) Request(ctx context.Context, obj *models.Thread) (*mode
 		return &models.Request{}, nil
 	}
 
-	request, err := obj.GetRequest()
+	request, err := obj.GetRequest(models.Tx(ctx))
 	if err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "GetThreadRequest")
 	}
@@ -90,21 +90,21 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 	}
 	user := models.CurrentUser(ctx)
 
-	lastViewedAt, err := obj.GetLastViewedAt(user)
+	lastViewedAt, err := obj.GetLastViewedAt(ctx, user)
 	if err != nil {
-		domain.Warn(domain.GetBuffaloContext(ctx), err.Error())
+		domain.Warn(ctx, err.Error())
 		return 0, nil
 	}
 
 	if lastViewedAt == nil {
-		domain.Warn(domain.GetBuffaloContext(ctx),
+		domain.Warn(ctx,
 			fmt.Sprintf("lastViewedAt nil for user %v on thread %v", user.ID, obj.ID))
 		return 0, nil
 	}
 
-	count, err2 := obj.UnreadMessageCount(user.ID, *lastViewedAt)
+	count, err2 := obj.UnreadMessageCount(ctx, user.ID, *lastViewedAt)
 	if err2 != nil {
-		domain.Warn(domain.GetBuffaloContext(ctx), err2.Error())
+		domain.Warn(ctx, err2.Error())
 		return 0, nil
 	}
 	return count, nil
@@ -115,7 +115,7 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
 	currentUser := models.CurrentUser(ctx)
 
-	threads, err := currentUser.GetThreads()
+	threads, err := currentUser.GetThreads(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreads")
 	}
@@ -127,7 +127,7 @@ func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
 func (r *queryResolver) MyThreads(ctx context.Context) ([]models.Thread, error) {
 	currentUser := models.CurrentUser(ctx)
 
-	threads, err := currentUser.GetThreads()
+	threads, err := currentUser.GetThreads(ctx)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetMyThreads")
 	}

--- a/application/gqlgen/user_test.go
+++ b/application/gqlgen/user_test.go
@@ -3,9 +3,9 @@ package gqlgen
 import (
 	"testing"
 
-	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/nulls"
 	"github.com/silinternational/wecarry-api/domain"
+	"github.com/silinternational/wecarry-api/internal/test"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -46,13 +46,12 @@ func (gs *GqlgenSuite) Test_getPublicProfile() {
 			want: &PublicProfile{},
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var ctx *buffalo.DefaultContext
-			profile := getPublicProfile(ctx, test.user)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := getPublicProfile(test.Ctx(), tt.user)
 
 			gs.NotNil(profile)
-			gs.Equal(test.want, profile, "incorrect profile")
+			gs.Equal(tt.want, profile, "incorrect profile")
 		})
 	}
 }

--- a/application/internal/test/test.go
+++ b/application/internal/test/test.go
@@ -116,7 +116,7 @@ func CreateRequestFixtures(tx *pop.Connection, n int, createFiles bool) models.R
 
 	var files models.Files
 	if createFiles {
-		files = CreateFileFixtures(n)
+		files = CreateFileFixtures(tx, n)
 	}
 
 	futureDate := time.Now().Add(4 * domain.DurationWeek)
@@ -163,21 +163,21 @@ func CreateLocationFixtures(tx *pop.Connection, n int) models.Locations {
 	return locations
 }
 
-func CreateFileFixtures(n int) models.Files {
+func CreateFileFixtures(tx *pop.Connection, n int) models.Files {
 	fileFixtures := make([]models.File, n)
 	for i := range fileFixtures {
-		fileFixtures[i] = CreateFileFixture()
+		fileFixtures[i] = CreateFileFixture(tx)
 	}
 	return fileFixtures
 }
 
-func CreateFileFixture() models.File {
+func CreateFileFixture(tx *pop.Connection) models.File {
 	// #nosec G404
 	f := models.File{
 		Name:    strconv.Itoa(rand.Int()) + ".gif",
 		Content: []byte("GIF89a"),
 	}
-	if err := f.Store(models.DB); err != nil {
+	if err := f.Store(tx); err != nil {
 		panic(fmt.Sprintf("failed to create file fixture, %s", err))
 	}
 	return f

--- a/application/job/job_test.go
+++ b/application/job/job_test.go
@@ -88,7 +88,7 @@ func (js *JobSuite) TestNewThreadMessageHandler() {
 
 			if test.wantNumberOfEmails == 1 {
 				var tp models.ThreadParticipant
-				_ = tp.FindByThreadIDAndUserID(test.message.ThreadID, test.recipientID)
+				_ = tp.FindByThreadIDAndUserID(js.DB, test.message.ThreadID, test.recipientID)
 				expect := time.Now()
 				js.WithinDuration(expect, tp.LastNotifiedAt, time.Second,
 					"last notified time not correct, got %v, wanted %v", tp.LastNotifiedAt, expect)

--- a/application/listeners/listeners.go
+++ b/application/listeners/listeners.go
@@ -185,7 +185,7 @@ func sendRequestStatusUpdatedNotification(e events.Event) {
 	pid := pEData.RequestID
 
 	request := models.Request{}
-	if err := request.FindByID(pid); err != nil {
+	if err := request.FindByID(models.DB, pid); err != nil {
 		domain.ErrLogger.Printf("unable to find request from event with id %v ... %s", pid, err)
 	}
 
@@ -204,11 +204,11 @@ func sendRequestCreatedNotifications(e events.Event) {
 	}
 
 	var request models.Request
-	if err := request.FindByID(eventData.RequestID); err != nil {
+	if err := request.FindByID(models.DB, eventData.RequestID); err != nil {
 		domain.ErrLogger.Printf("unable to find request %d from request-created event, %s", eventData.RequestID, err)
 	}
 
-	users, err := request.GetAudience()
+	users, err := request.GetAudience(models.DB)
 	if err != nil {
 		domain.ErrLogger.Printf("unable to get request audience in event listener: %s", err.Error())
 		return
@@ -229,16 +229,16 @@ func potentialProviderCreated(e events.Event) {
 	}
 
 	var potentialProvider models.User
-	if err := potentialProvider.FindByID(eventData.UserID); err != nil {
+	if err := potentialProvider.FindByID(models.DB, eventData.UserID); err != nil {
 		domain.ErrLogger.Printf("unable to find PotentialProvider User %d, %s", eventData.UserID, err)
 	}
 
 	var request models.Request
-	if err := request.FindByID(eventData.RequestID); err != nil {
+	if err := request.FindByID(models.DB, eventData.RequestID); err != nil {
 		domain.ErrLogger.Printf("unable to find request %d from PotentialProvider event, %s", eventData.RequestID, err)
 	}
 
-	creator, err := request.Creator()
+	creator, err := request.Creator(models.DB)
 	if err != nil {
 		domain.ErrLogger.Printf("unable to find request %d creator from PotentialProvider event, %s",
 			eventData.RequestID, err)
@@ -259,16 +259,16 @@ func potentialProviderSelfDestroyed(e events.Event) {
 	}
 
 	var potentialProvider models.User
-	if err := potentialProvider.FindByID(eventData.UserID); err != nil {
+	if err := potentialProvider.FindByID(models.DB, eventData.UserID); err != nil {
 		domain.ErrLogger.Printf("unable to find PotentialProvider User %d, %s", eventData.UserID, err)
 	}
 
 	var request models.Request
-	if err := request.FindByID(eventData.RequestID); err != nil {
+	if err := request.FindByID(models.DB, eventData.RequestID); err != nil {
 		domain.ErrLogger.Printf("unable to find request %d from PotentialProvider event, %s", eventData.RequestID, err)
 	}
 
-	creator, err := request.Creator()
+	creator, err := request.Creator(models.DB)
 	if err != nil {
 		domain.ErrLogger.Printf("unable to find request %d creator from PotentialProvider event, %s",
 			eventData.RequestID, err)
@@ -289,16 +289,16 @@ func potentialProviderRejected(e events.Event) {
 	}
 
 	var potentialProvider models.User
-	if err := potentialProvider.FindByID(eventData.UserID); err != nil {
+	if err := potentialProvider.FindByID(models.DB, eventData.UserID); err != nil {
 		domain.ErrLogger.Printf("unable to find PotentialProvider User %d, %s", eventData.UserID, err)
 	}
 
 	var request models.Request
-	if err := request.FindByID(eventData.RequestID); err != nil {
+	if err := request.FindByID(models.DB, eventData.RequestID); err != nil {
 		domain.ErrLogger.Printf("unable to find request %d from PotentialProvider event, %s", eventData.RequestID, err)
 	}
 
-	creator, err := request.Creator()
+	creator, err := request.Creator(models.DB)
 	if err != nil {
 		domain.ErrLogger.Printf("unable to find request %d creator from PotentialProvider event, %s",
 			eventData.RequestID, err)
@@ -312,7 +312,7 @@ func sendNewUserWelcome(user models.User) error {
 		return errors.New("'To' email address is required")
 	}
 
-	language := user.GetLanguagePreference()
+	language := user.GetLanguagePreference(models.DB)
 	subject := domain.GetTranslatedSubject(language, "Email.Subject.Welcome", map[string]string{})
 
 	msg := notifications.Message{

--- a/application/listeners/listeners_test.go
+++ b/application/listeners/listeners_test.go
@@ -156,11 +156,11 @@ func createFixturesForSendRequestCreatedNotifications(ms *ModelSuite) RequestFix
 	users := test.CreateUserFixtures(ms.DB, 3).Users
 
 	request := test.CreateRequestFixtures(ms.DB, 1, false)[0]
-	requestOrigin, err := request.GetOrigin()
+	requestOrigin, err := request.GetOrigin(ms.DB)
 	ms.NoError(err)
 
 	for i := range users {
-		ms.NoError(users[i].SetLocation(*requestOrigin))
+		ms.NoError(users[i].SetLocation(test.Ctx(), *requestOrigin))
 	}
 
 	return RequestFixtures{

--- a/application/listeners/requesthelpers_fixtures_test.go
+++ b/application/listeners/requesthelpers_fixtures_test.go
@@ -21,7 +21,7 @@ func CreateFixtures_GetRequestUsers(ms *ModelSuite, t *testing.T) orgUserRequest
 	org := userFixtures.Organization
 	users := userFixtures.Users
 
-	_, err := users[1].UpdateStandardPreferences(models.StandardPreferences{Language: domain.UserPreferenceLanguageFrench})
+	_, err := users[1].UpdateStandardPreferences(test.Ctx(), models.StandardPreferences{Language: domain.UserPreferenceLanguageFrench})
 
 	ms.NoError(err, "could not create language preference for user "+users[1].Nickname)
 
@@ -43,12 +43,12 @@ func CreateFixtures_RequestStatusUpdatedNotifications(ms *ModelSuite, t *testing
 	users := userFixtures.Users
 
 	tU := models.User{}
-	ms.NoError(tU.FindByID(users[1].ID))
+	ms.NoError(tU.FindByID(ms.DB, users[1].ID))
 
 	requests := test.CreateRequestFixtures(ms.DB, 2, false)
 	requests[0].Status = models.RequestStatusAccepted
 	requests[0].ProviderID = nulls.NewInt(users[1].ID)
-	ms.NoError(requests[0].Update())
+	ms.NoError(requests[0].Update(test.Ctx()))
 
 	return orgUserRequestFixtures{
 		orgs:     models.Organizations{org},
@@ -168,12 +168,12 @@ func createFixturesForTestSendNewRequestNotifications(ms *ModelSuite) orgUserReq
 	createFixture(ms, &org)
 
 	requests := test.CreateRequestFixtures(ms.DB, 1, false)
-	requestOrigin, err := requests[0].GetOrigin()
+	requestOrigin, err := requests[0].GetOrigin(ms.DB)
 	ms.NoError(err)
 
 	users := test.CreateUserFixtures(ms.DB, 3).Users
 	for i := range users {
-		ms.NoError(users[i].SetLocation(*requestOrigin))
+		ms.NoError(users[i].SetLocation(test.Ctx(), *requestOrigin))
 	}
 
 	return orgUserRequestFixtures{

--- a/application/listeners/requesthelpers_test.go
+++ b/application/listeners/requesthelpers_test.go
@@ -56,7 +56,7 @@ func (ms *ModelSuite) TestGetRequestUsers() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var request models.Request
-			err := request.FindByID(test.id)
+			err := request.FindByID(ms.DB, test.id)
 			ms.NoError(err, "error finding request for test")
 
 			requestUsers := getRequestUsers(request)

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -29,6 +29,8 @@
   translation: We had a problem finding the requests for the event
 - id: Meeting.Invites
   translation: We had a problem finding the invites for the event
+- id: Meeting.Organizers
+  translation: We had a problem finding the organizers for the event
 - id: Meeting.Participants
   translation: We had a problem finding the participants for the event
 - id: Meeting.UpdateImageFile

--- a/application/models/file_test.go
+++ b/application/models/file_test.go
@@ -117,7 +117,7 @@ func (ms *ModelSuite) TestFile_Store() {
 				Name:    tt.args.name,
 				Content: tt.args.content,
 			}
-			fErr := f.Store()
+			fErr := f.Store(ms.DB)
 			if tt.wantErr {
 				ms.NotNil(fErr)
 				ms.Equal(fErr.ErrorCode, tt.wantCode, "incorrect error type")
@@ -138,7 +138,7 @@ func (ms *ModelSuite) TestFile_FindByUUID() {
 		t.Errorf("failed to create S3 bucket, %s", err)
 		t.FailNow()
 	}
-	files := createFileFixtures(2)
+	files := createFileFixtures(ms.DB, 2)
 
 	type args struct {
 		fileUUID string
@@ -164,7 +164,7 @@ func (ms *ModelSuite) TestFile_FindByUUID() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var f File
-			err := f.FindByUUID(tt.args.fileUUID)
+			err := f.FindByUUID(ms.DB, tt.args.fileUUID)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected an error but did not get one")
@@ -189,7 +189,7 @@ func (ms *ModelSuite) TestFiles_FindByIDs() {
 		t.Errorf("failed to create S3 bucket, %s", err)
 		t.FailNow()
 	}
-	files := createFileFixtures(2)
+	files := createFileFixtures(ms.DB, 2)
 
 	tests := []struct {
 		name string
@@ -305,17 +305,17 @@ func (ms *ModelSuite) TestFiles_DeleteUnlinked() {
 		nUsers            = 2
 	)
 
-	_ = createFileFixtures(nOldUnlinkedFiles)
+	_ = createFileFixtures(ms.DB, nOldUnlinkedFiles)
 
 	ms.NoError(DB.RawQuery("UPDATE files set updated_at = ?", time.Now().Add(-5*domain.DurationWeek)).Exec())
 
-	_ = createFileFixtures(nNewUnlinkedFiles)
+	_ = createFileFixtures(ms.DB, nNewUnlinkedFiles)
 
 	requests := createRequestFixtures(ms.DB, nRequests, true)
 
-	requestFiles := createFileFixtures(nRequests)
+	requestFiles := createFileFixtures(ms.DB, nRequests)
 	for i, r := range requestFiles {
-		_, err := requests[i].AttachFile(r.UUID.String())
+		_, err := requests[i].AttachFile(ms.DB, r.UUID.String())
 		ms.NoError(err)
 	}
 
@@ -324,19 +324,19 @@ func (ms *ModelSuite) TestFiles_DeleteUnlinked() {
 	_ = createOrganizationFixtures(ms.DB, nOrganizations)
 
 	users := createUserFixtures(ms.DB, nUsers).Users
-	userPhotos := createFileFixtures(nUsers)
+	userPhotos := createFileFixtures(ms.DB, nUsers)
 	for i, u := range users {
-		_, err := u.AttachPhoto(userPhotos[i].UUID.String())
+		_, err := u.AttachPhoto(Ctx(), userPhotos[i].UUID.String())
 		ms.NoError(err)
 	}
 
 	f := Files{}
 
 	domain.Env.MaxFileDelete = 1
-	ms.Error(f.DeleteUnlinked())
+	ms.Error(f.DeleteUnlinked(ms.DB))
 
 	domain.Env.MaxFileDelete = 2
-	ms.NoError(f.DeleteUnlinked())
+	ms.NoError(f.DeleteUnlinked(ms.DB))
 	n, _ := DB.Count(&f)
 	ms.Equal(nRequests*2+nMeetings+nOrganizations+nUsers+nNewUnlinkedFiles, n, "wrong number of files remain")
 }

--- a/application/models/location.go
+++ b/application/models/location.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -80,13 +81,13 @@ func (v *geoValidator) IsValid(errors *validate.Errors) {
 }
 
 // Create stores the Location data as a new record in the database.
-func (l *Location) Create() error {
-	return create(l)
+func (l *Location) Create(ctx context.Context) error {
+	return create(Tx(ctx), l)
 }
 
 // Update writes the Location data to an existing database record.
-func (l *Location) Update() error {
-	return update(l)
+func (l *Location) Update(tx *pop.Connection) error {
+	return update(tx, l)
 }
 
 // DistanceKm calculates the distance in km between two locations
@@ -118,7 +119,7 @@ func (l *Location) IsNear(loc2 Location) bool {
 }
 
 // FindByIDs finds all Locations associated with the given IDs and loads them from the database
-func (l *Locations) FindByIDs(ids []int) error {
+func (l *Locations) FindByIDs(tx *pop.Connection, ids []int) error {
 	ids = domain.UniquifyIntSlice(ids)
-	return DB.Where("id in (?)", ids).All(l)
+	return tx.Where("id in (?)", ids).All(l)
 }

--- a/application/models/location_test.go
+++ b/application/models/location_test.go
@@ -149,7 +149,7 @@ func (ms *ModelSuite) TestLocation_Create() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.location.Create(); (err != nil) != tt.wantErr {
+			if err := tt.location.Create(Ctx()); (err != nil) != tt.wantErr {
 				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -382,7 +382,7 @@ func (ms *ModelSuite) TestLocations_FindByIDs() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var l Locations
-			err := l.FindByIDs(tt.ids)
+			err := l.FindByIDs(ms.DB, tt.ids)
 			ms.NoError(err)
 
 			got := make([]string, len(l))

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -1,11 +1,11 @@
 package models
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/nulls"
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/validate/v3"
@@ -97,12 +97,12 @@ func (v *dateValidator) IsValid(errors *validate.Errors) {
 }
 
 // FindByUUID finds a meeting by the UUID field and loads its CreatedBy field
-func (m *Meeting) FindByUUID(uuid string) error {
+func (m *Meeting) FindByUUID(tx *pop.Connection, uuid string) error {
 	if uuid == "" {
 		return errors.New("error finding meeting: uuid must not be blank")
 	}
 
-	if err := DB.Where("uuid = ?", uuid).First(m); err != nil {
+	if err := tx.Where("uuid = ?", uuid).First(m); err != nil {
 		return fmt.Errorf("error finding meeting by uuid: %s", err.Error())
 	}
 
@@ -115,11 +115,11 @@ func getOrdered(m *Meetings, q *pop.Query) error {
 
 // FindOnDate finds the meetings that have StartDate before timeInFocus-date and an EndDate after it
 // (inclusive on both)
-func (m *Meetings) FindOnDate(timeInFocus time.Time) error {
+func (m *Meetings) FindOnDate(tx *pop.Connection, timeInFocus time.Time) error {
 	date := timeInFocus.Format(domain.DateTimeFormat)
 	where := "start_date <= ? and end_date >= ?"
 
-	if err := getOrdered(m, DB.Where(where, date, date)); err != nil {
+	if err := getOrdered(m, tx.Where(where, date, date)); err != nil {
 		return fmt.Errorf("error finding meeting with start_date and end_date straddling %s ... %s",
 			date, err.Error())
 	}
@@ -128,10 +128,10 @@ func (m *Meetings) FindOnDate(timeInFocus time.Time) error {
 }
 
 // FindOnOrAfterDate finds the meetings that have an EndDate on or after the timeInFocus-date
-func (m *Meetings) FindOnOrAfterDate(timeInFocus time.Time) error {
+func (m *Meetings) FindOnOrAfterDate(ctx context.Context, timeInFocus time.Time) error {
 	date := timeInFocus.Format(domain.DateTimeFormat)
 
-	if err := getOrdered(m, DB.Where("end_date >= ?", date)); err != nil {
+	if err := getOrdered(m, Tx(ctx).Where("end_date >= ?", date)); err != nil {
 		return fmt.Errorf("error finding meeting with end_date before %s ... %s", date, err.Error())
 	}
 
@@ -139,10 +139,10 @@ func (m *Meetings) FindOnOrAfterDate(timeInFocus time.Time) error {
 }
 
 // FindAfterDate finds the meetings that have a StartDate after the timeInFocus-date
-func (m *Meetings) FindAfterDate(timeInFocus time.Time) error {
+func (m *Meetings) FindAfterDate(tx *pop.Connection, timeInFocus time.Time) error {
 	date := timeInFocus.Format(domain.DateTimeFormat)
 
-	if err := getOrdered(m, DB.Where("start_date > ?", date)); err != nil {
+	if err := getOrdered(m, tx.Where("start_date > ?", date)); err != nil {
 		return fmt.Errorf("error finding meeting with start_date after %s ... %s", date, err.Error())
 	}
 
@@ -151,12 +151,12 @@ func (m *Meetings) FindAfterDate(timeInFocus time.Time) error {
 
 // FindRecent finds the meetings that have an EndDate within the past <domain.RecentMeetingDelay> days
 // before timeInFocus-date (not inclusive)
-func (m *Meetings) FindRecent(timeInFocus time.Time) error {
+func (m *Meetings) FindRecent(ctx context.Context, timeInFocus time.Time) error {
 	yesterday := timeInFocus.Add(-domain.DurationDay).Format(domain.DateTimeFormat)
 	recentDate := timeInFocus.Add(-domain.RecentMeetingDelay)
 	where := "end_date between ? and ?"
 
-	if err := getOrdered(m, DB.Where(where, recentDate, yesterday)); err != nil {
+	if err := getOrdered(m, Tx(ctx).Where(where, recentDate, yesterday)); err != nil {
 		return fmt.Errorf("error finding meeting with end_date between %s and %s ... %s",
 			recentDate, yesterday, err.Error())
 	}
@@ -164,12 +164,12 @@ func (m *Meetings) FindRecent(timeInFocus time.Time) error {
 	return nil
 }
 
-func (m *Meeting) FindByInviteCode(code string) error {
+func (m *Meeting) FindByInviteCode(tx *pop.Connection, code string) error {
 	if code == "" {
 		return errors.New("error finding meeting: invite_code must not be blank")
 	}
 
-	if err := DB.Where("invite_code = ?", code).First(m); err != nil {
+	if err := tx.Where("invite_code = ?", code).First(m); err != nil {
 		return fmt.Errorf("error finding meeting by invite_code: %s", err.Error())
 	}
 
@@ -178,21 +178,21 @@ func (m *Meeting) FindByInviteCode(code string) error {
 
 // SetImageFile assigns a previously-stored File to this Meeting as its image. Parameter `fileID` is the UUID
 // of the image to attach.
-func (m *Meeting) SetImageFile(fileID string) (File, error) {
-	return addFile(m, fileID)
+func (m *Meeting) SetImageFile(ctx context.Context, fileID string) (File, error) {
+	return addFile(Tx(ctx), m, fileID)
 }
 
 // ImageFile retrieves the file attached as the Meeting Image
-func (m *Meeting) ImageFile() (*File, error) {
+func (m *Meeting) ImageFile(tx *pop.Connection) (*File, error) {
 	if !m.FileID.Valid {
 		return nil, nil
 	}
 	if m.ImgFile == nil {
-		if err := DB.Load(m, "ImgFile"); err != nil {
+		if err := tx.Load(m, "ImgFile"); err != nil {
 			return nil, err
 		}
 	}
-	if err := (*m.ImgFile).RefreshURL(); err != nil {
+	if err := (*m.ImgFile).RefreshURL(tx); err != nil {
 		return nil, err
 	}
 	f := *m.ImgFile
@@ -200,22 +200,22 @@ func (m *Meeting) ImageFile() (*File, error) {
 }
 
 // RemoveFile removes an attached file from the Meeting
-func (m *Meeting) RemoveFile() error {
-	return removeFile(m)
+func (m *Meeting) RemoveFile(ctx context.Context) error {
+	return removeFile(Tx(ctx), m)
 }
 
-func (m *Meeting) GetCreator() (*User, error) {
+func (m *Meeting) GetCreator(tx *pop.Connection) (*User, error) {
 	creator := User{}
-	if err := DB.Find(&creator, m.CreatedByID); err != nil {
+	if err := tx.Find(&creator, m.CreatedByID); err != nil {
 		return nil, err
 	}
 	return &creator, nil
 }
 
 // GetLocation returns the related Location object.
-func (m *Meeting) GetLocation() (Location, error) {
+func (m *Meeting) GetLocation(tx *pop.Connection) (Location, error) {
 	location := Location{}
-	if err := DB.Find(&location, m.LocationID); err != nil {
+	if err := tx.Find(&location, m.LocationID); err != nil {
 		return location, err
 	}
 
@@ -223,20 +223,20 @@ func (m *Meeting) GetLocation() (Location, error) {
 }
 
 // Create stores the Meeting data as a new record in the database.
-func (m *Meeting) Create() error {
-	return create(m)
+func (m *Meeting) Create(ctx context.Context) error {
+	return create(Tx(ctx), m)
 }
 
 // Update writes the Meeting data to an existing database record.
-func (m *Meeting) Update() error {
-	return update(m)
+func (m *Meeting) Update(ctx context.Context) error {
+	return update(Tx(ctx), m)
 }
 
 // SetLocation sets the location field, creating a new record in the database if necessary.
-func (m *Meeting) SetLocation(location Location) error {
+func (m *Meeting) SetLocation(ctx context.Context, location Location) error {
 	location.ID = m.LocationID
 	m.Location = location
-	return m.Location.Update()
+	return m.Location.Update(Tx(ctx))
 }
 
 // CanCreate returns a bool based on whether the current user is allowed to create a meeting
@@ -255,9 +255,9 @@ func (m *Meeting) CanUpdate(user User) bool {
 }
 
 // Requests return all associated Requests
-func (m *Meeting) Requests() (Requests, error) {
+func (m *Meeting) Requests(ctx context.Context) (Requests, error) {
 	var requests Requests
-	if err := DB.Where("meeting_id = ?", m.ID).Order("updated_at desc").All(&requests); err != nil {
+	if err := Tx(ctx).Where("meeting_id = ?", m.ID).Order("updated_at desc").All(&requests); err != nil {
 		return nil, fmt.Errorf("error getting requests for meeting id %v ... %v", m.ID, err)
 	}
 
@@ -265,7 +265,8 @@ func (m *Meeting) Requests() (Requests, error) {
 }
 
 // Invites returns all of the MeetingInvites for this Meeting. Only the meeting creator and organizers are authorized.
-func (m *Meeting) Invites(ctx buffalo.Context) (MeetingInvites, error) {
+func (m *Meeting) Invites(ctx context.Context) (MeetingInvites, error) {
+	tx := Tx(ctx)
 	i := MeetingInvites{}
 	if m == nil {
 		return i, nil
@@ -274,7 +275,7 @@ func (m *Meeting) Invites(ctx buffalo.Context) (MeetingInvites, error) {
 	if currentUser.ID != m.CreatedByID && !m.isOrganizer(ctx, currentUser.ID) && !currentUser.isSuperAdmin() {
 		return i, nil
 	}
-	if err := DB.Where("meeting_id = ?", m.ID).All(&i); err != nil {
+	if err := tx.Where("meeting_id = ?", m.ID).All(&i); err != nil {
 		return i, err
 	}
 	return i, nil
@@ -282,16 +283,17 @@ func (m *Meeting) Invites(ctx buffalo.Context) (MeetingInvites, error) {
 
 // Participants returns all of the MeetingParticipants for this Meeting. Only the meeting creator and organizers are
 // authorized.
-func (m *Meeting) Participants(ctx buffalo.Context) (MeetingParticipants, error) {
+func (m *Meeting) Participants(ctx context.Context) (MeetingParticipants, error) {
+	tx := Tx(ctx)
 	p := MeetingParticipants{}
 	if m == nil {
 		return p, nil
 	}
 	currentUser := CurrentUser(ctx)
 	if currentUser.ID != m.CreatedByID && !m.isOrganizer(ctx, currentUser.ID) && !currentUser.isSuperAdmin() {
-		return p, DB.Where("user_id = ? AND meeting_id = ?", currentUser.ID, m.ID).All(&p)
+		return p, tx.Where("user_id = ? AND meeting_id = ?", currentUser.ID, m.ID).All(&p)
 	}
-	if err := DB.Where("meeting_id = ?", m.ID).All(&p); err != nil {
+	if err := tx.Where("meeting_id = ?", m.ID).All(&p); err != nil {
 		return p, err
 	}
 	return p, nil
@@ -299,12 +301,12 @@ func (m *Meeting) Participants(ctx buffalo.Context) (MeetingParticipants, error)
 
 // Organizers returns all of the users who are organizers for this Meeting. No authorization is checked, so
 // any queries should render this as a PublicProfile to limit field visibility.
-func (m *Meeting) Organizers(ctx buffalo.Context) (Users, error) {
+func (m *Meeting) Organizers(ctx context.Context) (Users, error) {
 	u := Users{}
 	if m == nil {
 		return u, nil
 	}
-	if err := DB.
+	if err := Tx(ctx).
 		Select("users.id", "users.uuid", "nickname", "file_id", "auth_photo_url").
 		Where("meeting_participants.is_organizer=true").
 		Where("meeting_participants.meeting_id=?", m.ID).
@@ -315,34 +317,36 @@ func (m *Meeting) Organizers(ctx buffalo.Context) (Users, error) {
 	return u, nil
 }
 
-func (m *Meeting) RemoveInvite(ctx buffalo.Context, email string) error {
+func (m *Meeting) RemoveInvite(ctx context.Context, email string) error {
 	var invite MeetingInvite
-	if err := invite.FindByMeetingIDAndEmail(m.ID, email); err != nil {
+	tx := Tx(ctx)
+	if err := invite.FindByMeetingIDAndEmail(tx, m.ID, email); err != nil {
 		return err
 	}
-	return invite.Destroy()
+	return invite.Destroy(tx)
 }
 
-func (m *Meeting) RemoveParticipant(ctx buffalo.Context, userUUID string) error {
+func (m *Meeting) RemoveParticipant(ctx context.Context, userUUID string) error {
 	var user User
-	if err := user.FindByUUID(userUUID); err != nil {
+	tx := Tx(ctx)
+	if err := user.FindByUUID(ctx, userUUID); err != nil {
 		return fmt.Errorf("invalid user ID %s in Meeting.RemoveParticipant, %s", userUUID, err)
 	}
 	var participant MeetingParticipant
-	if err := participant.FindByMeetingIDAndUserID(m.ID, user.ID); err != nil {
+	if err := participant.FindByMeetingIDAndUserID(tx, m.ID, user.ID); err != nil {
 		return fmt.Errorf("failed to load MeetingParticipant in Meeting.RemoveParticipant, %s", err)
 	}
-	return participant.Destroy()
+	return participant.Destroy(tx)
 }
 
-func (m *Meeting) IsCodeValid(code string) bool {
+func (m *Meeting) IsCodeValid(tx *pop.Connection, code string) bool {
 	if m.InviteCode.Valid && m.InviteCode.UUID.String() == code {
 		return true
 	}
 	return false
 }
 
-func (m *Meeting) isOrganizer(ctx buffalo.Context, userID int) bool {
+func (m *Meeting) isOrganizer(ctx context.Context, userID int) bool {
 	organizers, err := m.Organizers(ctx)
 	if err != nil {
 		domain.Error(ctx, "isOrganizer() error reading list of meeting organizers, "+err.Error())
@@ -355,12 +359,12 @@ func (m *Meeting) isOrganizer(ctx buffalo.Context, userID int) bool {
 	return false
 }
 
-func (m *Meeting) isVisible(ctx buffalo.Context, userID int) bool {
+func (m *Meeting) isVisible(ctx context.Context, userID int) bool {
 	return true
 }
 
 // FindByIDs finds all Meetings associated with the given IDs and loads them from the database
-func (m *Meetings) FindByIDs(ids []int) error {
+func (m *Meetings) FindByIDs(tx *pop.Connection, ids []int) error {
 	ids = domain.UniquifyIntSlice(ids)
-	return DB.Where("id in (?)", ids).All(m)
+	return tx.Where("id in (?)", ids).All(m)
 }

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -128,10 +128,10 @@ func (m *Meetings) FindOnDate(tx *pop.Connection, timeInFocus time.Time) error {
 }
 
 // FindOnOrAfterDate finds the meetings that have an EndDate on or after the timeInFocus-date
-func (m *Meetings) FindOnOrAfterDate(ctx context.Context, timeInFocus time.Time) error {
+func (m *Meetings) FindOnOrAfterDate(tx *pop.Connection, timeInFocus time.Time) error {
 	date := timeInFocus.Format(domain.DateTimeFormat)
 
-	if err := getOrdered(m, Tx(ctx).Where("end_date >= ?", date)); err != nil {
+	if err := getOrdered(m, tx.Where("end_date >= ?", date)); err != nil {
 		return fmt.Errorf("error finding meeting with end_date before %s ... %s", date, err.Error())
 	}
 
@@ -151,12 +151,12 @@ func (m *Meetings) FindAfterDate(tx *pop.Connection, timeInFocus time.Time) erro
 
 // FindRecent finds the meetings that have an EndDate within the past <domain.RecentMeetingDelay> days
 // before timeInFocus-date (not inclusive)
-func (m *Meetings) FindRecent(ctx context.Context, timeInFocus time.Time) error {
+func (m *Meetings) FindRecent(tx *pop.Connection, timeInFocus time.Time) error {
 	yesterday := timeInFocus.Add(-domain.DurationDay).Format(domain.DateTimeFormat)
 	recentDate := timeInFocus.Add(-domain.RecentMeetingDelay)
 	where := "end_date between ? and ?"
 
-	if err := getOrdered(m, Tx(ctx).Where(where, recentDate, yesterday)); err != nil {
+	if err := getOrdered(m, tx.Where(where, recentDate, yesterday)); err != nil {
 		return fmt.Errorf("error finding meeting with end_date between %s and %s ... %s",
 			recentDate, yesterday, err.Error())
 	}

--- a/application/models/meeting_fixtures_test.go
+++ b/application/models/meeting_fixtures_test.go
@@ -101,15 +101,15 @@ func createMeetingFixtures_CanUpdate(ms *ModelSuite) meetingFixtures {
 
 	superUser := &uf.Users[1]
 	superUser.AdminRole = UserAdminRoleSuperAdmin
-	ms.NoError(superUser.Save())
+	ms.NoError(superUser.Save(Ctx()))
 
 	salesUser := &uf.Users[2]
 	salesUser.AdminRole = UserAdminRoleSalesAdmin
-	ms.NoError(salesUser.Save())
+	ms.NoError(salesUser.Save(Ctx()))
 
 	adminUser := &uf.Users[3]
 	adminUser.AdminRole = UserAdminRoleAdmin
-	ms.NoError(adminUser.Save())
+	ms.NoError(adminUser.Save(Ctx()))
 
 	meeting := Meeting{
 		CreatedByID: mtgUser.ID,

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -164,7 +164,7 @@ func (ms *ModelSuite) TestMeeting_FindByUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meeting Meeting
-			err := meeting.FindByUUID(test.uuid)
+			err := meeting.FindByUUID(ms.DB, test.uuid)
 			if test.wantErr {
 				ms.Error(err, "FindByUUID() did not return expected error")
 				return
@@ -199,7 +199,7 @@ func (ms *ModelSuite) TestMeeting_FindOnDate() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meetings Meetings
-			err := meetings.FindOnDate(test.testNow)
+			err := meetings.FindOnDate(ms.DB, test.testNow)
 			ms.NoError(err, "unexpected error")
 
 			mNames := make([]string, len(meetings))
@@ -245,7 +245,7 @@ func (ms *ModelSuite) TestMeeting_FindOnOrAfterDate() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meetings Meetings
-			err := meetings.FindOnOrAfterDate(test.testNow)
+			err := meetings.FindOnOrAfterDate(Ctx(), test.testNow)
 			ms.NoError(err, "unexpected error")
 
 			mNames := getMeetingNames(meetings)
@@ -278,7 +278,7 @@ func (ms *ModelSuite) TestMeeting_FindAfterDate() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meetings Meetings
-			err := meetings.FindAfterDate(test.testNow)
+			err := meetings.FindAfterDate(ms.DB, test.testNow)
 			ms.NoError(err, "unexpected error")
 
 			mNames := getMeetingNames(meetings)
@@ -311,7 +311,7 @@ func (ms *ModelSuite) TestMeeting_FindRecent() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meetings Meetings
-			err := meetings.FindRecent(test.testNow)
+			err := meetings.FindRecent(Ctx(), test.testNow)
 			ms.NoError(err, "unexpected error")
 
 			mNames := getMeetingNames(meetings)
@@ -337,7 +337,7 @@ func (ms *ModelSuite) TestMeeting_FindByInviteCode() {
 	for _, test := range tests {
 		ms.T().Run(test.name, func(t *testing.T) {
 			var meeting Meeting
-			err := meeting.FindByInviteCode(test.code)
+			err := meeting.FindByInviteCode(ms.DB, test.code)
 			if test.wantErr {
 				ms.Error(err, "FindByInviteCode() did not return expected error")
 				return
@@ -365,16 +365,16 @@ func (ms *ModelSuite) TestMeeting_ImageFile() {
 	}
 	createFixture(ms, &meeting)
 
-	f, err := meeting.ImageFile()
+	f, err := meeting.ImageFile(ms.DB)
 	ms.NoError(err, "unexpected error from Meeting.ImageFile()")
 	ms.Nil(f, "expected nil returned from Meeting.ImageFile()")
 
-	imageFixture := createFileFixture()
+	imageFixture := createFileFixture(ms.DB)
 
-	attachedFile, err := meeting.SetImageFile(imageFixture.UUID.String())
+	attachedFile, err := meeting.SetImageFile(Ctx(), imageFixture.UUID.String())
 	ms.NoError(err)
 
-	if got, err := meeting.ImageFile(); err == nil {
+	if got, err := meeting.ImageFile(ms.DB); err == nil {
 		ms.Equal(attachedFile.UUID.String(), got.UUID.String())
 		ms.True(got.URLExpiration.After(time.Now().Add(time.Minute)))
 		ms.Equal(imageFixture.Name, got.Name)
@@ -393,7 +393,7 @@ func (ms *ModelSuite) TestMeeting_GetCreator() {
 	meeting := Meeting{CreatedByID: user.ID, Name: "name", LocationID: location.ID}
 	createFixture(ms, &meeting)
 
-	creator, err := meeting.GetCreator()
+	creator, err := meeting.GetCreator(ms.DB)
 	ms.NoError(err, "unexpected error from meeting.GetCreator()")
 	ms.Equal(user.Nickname, creator.Nickname, "incorrect user/creator of meeting")
 }
@@ -421,10 +421,10 @@ func (ms *ModelSuite) TestMeeting_GetSetLocation() {
 	meeting := Meeting{CreatedByID: user.ID, Name: "name", LocationID: locations[0].ID}
 	createFixture(ms, &meeting)
 
-	err := meeting.SetLocation(locations[1])
+	err := meeting.SetLocation(Ctx(), locations[1])
 	ms.NoError(err, "unexpected error from meeting.SetLocation()")
 
-	locationFromDB, err := meeting.GetLocation()
+	locationFromDB, err := meeting.GetLocation(ms.DB)
 	ms.NoError(err, "unexpected error from meeting.GetLocation()")
 	locations[1].ID = locationFromDB.ID
 	ms.Equal(locations[1], locationFromDB, "location data doesn't match after update")
@@ -479,7 +479,7 @@ func (ms *ModelSuite) TestMeeting_GetRequests() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.Requests()
+			got, err := tt.meeting.Requests(Ctx())
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -804,7 +804,7 @@ func (ms *ModelSuite) TestMeeting_isCodeValid() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			ms.Equal(tt.want, tt.meeting.IsCodeValid(tt.code), "IsCodeValid returned incorrect result")
+			ms.Equal(tt.want, tt.meeting.IsCodeValid(ms.DB, tt.code), "IsCodeValid returned incorrect result")
 		})
 	}
 }
@@ -870,7 +870,7 @@ func (ms *ModelSuite) TestMeetings_FindByIDs() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var m Meetings
-			err := m.FindByIDs(tt.ids)
+			err := m.FindByIDs(ms.DB, tt.ids)
 			ms.NoError(err)
 
 			got := make([]string, len(m))

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -245,7 +245,7 @@ func (ms *ModelSuite) TestMeeting_FindOnOrAfterDate() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meetings Meetings
-			err := meetings.FindOnOrAfterDate(Ctx(), test.testNow)
+			err := meetings.FindOnOrAfterDate(ms.DB, test.testNow)
 			ms.NoError(err, "unexpected error")
 
 			mNames := getMeetingNames(meetings)
@@ -311,7 +311,7 @@ func (ms *ModelSuite) TestMeeting_FindRecent() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var meetings Meetings
-			err := meetings.FindRecent(Ctx(), test.testNow)
+			err := meetings.FindRecent(ms.DB, test.testNow)
 			ms.NoError(err, "unexpected error")
 
 			mNames := getMeetingNames(meetings)

--- a/application/models/meetinginvite_test.go
+++ b/application/models/meetinginvite_test.go
@@ -91,7 +91,7 @@ func (ms *ModelSuite) TestMeetingInvite_Create() {
 		InviterID: inviter.ID,
 		Email:     "existing@example.com",
 	}
-	ms.NoError(invite.Create())
+	ms.NoError(invite.Create(Ctx()))
 
 	tests := []struct {
 		name    string
@@ -132,7 +132,7 @@ func (ms *ModelSuite) TestMeetingInvite_Create() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			err := tt.invite.Create()
+			err := tt.invite.Create(Ctx())
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")
@@ -170,7 +170,7 @@ func (ms *ModelSuite) TestMeetingInvite_Meeting() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.invite.Meeting()
+			got, err := tt.invite.Meeting(Ctx())
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")
@@ -205,7 +205,7 @@ func (ms *ModelSuite) TestMeetingInvite_Inviter() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.invite.Inviter()
+			got, err := tt.invite.Inviter(Ctx())
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")
@@ -280,7 +280,7 @@ func (ms *ModelSuite) TestMeetingInvite_FindBySecret() {
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
 			var inv MeetingInvite
-			err := inv.FindBySecret(tt.meeting, tt.email, tt.secret)
+			err := inv.FindBySecret(ms.DB, tt.meeting, tt.email, tt.secret)
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")

--- a/application/models/meetingparticipant.go
+++ b/application/models/meetingparticipant.go
@@ -99,14 +99,14 @@ func (m *MeetingParticipant) FindOrCreate(ctx context.Context, meeting Meeting, 
 
 	if code == nil {
 		if cUser.CanCreateMeetingParticipant(ctx, meeting) {
-			return m.createWithoutInvite(ctx, tx, meeting)
+			return m.createWithoutInvite(ctx, meeting)
 		}
 		return domain.ReportError(ctx, errors.New("user is not allowed to self-join meeting without a code"),
 			"CreateMeetingParticipant.Unauthorized")
 	}
 
 	if meeting.IsCodeValid(tx, *code) {
-		return m.createWithoutInvite(ctx, tx, meeting)
+		return m.createWithoutInvite(ctx, meeting)
 	}
 
 	var invite MeetingInvite
@@ -126,10 +126,10 @@ func (m *MeetingParticipant) FindOrCreate(ctx context.Context, meeting Meeting, 
 	return nil
 }
 
-func (m *MeetingParticipant) createWithoutInvite(ctx context.Context, tx *pop.Connection, meeting Meeting) error {
+func (m *MeetingParticipant) createWithoutInvite(ctx context.Context, meeting Meeting) error {
 	m.UserID = CurrentUser(ctx).ID
 	m.MeetingID = meeting.ID
-	if err := tx.Create(m); err != nil {
+	if err := Tx(ctx).Create(m); err != nil {
 		return domain.ReportError(ctx, err, "CreateMeetingParticipant")
 	}
 	return nil

--- a/application/models/meetingparticipant.go
+++ b/application/models/meetingparticipant.go
@@ -43,24 +43,24 @@ func (m *MeetingParticipant) Validate(tx *pop.Connection) (*validate.Errors, err
 }
 
 // Meeting returns the related Meeting record
-func (m *MeetingParticipant) Meeting() (Meeting, error) {
+func (m *MeetingParticipant) Meeting(ctx context.Context) (Meeting, error) {
 	var meeting Meeting
-	return meeting, DB.Find(&meeting, m.MeetingID)
+	return meeting, Tx(ctx).Find(&meeting, m.MeetingID)
 }
 
 // User returns the related User record of the participant
-func (m *MeetingParticipant) User() (User, error) {
+func (m *MeetingParticipant) User(ctx context.Context) (User, error) {
 	var user User
-	return user, DB.Find(&user, m.UserID)
+	return user, Tx(ctx).Find(&user, m.UserID)
 }
 
 // Invite returns the related MeetingInvite record
-func (m *MeetingParticipant) Invite() (*MeetingInvite, error) {
+func (m *MeetingParticipant) Invite(ctx context.Context) (*MeetingInvite, error) {
 	var invite MeetingInvite
 	if !m.InviteID.Valid {
 		return nil, nil
 	}
-	err := DB.Find(&invite, m.InviteID.Int)
+	err := Tx(ctx).Find(&invite, m.InviteID.Int)
 	if err != nil {
 		return nil, err
 	}
@@ -68,28 +68,28 @@ func (m *MeetingParticipant) Invite() (*MeetingInvite, error) {
 }
 
 // FindByMeetingIDAndUserID does what it says
-func (m *MeetingParticipant) FindByMeetingIDAndUserID(meetingID, userID int) error {
-	return DB.Where("meeting_id = ? and user_id = ?", meetingID, userID).First(m)
+func (m *MeetingParticipant) FindByMeetingIDAndUserID(tx *pop.Connection, meetingID, userID int) error {
+	return tx.Where("meeting_id = ? and user_id = ?", meetingID, userID).First(m)
 }
 
 // CreateFromInvite creates a new MeetingParticipant using the MeetingInvite's information
-func (m *MeetingParticipant) CreateFromInvite(invite MeetingInvite, userID int) error {
+func (m *MeetingParticipant) CreateFromInvite(tx *pop.Connection, invite MeetingInvite, userID int) error {
 	m.InviteID = nulls.NewInt(invite.ID)
 	m.UserID = userID
 	m.MeetingID = invite.MeetingID
-	return DB.Create(m)
+	return tx.Create(m)
 }
 
-func (m *MeetingParticipant) Destroy() error {
-	return DB.Destroy(m)
+func (m *MeetingParticipant) Destroy(tx *pop.Connection) error {
+	return tx.Destroy(m)
 }
 
 // FindOrCreate a new MeetingParticipant from a meeting ID and code. If `code` is nil, the meeting must be non-INVITE_ONLY.
 // Otherwise, `code` must match either a MeetingInvite secret code or a Meeting invite code.
 func (m *MeetingParticipant) FindOrCreate(ctx context.Context, meeting Meeting, code *string) error {
 	cUser := CurrentUser(ctx)
-
-	if err := m.FindByMeetingIDAndUserID(meeting.ID, cUser.ID); domain.IsOtherThanNoRows(err) {
+	tx := Tx(ctx)
+	if err := m.FindByMeetingIDAndUserID(tx, meeting.ID, cUser.ID); domain.IsOtherThanNoRows(err) {
 		return domain.ReportError(ctx, err,
 			"CreateMeetingParticipant.FindExisting")
 	}
@@ -98,19 +98,19 @@ func (m *MeetingParticipant) FindOrCreate(ctx context.Context, meeting Meeting, 
 	}
 
 	if code == nil {
-		if cUser.CanCreateMeetingParticipant(domain.GetBuffaloContext(ctx), meeting) {
-			return m.createWithoutInvite(ctx, meeting)
+		if cUser.CanCreateMeetingParticipant(ctx, meeting) {
+			return m.createWithoutInvite(ctx, tx, meeting)
 		}
 		return domain.ReportError(ctx, errors.New("user is not allowed to self-join meeting without a code"),
 			"CreateMeetingParticipant.Unauthorized")
 	}
 
-	if meeting.IsCodeValid(*code) {
-		return m.createWithoutInvite(ctx, meeting)
+	if meeting.IsCodeValid(tx, *code) {
+		return m.createWithoutInvite(ctx, tx, meeting)
 	}
 
 	var invite MeetingInvite
-	if err := invite.FindBySecret(meeting.ID, cUser.Email, *code); domain.IsOtherThanNoRows(err) {
+	if err := invite.FindBySecret(tx, meeting.ID, cUser.Email, *code); domain.IsOtherThanNoRows(err) {
 		return domain.ReportError(ctx, err, "CreateMeetingParticipant.FindBySecret")
 	}
 	if invite.ID == 0 {
@@ -120,16 +120,16 @@ func (m *MeetingParticipant) FindOrCreate(ctx context.Context, meeting Meeting, 
 	m.InviteID = nulls.NewInt(invite.ID)
 	m.UserID = cUser.ID
 	m.MeetingID = meeting.ID
-	if err := DB.Create(m); err != nil {
+	if err := tx.Create(m); err != nil {
 		return domain.ReportError(ctx, err, "CreateMeetingParticipant")
 	}
 	return nil
 }
 
-func (m *MeetingParticipant) createWithoutInvite(ctx context.Context, meeting Meeting) error {
+func (m *MeetingParticipant) createWithoutInvite(ctx context.Context, tx *pop.Connection, meeting Meeting) error {
 	m.UserID = CurrentUser(ctx).ID
 	m.MeetingID = meeting.ID
-	if err := DB.Create(m); err != nil {
+	if err := tx.Create(m); err != nil {
 		return domain.ReportError(ctx, err, "CreateMeetingParticipant")
 	}
 	return nil

--- a/application/models/meetingparticipant_test.go
+++ b/application/models/meetingparticipant_test.go
@@ -83,7 +83,7 @@ func (ms *ModelSuite) TestMeetingParticipant_Meeting() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.participant.Meeting()
+			got, err := tt.participant.Meeting(Ctx())
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")
@@ -118,7 +118,7 @@ func (ms *ModelSuite) TestMeetingParticipant_User() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.participant.User()
+			got, err := tt.participant.User(Ctx())
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")

--- a/application/models/message_fixtures_test.go
+++ b/application/models/message_fixtures_test.go
@@ -65,7 +65,7 @@ func Fixtures_Message_Create(ms *ModelSuite, t *testing.T) MessageFixtures {
 
 	org := createOrganizationFixtures(ms.DB, 1)[0]
 	requests[0].OrganizationID = org.ID
-	ms.NoError(requests[0].Update())
+	ms.NoError(requests[0].Update(Ctx()))
 
 	tf := CreateThreadFixtures(ms, requests[1])
 

--- a/application/models/message_test.go
+++ b/application/models/message_test.go
@@ -94,7 +94,7 @@ func (ms *ModelSuite) TestMessage_GetSender() {
 	messages := messageFixtures.Messages
 	users := messageFixtures.Users
 
-	userResults, err := messages[0].GetSender()
+	userResults, err := messages[0].GetSender(ms.DB)
 	if err != nil {
 		t.Errorf("unexpected error ... %v", err)
 		t.FailNow()
@@ -113,7 +113,7 @@ func (ms *ModelSuite) TestMessage_GetThread() {
 	messages := messageFixtures.Messages
 	threads := messageFixtures.Threads
 
-	threadResults, err := messages[0].GetThread()
+	threadResults, err := messages[0].GetThread(ms.DB)
 	if err != nil {
 		t.Errorf("unexpected error ... %v", err)
 		t.FailNow()
@@ -228,7 +228,7 @@ func (ms *ModelSuite) TestMessage_FindByID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var message Message
-			err := message.FindByID(test.id, test.eagerFields...)
+			err := message.FindByID(ms.DB, test.id, test.eagerFields...)
 
 			if test.wantErr {
 				ms.Error(err)
@@ -269,7 +269,7 @@ func (ms *ModelSuite) TestMessage_FindByUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var message Message
-			err := message.findByUUID(test.uuid)
+			err := message.findByUUID(ms.DB, test.uuid)
 
 			if test.wantErr != "" {
 				ms.Error(err)
@@ -321,7 +321,7 @@ func (ms *ModelSuite) TestMessage_FindByUserAndUUID() {
 			} else {
 				testUUID = *test.uuid
 			}
-			err := message.FindByUserAndUUID(test.user, testUUID)
+			err := message.FindByUserAndUUID(Ctx(), test.user, testUUID)
 
 			if test.wantErr != "" {
 				ms.Error(err)

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -350,9 +350,7 @@ func Tx(ctx context.Context) *pop.Connection {
 	}
 	tx, ok := ctx.Value("tx").(*pop.Connection)
 	if !ok {
-		domain.Error(ctx, "transaction not found in context")
 		return DB
 	}
-	domain.Warn(ctx, "------------- found connection")
 	return tx
 }

--- a/application/models/models.go
+++ b/application/models/models.go
@@ -91,7 +91,7 @@ func GetStringFromNullsString(inString nulls.String) *string {
 // GetIntFromNullsInt returns a pointer to make it easier for calling
 // functions to return a pointer without an extra line of code.
 func GetIntFromNullsInt(in nulls.Int) *int {
-	output := int(0)
+	output := 0
 	if in.Valid {
 		output = in.Int
 	}
@@ -162,13 +162,13 @@ func emitEvent(e events.Event) {
 	}
 }
 
-func create(m interface{}) error {
+func create(tx *pop.Connection, m interface{}) error {
 	uuidField := fieldByName(m, "UUID")
 	if uuidField.IsValid() && uuidField.Interface().(uuid.UUID).Version() == 0 {
 		uuidField.Set(reflect.ValueOf(domain.GetUUID()))
 	}
 
-	valErrs, err := DB.ValidateAndCreate(m)
+	valErrs, err := tx.ValidateAndCreate(m)
 	if err != nil {
 		return err
 	}
@@ -179,8 +179,8 @@ func create(m interface{}) error {
 	return nil
 }
 
-func update(m interface{}) error {
-	valErrs, err := DB.ValidateAndUpdate(m)
+func update(tx *pop.Connection, m interface{}) error {
+	valErrs, err := tx.ValidateAndUpdate(m)
 	if err != nil {
 		return err
 	}
@@ -191,13 +191,13 @@ func update(m interface{}) error {
 	return nil
 }
 
-func save(m interface{}) error {
+func save(tx *pop.Connection, m interface{}) error {
 	uuidField := fieldByName(m, "UUID")
 	if uuidField.IsValid() && uuidField.Interface().(uuid.UUID).Version() == 0 {
 		uuidField.Set(reflect.ValueOf(domain.GetUUID()))
 	}
 
-	validationErrs, err := DB.ValidateAndSave(m)
+	validationErrs, err := tx.ValidateAndSave(m)
 	if validationErrs != nil && validationErrs.HasAny() {
 		return errors.New(flattenPopErrors(validationErrs))
 	}
@@ -230,10 +230,10 @@ func gravatarURL(email string) string {
 	return url
 }
 
-func addFile(m interface{}, fileID string) (File, error) {
+func addFile(tx *pop.Connection, m interface{}, fileID string) (File, error) {
 	var f File
 
-	if err := f.FindByUUID(fileID); err != nil {
+	if err := f.FindByUUID(tx, fileID); err != nil {
 		return f, err
 	}
 
@@ -249,12 +249,12 @@ func addFile(m interface{}, fileID string) (File, error) {
 		return f, errors.New("error identifying ID field")
 	}
 	if idField.Interface().(int) > 0 {
-		if err := DB.UpdateColumns(m, "file_id", "updated_at"); err != nil {
+		if err := tx.UpdateColumns(m, "file_id", "updated_at"); err != nil {
 			return f, fmt.Errorf("failed to update the file_id column, %s", err)
 		}
 	}
 
-	if err := f.SetLinked(DB); err != nil {
+	if err := f.SetLinked(tx); err != nil {
 		domain.ErrLogger.Printf("error marking file %d as linked, %s", f.ID, err)
 	}
 
@@ -263,14 +263,14 @@ func addFile(m interface{}, fileID string) (File, error) {
 	}
 
 	oldFile := File{ID: oldID.Int}
-	if err := oldFile.ClearLinked(DB); err != nil {
+	if err := oldFile.ClearLinked(tx); err != nil {
 		domain.ErrLogger.Printf("error marking old file %d as unlinked, %s", oldFile.ID, err)
 	}
 
 	return f, nil
 }
 
-func removeFile(m interface{}) error {
+func removeFile(tx *pop.Connection, m interface{}) error {
 	idField := fieldByName(m, "ID")
 	if !idField.IsValid() {
 		return errors.New("error identifying ID field")
@@ -287,7 +287,7 @@ func removeFile(m interface{}) error {
 
 	oldID := imageField.Interface().(nulls.Int)
 	imageField.Set(reflect.ValueOf(nulls.Int{}))
-	if err := DB.UpdateColumns(m, "file_id", "updated_at"); err != nil {
+	if err := tx.UpdateColumns(m, "file_id", "updated_at"); err != nil {
 		return fmt.Errorf("failed to update file_id column, %s", err)
 	}
 
@@ -296,7 +296,7 @@ func removeFile(m interface{}) error {
 	}
 
 	oldFile := File{ID: oldID.Int}
-	if err := oldFile.ClearLinked(DB); err != nil {
+	if err := oldFile.ClearLinked(tx); err != nil {
 		domain.ErrLogger.Printf("error marking old meeting file %d as unlinked, %s", oldFile.ID, err)
 	}
 	return nil
@@ -339,4 +339,20 @@ func destroyTable(i interface{}) {
 	if err := DB.Destroy(i); err != nil {
 		panic(err.Error())
 	}
+}
+
+// Tx retrieves the database transaction from the context, which can be the context
+// provided by gqlgen or the inner "BuffaloContext" assigned to the value key of the same name.
+func Tx(ctx context.Context) *pop.Connection {
+	bc, ok := ctx.Value(domain.BuffaloContext).(buffalo.Context)
+	if ok {
+		return Tx(bc)
+	}
+	tx, ok := ctx.Value("tx").(*pop.Connection)
+	if !ok {
+		domain.Error(ctx, "transaction not found in context")
+		return DB
+	}
+	domain.Warn(ctx, "------------- found connection")
+	return tx
 }

--- a/application/models/models_test.go
+++ b/application/models/models_test.go
@@ -67,6 +67,13 @@ func createTestContext(user User) buffalo.Context {
 	return ctx
 }
 
+func Ctx() context.Context {
+	ctx := &testBuffaloContext{
+		params: map[interface{}]interface{}{},
+	}
+	return ctx
+}
+
 func (ms *ModelSuite) TestCurrentUser() {
 	// setup
 	user := createUserFixtures(ms.DB, 1).Users[0]
@@ -111,7 +118,7 @@ func (ms *ModelSuite) Test_addFile() {
 	uf := createUserFixtures(ms.DB, 3)
 	users := uf.Users
 
-	files := createFileFixtures(3)
+	files := createFileFixtures(ms.DB, 3)
 	users[1].FileID = nulls.NewInt(files[0].ID)
 	ms.NoError(ms.DB.UpdateColumns(&users[1], "file_id"))
 
@@ -145,7 +152,7 @@ func (ms *ModelSuite) Test_addFile() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := addFile(&tt.user, tt.newImage)
+			got, err := addFile(ms.DB, &tt.user, tt.newImage)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -168,7 +175,7 @@ func (ms *ModelSuite) Test_removeFile() {
 	uf := createUserFixtures(ms.DB, 2)
 	users := uf.Users
 
-	files := createFileFixtures(1)
+	files := createFileFixtures(ms.DB, 1)
 	users[1].FileID = nulls.NewInt(files[0].ID)
 	ms.NoError(ms.DB.UpdateColumns(&users[1], "file_id"))
 	files[0].Linked = true
@@ -198,7 +205,7 @@ func (ms *ModelSuite) Test_removeFile() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			err := removeFile(&tt.user)
+			err := removeFile(ms.DB, &tt.user)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)

--- a/application/models/organization_test.go
+++ b/application/models/organization_test.go
@@ -41,7 +41,7 @@ func (ms *ModelSuite) TestOrganization_FindOrgByUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var org Organization
-			err := org.FindByUUID(test.args.uuid)
+			err := org.FindByUUID(ms.DB, test.args.uuid)
 			if test.wantErr {
 				if err == nil {
 					t.Errorf("Expected an error, but did not get one")
@@ -62,7 +62,7 @@ func (ms *ModelSuite) TestOrganization_FindOrgByUUID() {
 }
 
 func (ms *ModelSuite) TestOrganization_Create() {
-	file := createFileFixture()
+	file := createFileFixture(ms.DB)
 
 	t := ms.T()
 	tests := []struct {
@@ -101,7 +101,7 @@ func (ms *ModelSuite) TestOrganization_Create() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.org.Save()
+			err := test.org.Save(Ctx())
 			if test.wantErr == true {
 				if err == nil {
 					t.Errorf("Expected an error, but did not get one")
@@ -110,7 +110,7 @@ func (ms *ModelSuite) TestOrganization_Create() {
 				t.Errorf("Unexpected error %v", err)
 			} else {
 				var org Organization
-				err := org.FindByUUID(test.org.UUID.String())
+				err := org.FindByUUID(ms.DB, test.org.UUID.String())
 				if err != nil {
 					t.Errorf("Couldn't find new org %v: %v", test.org.Name, err)
 				}
@@ -224,7 +224,7 @@ func (ms *ModelSuite) TestOrganization_FindByDomain() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var org Organization
-			err := org.FindByDomain(test.args.domain)
+			err := org.FindByDomain(ms.DB, test.args.domain)
 			if test.wantErr {
 				if err == nil {
 					t.Errorf("Expected an error, but did not get one")
@@ -250,28 +250,28 @@ func (ms *ModelSuite) TestOrganization_AddRemoveDomain() {
 
 	orgFixtures := createOrganizationFixtures(ms.DB, 2)
 
-	err := orgFixtures[0].AddDomain("first.com", "", "")
+	err := orgFixtures[0].AddDomain(Ctx(), "first.com", "", "")
 	ms.NoError(err, "unable to add first domain to Org1: %s", err)
-	domains, _ := orgFixtures[0].Domains()
+	domains, _ := orgFixtures[0].Domains(Ctx())
 	if len(domains) != 1 {
 		t.Errorf("did not get error, but failed to add first domain to Org1")
 	}
 
-	err = orgFixtures[0].AddDomain("second.com", "", "")
+	err = orgFixtures[0].AddDomain(Ctx(), "second.com", "", "")
 	ms.NoError(err, "unable to add second domain to Org1: %s", err)
-	domains, _ = orgFixtures[0].Domains()
+	domains, _ = orgFixtures[0].Domains(Ctx())
 	if len(domains) != 2 {
 		t.Errorf("did not get error, but failed to add second domain to Org1")
 	}
 
-	err = orgFixtures[1].AddDomain("second.com", "", "")
+	err = orgFixtures[1].AddDomain(Ctx(), "second.com", "", "")
 	ms.Error(err, "was able to add existing domain (second.com) to Org2 but should have gotten error")
-	domains, _ = orgFixtures[0].Domains()
+	domains, _ = orgFixtures[0].Domains(Ctx())
 	ms.Equal(2, len(domains), "after reloading org domains we did not get what we expected")
 
-	err = orgFixtures[0].RemoveDomain("first.com")
+	err = orgFixtures[0].RemoveDomain(Ctx(), "first.com")
 	ms.NoError(err, "unable to remove domain: %s", err)
-	domains, _ = orgFixtures[0].Domains()
+	domains, _ = orgFixtures[0].Domains(Ctx())
 	ms.Equal(1, len(domains), "org domains count after removing domain is not correct")
 }
 
@@ -279,11 +279,11 @@ func (ms *ModelSuite) TestOrganization_Save() {
 	t := ms.T()
 
 	orgFixtures := createOrganizationFixtures(ms.DB, 2)
-	file := createFileFixture()
+	file := createFileFixture(ms.DB)
 
 	// test save of existing organization
 	orgFixtures[0].Name = "changed"
-	err := orgFixtures[0].Save()
+	err := orgFixtures[0].Save(Ctx())
 	if err != nil {
 		t.Error(err)
 	}
@@ -307,7 +307,7 @@ func (ms *ModelSuite) TestOrganization_Save() {
 		FileID:     nulls.NewInt(file.ID),
 	}
 
-	err = newOrg.Save()
+	err = newOrg.Save(Ctx())
 	if err != nil {
 		t.Error(err)
 	}
@@ -323,7 +323,7 @@ func (ms *ModelSuite) TestOrganization_All() {
 	orgFixtures := createOrganizationFixtures(ms.DB, 2)
 
 	var allOrgs Organizations
-	err := allOrgs.All()
+	err := allOrgs.All(ms.DB)
 	if err != nil {
 		t.Error(err)
 	}
@@ -336,7 +336,7 @@ func (ms *ModelSuite) TestOrganization_All() {
 func (ms *ModelSuite) TestOrganization_GetDomains() {
 	f := CreateFixturesForOrganizationGetDomains(ms)
 
-	orgDomains, err := f.Organizations[0].Domains()
+	orgDomains, err := f.Organizations[0].Domains(Ctx())
 	ms.NoError(err)
 
 	domains := make([]string, len(orgDomains))
@@ -369,7 +369,7 @@ func (ms *ModelSuite) TestOrganization_GetUsers() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			users, err := test.org.GetUsers()
+			users, err := test.org.GetUsers(ms.DB)
 
 			if test.wantErr != "" {
 				ms.Error(err)
@@ -411,7 +411,7 @@ func (ms *ModelSuite) TestOrganization_AllWhereUserIsOrgAdmin() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var got Organizations
-			err := got.AllWhereUserIsOrgAdmin(test.user)
+			err := got.AllWhereUserIsOrgAdmin(Ctx(), test.user)
 
 			if test.wantErr != "" {
 				ms.Error(err)
@@ -450,7 +450,7 @@ func (ms *ModelSuite) TestOrganization_LogoURL() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logoURL, err := tt.org.LogoURL()
+			logoURL, err := tt.org.LogoURL(Ctx())
 			if tt.wantErr != "" {
 				ms.Errorf(err, "expected error %s but got no error", tt.wantErr, err)
 				ms.Contains(err.Error(), tt.wantErr)
@@ -471,7 +471,7 @@ func (ms *ModelSuite) TestOrganization_CreateTrust() {
 
 	orgs := createOrganizationFixtures(ms.DB, 4)
 	trust := OrganizationTrust{PrimaryID: orgs[0].ID, SecondaryID: orgs[1].ID}
-	ms.NoError(trust.CreateSymmetric())
+	ms.NoError(trust.CreateSymmetric(ms.DB))
 
 	tests := []struct {
 		name      string
@@ -490,14 +490,14 @@ func (ms *ModelSuite) TestOrganization_CreateTrust() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.primary.CreateTrust(tt.secondary.UUID.String())
+			err := tt.primary.CreateTrust(Ctx(), tt.secondary.UUID.String())
 			if tt.wantErr != "" {
 				ms.Errorf(err, "expected error %s but got no error", tt.wantErr, err)
 				ms.Contains(err.Error(), tt.wantErr)
 				return
 			}
 			ms.NoError(err)
-			trustedOrgs, err := tt.primary.TrustedOrganizations()
+			trustedOrgs, err := tt.primary.TrustedOrganizations(Ctx())
 			ms.NoError(err)
 			ms.Equal(tt.want, len(trustedOrgs))
 		})
@@ -512,8 +512,8 @@ func (ms *ModelSuite) TestOrganization_RemoveTrust() {
 		{PrimaryID: orgs[0].ID, SecondaryID: orgs[1].ID},
 		{PrimaryID: orgs[1].ID, SecondaryID: orgs[2].ID},
 	}
-	ms.NoError(trusts[0].CreateSymmetric())
-	ms.NoError(trusts[1].CreateSymmetric())
+	ms.NoError(trusts[0].CreateSymmetric(ms.DB))
+	ms.NoError(trusts[1].CreateSymmetric(ms.DB))
 
 	tests := []struct {
 		name      string
@@ -530,14 +530,14 @@ func (ms *ModelSuite) TestOrganization_RemoveTrust() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.primary.RemoveTrust(tt.secondary.UUID.String())
+			err := tt.primary.RemoveTrust(Ctx(), tt.secondary.UUID.String())
 			if tt.wantErr != "" {
 				ms.Errorf(err, "expected error %s but got no error", tt.wantErr, err)
 				ms.Contains(err.Error(), tt.wantErr)
 				return
 			}
 			ms.NoError(err)
-			trustedOrgs, err := tt.primary.TrustedOrganizations()
+			trustedOrgs, err := tt.primary.TrustedOrganizations(Ctx())
 			ms.NoError(err)
 			ms.Equal(tt.want, len(trustedOrgs))
 		})
@@ -552,8 +552,8 @@ func (ms *ModelSuite) TestOrganization_TrustedOrganizations() {
 		{PrimaryID: orgs[0].ID, SecondaryID: orgs[1].ID},
 		{PrimaryID: orgs[2].ID, SecondaryID: orgs[0].ID},
 	}
-	ms.NoError(trusts[0].CreateSymmetric())
-	ms.NoError(trusts[1].CreateSymmetric())
+	ms.NoError(trusts[0].CreateSymmetric(ms.DB))
+	ms.NoError(trusts[1].CreateSymmetric(ms.DB))
 
 	tests := []struct {
 		name    string
@@ -568,7 +568,7 @@ func (ms *ModelSuite) TestOrganization_TrustedOrganizations() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.primary.TrustedOrganizations()
+			got, err := tt.primary.TrustedOrganizations(Ctx())
 			ms.NoError(err, "unexpected error from UUT")
 			ms.Equal(len(tt.want), len(got), "received incorrect number of orgs")
 			ids := make([]int, len(got))
@@ -605,7 +605,7 @@ func (ms *ModelSuite) TestOrganization_GetAuthProvider() {
 		AuthConfig: adAuthConfig,
 		UUID:       uid,
 	}
-	err := org.Save()
+	err := org.Save(Ctx())
 	ms.NoError(err, "unable to create organization fixture")
 
 	orgDomain1 := OrganizationDomain{
@@ -614,7 +614,7 @@ func (ms *ModelSuite) TestOrganization_GetAuthProvider() {
 		AuthType:       AuthTypeDefault,
 		AuthConfig:     "",
 	}
-	err = orgDomain1.Save()
+	err = orgDomain1.Save(Ctx())
 	ms.NoError(err, "unable to create orgDomain1 fixture")
 
 	orgDomain2 := OrganizationDomain{
@@ -623,20 +623,20 @@ func (ms *ModelSuite) TestOrganization_GetAuthProvider() {
 		AuthType:       AuthTypeGoogle,
 		AuthConfig:     "",
 	}
-	err = orgDomain2.Save()
+	err = orgDomain2.Save(Ctx())
 	ms.NoError(err, "unable to create orgDomain2 fixture")
 
 	var o Organization
-	err = o.FindByUUID(uid.String())
+	err = o.FindByUUID(ms.DB, uid.String())
 	ms.NoError(err, "unable to find organization fixture")
 
 	// should get type azuread:
-	provider, err := o.GetAuthProvider("test@domain1.com")
+	provider, err := o.GetAuthProvider(Ctx(), "test@domain1.com")
 	ms.NoError(err, "unable to get authprovider for test@domain1.com")
 	ms.IsType(&azureadv2.Provider{}, provider, "auth provider not expected azureAD type")
 
 	// should get type google:
-	provider, err = o.GetAuthProvider("test@domain2.com")
+	provider, err = o.GetAuthProvider(Ctx(), "test@domain2.com")
 	ms.NoError(err, "unable to get authprovider for test@domain2.com")
 	ms.IsType(&google.Provider{}, provider, "auth provider not expected google type")
 }
@@ -665,7 +665,7 @@ func (ms *ModelSuite) TestOrganizations_FindByIDs() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var o Organizations
-			err := o.FindByIDs(tt.ids)
+			err := o.FindByIDs(ms.DB, tt.ids)
 			ms.NoError(err)
 
 			got := make([]string, len(o))

--- a/application/models/organizationdomain.go
+++ b/application/models/organizationdomain.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -35,28 +36,28 @@ func (o *OrganizationDomain) ValidateCreate(tx *pop.Connection) (*validate.Error
 }
 
 // Organization loads the Organization record
-func (o *OrganizationDomain) Organization() (Organization, error) {
+func (o *OrganizationDomain) Organization(ctx context.Context) (Organization, error) {
 	if o.OrganizationID <= 0 {
 		return Organization{}, errors.New("OrganizationID is not valid")
 	}
 	var organization Organization
-	if err := DB.Find(&organization, o.OrganizationID); err != nil {
+	if err := Tx(ctx).Find(&organization, o.OrganizationID); err != nil {
 		return Organization{}, err
 	}
 	return organization, nil
 }
 
 // Create stores the OrganizationDomain data as a new record in the database.
-func (o *OrganizationDomain) Create() error {
-	return create(o)
+func (o *OrganizationDomain) Create(tx *pop.Connection) error {
+	return create(tx, o)
 }
 
 // FindByDomain finds a record by the domain name
-func (o *OrganizationDomain) FindByDomain(domainName string) error {
-	return DB.Where("domain = ?", domainName).First(o)
+func (o *OrganizationDomain) FindByDomain(ctx context.Context, domainName string) error {
+	return Tx(ctx).Where("domain = ?", domainName).First(o)
 }
 
-// Save wrap DB.Save() call to check for errors and operate on attached object
-func (o *OrganizationDomain) Save() error {
-	return save(o)
+// Save wrap tx.Save() call to check for errors and operate on attached object
+func (o *OrganizationDomain) Save(ctx context.Context) error {
+	return save(Tx(ctx), o)
 }

--- a/application/models/organizationdomain_test.go
+++ b/application/models/organizationdomain_test.go
@@ -32,7 +32,7 @@ func (ms *ModelSuite) TestOrganizationDomain_Organization() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			o := test.orgDomain
-			got, err := o.Organization()
+			got, err := o.Organization(Ctx())
 
 			if test.wantErr {
 				ms.Error(err)

--- a/application/models/organizationtrust_test.go
+++ b/application/models/organizationtrust_test.go
@@ -93,7 +93,7 @@ func (ms *ModelSuite) TestTrust_Create() {
 				PrimaryID:   tt.trust.PrimaryID,
 				SecondaryID: tt.trust.SecondaryID,
 			}
-			err := newTrust.CreateSymmetric()
+			err := newTrust.CreateSymmetric(ms.DB)
 			if tt.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error type")
@@ -102,7 +102,7 @@ func (ms *ModelSuite) TestTrust_Create() {
 			ms.NoError(err, "unexpected error")
 
 			org := Organization{ID: tt.trust.PrimaryID}
-			orgs, err := org.TrustedOrganizations()
+			orgs, err := org.TrustedOrganizations(Ctx())
 			ms.NoError(err)
 
 			ms.Equal(tt.want, len(orgs), "incorrect number of OrganizationTrust records")
@@ -134,7 +134,7 @@ func (ms *ModelSuite) TestTrust_Remove() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var trust OrganizationTrust
-			err := trust.RemoveSymmetric(tt.trust.PrimaryID, tt.trust.SecondaryID)
+			err := trust.RemoveSymmetric(ms.DB, tt.trust.PrimaryID, tt.trust.SecondaryID)
 			if tt.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error type")
@@ -143,11 +143,11 @@ func (ms *ModelSuite) TestTrust_Remove() {
 			ms.NoError(err, "unexpected error")
 
 			org1 := Organization{ID: tt.trust.PrimaryID}
-			orgs1, err := org1.TrustedOrganizations()
+			orgs1, err := org1.TrustedOrganizations(Ctx())
 			ms.NoError(err)
 
 			org2 := Organization{ID: tt.trust.SecondaryID}
-			orgs2, err := org2.TrustedOrganizations()
+			orgs2, err := org2.TrustedOrganizations(Ctx())
 			ms.NoError(err)
 
 			ms.Equal(tt.want, len(orgs1)+len(orgs2), "incorrect number of OrganizationTrust records")
@@ -179,7 +179,7 @@ func (ms *ModelSuite) TestTrust_FindByOrgIDs() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var trust OrganizationTrust
-			err := trust.FindByOrgIDs(tt.id1, tt.id2)
+			err := trust.FindByOrgIDs(ms.DB, tt.id1, tt.id2)
 			if tt.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error type")
@@ -220,7 +220,7 @@ func (ms *ModelSuite) TestTrusts_FindByOrgID() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var trusts OrganizationTrusts
-			err := trusts.FindByOrgID(tt.id)
+			err := trusts.FindByOrgID(ms.DB, tt.id)
 			if tt.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error type")

--- a/application/models/potentialprovider.go
+++ b/application/models/potentialprovider.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,7 +44,7 @@ func (p *PotentialProvider) Validate(tx *pop.Connection) (*validate.Errors, erro
 	return validate.Validate(
 		&validators.IntIsPresent{Field: p.RequestID, Name: "RequestID"},
 		&validators.IntIsPresent{Field: p.UserID, Name: "UserID"},
-		&uniqueTogetherValidator{Object: p, Name: "UniqueTogether"},
+		&uniqueTogetherValidator{Object: p, Name: "UniqueTogether", tx: tx},
 	), nil
 }
 
@@ -61,6 +62,7 @@ type uniqueTogetherValidator struct {
 	Name    string
 	Object  *PotentialProvider
 	Message string
+	tx      *pop.Connection
 }
 
 // IsValid ensures there are no other PotentialProviders with both the
@@ -69,7 +71,7 @@ func (v *uniqueTogetherValidator) IsValid(errors *validate.Errors) {
 	p := PotentialProvider{}
 	pID := v.Object.RequestID
 	uID := v.Object.UserID
-	if err := DB.Where("request_id = ? and user_id = ?", pID, uID).First(&p); err != nil {
+	if err := v.tx.Where("request_id = ? and user_id = ?", pID, uID).First(&p); err != nil {
 		if domain.IsOtherThanNoRows(err) {
 			v.Message = "Error database for duplicate potential providers: " + err.Error()
 			errors.Add(validators.GenerateKey(v.Name), v.Message)
@@ -91,8 +93,8 @@ type PotentialProviderEventData struct {
 }
 
 // Create stores the PotentialProvider data as a new record in the database.
-func (p *PotentialProvider) Create() error {
-	if err := create(p); err != nil {
+func (p *PotentialProvider) Create(ctx context.Context) error {
+	if err := create(Tx(ctx), p); err != nil {
 		return err
 	}
 
@@ -113,8 +115,8 @@ func (p *PotentialProvider) Create() error {
 }
 
 // Update writes the PotentialProvider data to an existing database record.
-func (p *PotentialProvider) Update() error {
-	return update(p)
+func (p *PotentialProvider) Update(tx *pop.Connection) error {
+	return update(tx, p)
 }
 
 // FindUsersByRequestID gets the Users associated with the Request's PotentialProviders
@@ -123,7 +125,7 @@ func (p *PotentialProvider) Update() error {
 // If the currentUser is the requester or a SuperAdmin, then all potentialProvider Users are returned.
 // If the currentUser is one of the potentialProviders, that User is returned.
 // Otherwise, an empty slice of Users is returned.
-func (p *PotentialProviders) FindUsersByRequestID(request Request, currentUser User) (Users, error) {
+func (p *PotentialProviders) FindUsersByRequestID(tx *pop.Connection, request Request, currentUser User) (Users, error) {
 	if request.ID <= 0 {
 		return Users{}, fmt.Errorf("error finding potential_provider, invalid id %v", request.ID)
 	}
@@ -136,7 +138,7 @@ func (p *PotentialProviders) FindUsersByRequestID(request Request, currentUser U
 		whereQ = fmt.Sprintf("request_id = %v", request.ID)
 	}
 
-	if err := DB.Eager("User").Where(whereQ).All(p); err != nil {
+	if err := tx.Eager("User").Where(whereQ).All(p); err != nil {
 		if domain.IsOtherThanNoRows(err) {
 			return Users{}, fmt.Errorf("failed to find potential_provider records for request %d, %s",
 				request.ID, err)
@@ -162,23 +164,23 @@ func (p *PotentialProvider) CanUserAccessPotentialProvider(request Request, curr
 
 // FindWithRequestUUIDAndUserUUID  finds the PotentialProvider associated with both the requestUUID and the userUUID
 // No authorization checks are performed - they must be done separately
-func (p *PotentialProvider) FindWithRequestUUIDAndUserUUID(requestUUID, userUUID string, currentUser User) error {
+func (p *PotentialProvider) FindWithRequestUUIDAndUserUUID(ctx context.Context, requestUUID, userUUID string, currentUser User) error {
 	var request Request
-	if err := request.FindByUUID(requestUUID); err != nil {
+	tx := Tx(ctx)
+	if err := request.FindByUUID(tx, requestUUID); err != nil {
 		return errors.New("unable to find Request in order to find PotentialProvider: " + err.Error())
 	}
 
 	var user User
-	if err := user.FindByUUID(userUUID); err != nil {
+	if err := user.FindByUUID(ctx, userUUID); err != nil {
 		return errors.New("unable to find User in order to find PotentialProvider: " + err.Error())
 	}
 
-	if err := DB.Where("request_id = ? AND user_id = ?", request.ID, user.ID).First(p); err != nil {
+	if err := tx.Where("request_id = ? AND user_id = ?", request.ID, user.ID).First(p); err != nil {
 		return errors.New("unable to find PotentialProvider: " + err.Error())
 	}
 
 	if !p.CanUserAccessPotentialProvider(request, currentUser) {
-		p = nil
 		return errors.New("user not allowed to access PotentialProvider")
 	}
 
@@ -186,19 +188,20 @@ func (p *PotentialProvider) FindWithRequestUUIDAndUserUUID(requestUUID, userUUID
 }
 
 // NewWithRequestUUID populates a new PotentialProvider but does not save it
-func (p *PotentialProvider) NewWithRequestUUID(requestUUID string, userID int) error {
+func (p *PotentialProvider) NewWithRequestUUID(ctx context.Context, requestUUID string, userID int) error {
 	var user User
-	if err := user.FindByID(userID); err != nil {
+	tx := Tx(ctx)
+	if err := user.FindByID(tx, userID); err != nil {
 		return err
 	}
 
 	var request Request
-	if err := request.FindByUUID(requestUUID); err != nil {
+	if err := request.FindByUUID(tx, requestUUID); err != nil {
 		return err
 	}
 
 	if request.CreatedByID == userID {
-		return errors.New("PotentialProvider User must not be the Request's Receiver.")
+		return errors.New("the PotentialProvider User must not be the Request's Receiver")
 	}
 
 	p.RequestID = request.ID
@@ -208,15 +211,15 @@ func (p *PotentialProvider) NewWithRequestUUID(requestUUID string, userID int) e
 }
 
 // Destroy destroys the PotentialProvider
-func (p *PotentialProvider) Destroy() error {
-	return DB.Destroy(p)
+func (p *PotentialProvider) Destroy(ctx context.Context) error {
+	return Tx(ctx).Destroy(p)
 }
 
 // DestroyAllWithRequestUUID Destroys all the PotentialProviders associated with a Request depending
 //  on whether the current user is a SuperAdmin or the Request's creator.
-func (p *PotentialProviders) DestroyAllWithRequestUUID(requestUUID string, currentUser User) error {
+func (p *PotentialProviders) DestroyAllWithRequestUUID(tx *pop.Connection, requestUUID string, currentUser User) error {
 	var request Request
-	if err := request.FindByUUID(requestUUID); err != nil {
+	if err := request.FindByUUID(tx, requestUUID); err != nil {
 		return errors.New("unable to find Request in order to remove PotentialProviders: " + err.Error())
 	}
 
@@ -225,8 +228,8 @@ func (p *PotentialProviders) DestroyAllWithRequestUUID(requestUUID string, curre
 			currentUser.ID, request.ID)
 	}
 
-	if err := DB.Where("request_id = ?", request.ID).All(p); err != nil {
+	if err := tx.Where("request_id = ?", request.ID).All(p); err != nil {
 		return errors.New("unable to find Request's Potential Providers in order to remove them: " + err.Error())
 	}
-	return DB.Destroy(p)
+	return tx.Destroy(p)
 }

--- a/application/models/potentialprovider_test.go
+++ b/application/models/potentialprovider_test.go
@@ -56,7 +56,7 @@ func (ms *ModelSuite) TestPotentialProviders_FindUsersByRequestID() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			providers := PotentialProviders{}
-			users, err := providers.FindUsersByRequestID(tt.request, tt.user)
+			users, err := providers.FindUsersByRequestID(ms.DB, tt.request, tt.user)
 			ms.NoError(err, "unexpected error")
 			ids := make([]int, len(users))
 			for i, u := range users {
@@ -108,7 +108,7 @@ func (ms *ModelSuite) TestPotentialProvider_FindWithRequestUUIDAndUserUUID() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := PotentialProvider{}
-			err := provider.FindWithRequestUUIDAndUserUUID(tt.request.UUID.String(),
+			err := provider.FindWithRequestUUIDAndUserUUID(Ctx(), tt.request.UUID.String(),
 				tt.ppUserUUID.String(), tt.currentUser)
 
 			if tt.wantErr != "" {
@@ -160,7 +160,7 @@ func (ms *ModelSuite) TestPotentialProviders_DestroyAllWithRequestUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			providers := PotentialProviders{}
-			err := providers.DestroyAllWithRequestUUID(test.request.UUID.String(), test.currentUser)
+			err := providers.DestroyAllWithRequestUUID(ms.DB, test.request.UUID.String(), test.currentUser)
 
 			if test.wantErr != "" {
 				ms.Error(err, "did not get error as expected")
@@ -201,7 +201,7 @@ func (ms *ModelSuite) TestNewWithRequestUUID() {
 			name:    "bad - using request's CreatedBy",
 			request: requests[0],
 			userID:  users[0].ID,
-			wantErr: "PotentialProvider User must not be the Request's Receiver.",
+			wantErr: "the PotentialProvider User must not be the Request's Receiver",
 		},
 		{
 			name:    "good - second request second user",
@@ -212,7 +212,7 @@ func (ms *ModelSuite) TestNewWithRequestUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			provider := PotentialProvider{}
-			err := provider.NewWithRequestUUID(test.request.UUID.String(), test.userID)
+			err := provider.NewWithRequestUUID(Ctx(), test.request.UUID.String(), test.userID)
 			if test.wantErr != "" {
 				ms.Error(err, "expected an error but did not get one")
 				ms.Equal(test.wantErr, err.Error(), "incorrect error message")

--- a/application/models/request_fixtures_test.go
+++ b/application/models/request_fixtures_test.go
@@ -168,10 +168,10 @@ func CreateFixturesForRequestsGetFiles(ms *ModelSuite) RequestFixtures {
 	request := Request{CreatedByID: user.ID, OrganizationID: organization.ID, DestinationID: location.ID}
 	createFixture(ms, &request)
 
-	files := createFileFixtures(3)
+	files := createFileFixtures(ms.DB, 3)
 
 	for i := range files {
-		_, err := request.AttachFile(files[i].UUID.String())
+		_, err := request.AttachFile(ms.DB, files[i].UUID.String())
 		ms.NoError(err, "failed to attach file to request fixture")
 	}
 
@@ -239,12 +239,12 @@ func CreateFixtures_Requests_FindByUser(ms *ModelSuite) RequestFixtures {
 		AuthEmail:      users[0].Email,
 	})
 
-	uo, err := users[2].FindUserOrganization(orgs[0])
+	uo, err := users[2].FindUserOrganization(ms.DB, orgs[0])
 	ms.NoError(err)
 	uo.OrganizationID = orgs[2].ID
 	ms.NoError(DB.UpdateColumns(&uo, "organization_id"))
 
-	uo, err = users[3].FindUserOrganization(orgs[0])
+	uo, err = users[3].FindUserOrganization(ms.DB, orgs[0])
 	ms.NoError(err)
 	uo.OrganizationID = orgs[1].ID
 	ms.NoError(DB.UpdateColumns(&uo, "organization_id"))

--- a/application/models/requestfile.go
+++ b/application/models/requestfile.go
@@ -48,6 +48,6 @@ func (p *RequestFile) ValidateUpdate(tx *pop.Connection) (*validate.Errors, erro
 }
 
 // Create stores the RequestFile data as a new record in the database.
-func (p *RequestFile) Create() error {
-	return create(p)
+func (p *RequestFile) Create(tx *pop.Connection) error {
+	return create(tx, p)
 }

--- a/application/models/requesthistory_test.go
+++ b/application/models/requesthistory_test.go
@@ -28,7 +28,7 @@ func (ms *ModelSuite) TestRequestHistory_Load() {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.requestHistory.Load("Receiver")
+			err := test.requestHistory.Load(ms.DB, "Receiver")
 			ms.NoError(err, "did not expect any error")
 
 			ms.Equal(test.wantEmail, test.requestHistory.Receiver.Email, "incorrect Receiver email")
@@ -78,7 +78,7 @@ func (ms *ModelSuite) TestRequestHistory_pop() {
 			test.request.Status = test.newStatus
 			var pHistory RequestHistory
 
-			err := pHistory.popForRequest(test.request, test.currentStatus)
+			err := pHistory.popForRequest(ms.DB, test.request, test.currentStatus)
 			if test.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), test.wantErr, "unexpected error message")
@@ -164,7 +164,7 @@ func (ms *ModelSuite) TestRequestHistory_createForRequest() {
 
 			var pH RequestHistory
 
-			err := pH.createForRequest(test.request)
+			err := pH.createForRequest(ms.DB, test.request)
 			if test.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), test.wantErr, "unexpected error message")

--- a/application/models/threadparticipant.go
+++ b/application/models/threadparticipant.go
@@ -55,21 +55,21 @@ func (t *ThreadParticipant) ValidateUpdate(tx *pop.Connection) (*validate.Errors
 }
 
 // UpdateLastViewedAt sets the last viewed time field and writes to the database
-func (t *ThreadParticipant) UpdateLastViewedAt(lastViewedAt time.Time) error {
+func (t *ThreadParticipant) UpdateLastViewedAt(tx *pop.Connection, lastViewedAt time.Time) error {
 	t.LastViewedAt = lastViewedAt
-	if err := t.Update(); err != nil {
+	if err := t.Update(tx); err != nil {
 		return fmt.Errorf("failed to update thread_participant.last_viewed_at, %s", err)
 	}
 	return nil
 }
 
 // FindByThreadIDAndUserID reads a record by the given Thread ID and User ID
-func (t *ThreadParticipant) FindByThreadIDAndUserID(threadID, userID int) error {
+func (t *ThreadParticipant) FindByThreadIDAndUserID(tx *pop.Connection, threadID, userID int) error {
 	if threadID <= 0 || userID <= 0 {
 		return fmt.Errorf("error finding thread_participant, invalid id ... threadID %v, userID %v", threadID, userID)
 	}
 
-	if err := DB.Where("user_id = ? AND thread_id = ?", userID, threadID).First(t); err != nil {
+	if err := tx.Where("user_id = ? AND thread_id = ?", userID, threadID).First(t); err != nil {
 		return fmt.Errorf("failed to find thread_participant record for user %d and thread %d, %s",
 			userID, threadID, err)
 	}
@@ -77,20 +77,20 @@ func (t *ThreadParticipant) FindByThreadIDAndUserID(threadID, userID int) error 
 }
 
 // UpdateLastNotifiedAt sets LastNotifiedAt and writes to the database
-func (t *ThreadParticipant) UpdateLastNotifiedAt(newTime time.Time) error {
+func (t *ThreadParticipant) UpdateLastNotifiedAt(tx *pop.Connection, newTime time.Time) error {
 	t.LastNotifiedAt = newTime
-	if err := t.Update(); err != nil {
+	if err := t.Update(tx); err != nil {
 		return fmt.Errorf("failed to update thread_participant.last_notified_at, %s", err)
 	}
 	return nil
 }
 
 // Create stores the ThreadParticipant data as a new record in the database.
-func (t *ThreadParticipant) Create() error {
-	return create(t)
+func (t *ThreadParticipant) Create(tx *pop.Connection) error {
+	return create(tx, t)
 }
 
 // Update writes the ThreadParticipant data to an existing database record.
-func (t *ThreadParticipant) Update() error {
-	return update(t)
+func (t *ThreadParticipant) Update(tx *pop.Connection) error {
+	return update(tx, t)
 }

--- a/application/models/threadparticipant_test.go
+++ b/application/models/threadparticipant_test.go
@@ -125,7 +125,7 @@ func (ms *ModelSuite) TestThreadParticipant_UpdateLastViewedAt() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tp := test.threadParticipant
-			err := tp.UpdateLastViewedAt(test.lastViewedAt)
+			err := tp.UpdateLastViewedAt(ms.DB, test.lastViewedAt)
 
 			// reload from database to ensure the new time was saved
 			_ = ms.DB.Reload(&tp)
@@ -205,7 +205,7 @@ func (ms *ModelSuite) TestThreadParticipant_FindByThreadIDAndUserID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var tp ThreadParticipant
-			err := tp.FindByThreadIDAndUserID(test.threadID, test.userID)
+			err := tp.FindByThreadIDAndUserID(ms.DB, test.threadID, test.userID)
 
 			if test.wantErr {
 				ms.Error(err, "did not get an error from FindByThreadIDAndUserID")
@@ -277,7 +277,7 @@ func (ms *ModelSuite) TestThreadParticipant_UpdateLastNotifiedAt() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tp := test.threadParticipant
-			err := tp.UpdateLastNotifiedAt(test.LastNotifiedAt)
+			err := tp.UpdateLastNotifiedAt(ms.DB, test.LastNotifiedAt)
 
 			// reload from database to ensure the new time was saved
 			_ = ms.DB.Reload(&tp)

--- a/application/models/user.go
+++ b/application/models/user.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/events"
 	"github.com/gobuffalo/nulls"
 	"github.com/gobuffalo/pop/v5"
@@ -109,12 +108,12 @@ func (u *User) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // All retrieves all Users from the database.
-func (u *Users) All() error {
-	return DB.Order("nickname asc").All(u)
+func (u *Users) All(ctx context.Context) error {
+	return Tx(ctx).Order("nickname asc").All(u)
 }
 
 // CreateAccessToken - Create and store new UserAccessToken
-func (u *User) CreateAccessToken(org Organization, clientID string) (string, int64, error) {
+func (u *User) CreateAccessToken(tx *pop.Connection, org Organization, clientID string) (string, int64, error) {
 	if clientID == "" {
 		return "", 0, fmt.Errorf("cannot create token with empty clientID for user %s", u.Nickname)
 	}
@@ -130,14 +129,14 @@ func (u *User) CreateAccessToken(org Organization, clientID string) (string, int
 	}
 
 	if org.ID > 0 {
-		userOrg, err := u.FindUserOrganization(org)
+		userOrg, err := u.FindUserOrganization(tx, org)
 		if err != nil {
 			return "", 0, err
 		}
 		userAccessToken.UserOrganizationID = nulls.NewInt(userOrg.ID)
 	}
 
-	if err := userAccessToken.Create(); err != nil {
+	if err := userAccessToken.Create(tx); err != nil {
 		return "", 0, err
 	}
 
@@ -145,13 +144,13 @@ func (u *User) CreateAccessToken(org Organization, clientID string) (string, int
 }
 
 // CreateOrglessAccessToken - Create and store new UserAccessToken with no associated UserOrg
-func (u *User) CreateOrglessAccessToken(clientID string) (string, int64, error) {
-	return u.CreateAccessToken(Organization{}, clientID)
+func (u *User) CreateOrglessAccessToken(tx *pop.Connection, clientID string) (string, int64, error) {
+	return u.CreateAccessToken(tx, Organization{}, clientID)
 }
 
-func (u *User) GetOrgIDs() []int {
+func (u *User) GetOrgIDs(tx *pop.Connection) []int {
 	// ignore the error and allow the user's Organizations to be an empty slice.
-	_ = DB.Load(u, "Organizations")
+	_ = tx.Load(u, "Organizations")
 
 	s := make([]int, len(u.Organizations))
 	for i, v := range u.Organizations {
@@ -161,7 +160,7 @@ func (u *User) GetOrgIDs() []int {
 	return s
 }
 
-func (u *User) hydrateFromAuthUser(authUser *auth.User, authType string) error {
+func (u *User) hydrateFromAuthUser(ctx context.Context, authUser *auth.User, authType string) error {
 	newUser := true
 	if u.ID != 0 {
 		newUser = false
@@ -183,11 +182,11 @@ func (u *User) hydrateFromAuthUser(authUser *auth.User, authType string) error {
 	// if new user they will need a unique Nickname
 	if newUser {
 		u.Nickname = authUser.Nickname
-		if err := u.uniquifyNickname(getShuffledPrefixes()); err != nil {
+		if err := u.uniquifyNickname(Tx(ctx), getShuffledPrefixes()); err != nil {
 			return err
 		}
 	}
-	if err := u.Save(); err != nil {
+	if err := u.Save(ctx); err != nil {
 		return errors.New("unable to save user record: " + err.Error())
 	}
 
@@ -202,9 +201,10 @@ func (u *User) hydrateFromAuthUser(authUser *auth.User, authType string) error {
 	return nil
 }
 
-func (u *User) FindOrCreateFromAuthUser(orgID int, authUser *auth.User) error {
-	var userOrgs UserOrganizations
-	err := userOrgs.FindByAuthEmail(authUser.Email, orgID)
+func (u *User) FindOrCreateFromAuthUser(ctx context.Context, orgID int, authUser *auth.User) error {
+	userOrgs := UserOrganizations{}
+	tx := Tx(ctx)
+	err := userOrgs.FindByAuthEmail(tx, authUser.Email, orgID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -217,13 +217,13 @@ func (u *User) FindOrCreateFromAuthUser(orgID int, authUser *auth.User) error {
 		if userOrgs[0].AuthID != authUser.UserID {
 			return errors.New("a user in this organization with this email address already exists with different user id")
 		}
-		err = DB.Where("uuid = ?", userOrgs[0].User.UUID).First(u)
+		err = tx.Where("uuid = ?", userOrgs[0].User.UUID).First(u)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 	}
 
-	if err := u.hydrateFromAuthUser(authUser, ""); err != nil {
+	if err := u.hydrateFromAuthUser(ctx, authUser, ""); err != nil {
 		return err
 	}
 
@@ -236,7 +236,7 @@ func (u *User) FindOrCreateFromAuthUser(orgID int, authUser *auth.User) error {
 			AuthEmail:      u.Email,
 			LastLogin:      time.Now(),
 		}
-		err = userOrg.Create()
+		err = userOrg.Create(tx)
 		if err != nil {
 			return fmt.Errorf("unable to create new user_organization record: %s", err.Error())
 		}
@@ -247,12 +247,12 @@ func (u *User) FindOrCreateFromAuthUser(orgID int, authUser *auth.User) error {
 
 // FindOrCreateFromOrglessAuthUser creates a new User based on an auth.User and
 // sets its SocialAuthProvider field so they can login again in future.
-func (u *User) FindOrCreateFromOrglessAuthUser(authUser *auth.User, authType string) error {
-	if err := DB.Where("email = ?", authUser.Email).First(u); domain.IsOtherThanNoRows(err) {
+func (u *User) FindOrCreateFromOrglessAuthUser(ctx context.Context, authUser *auth.User, authType string) error {
+	if err := Tx(ctx).Where("email = ?", authUser.Email).First(u); domain.IsOtherThanNoRows(err) {
 		return errors.WithStack(err)
 	}
 
-	return u.hydrateFromAuthUser(authUser, authType)
+	return u.hydrateFromAuthUser(ctx, authUser, authType)
 }
 
 // CanCreateOrganization returns true if the given user is allowed to create organizations
@@ -266,14 +266,14 @@ func (u *User) CanCreateOrganizationTrust() bool {
 }
 
 // CanRemoveOrganizationTrust returns true if the given user is allowed to remove an OrganizationTrust
-func (u *User) CanRemoveOrganizationTrust(orgId int) bool {
+func (u *User) CanRemoveOrganizationTrust(ctx context.Context, orgId int) bool {
 	// if user is a system admin, allow
 	if u.AdminRole == UserAdminRoleSuperAdmin || u.AdminRole == UserAdminRoleSalesAdmin {
 		return true
 	}
 
 	// make sure we're checking current user orgs
-	if err := DB.Load(u, "UserOrganizations"); err != nil {
+	if err := Tx(ctx).Load(u, "UserOrganizations"); err != nil {
 		return false
 	}
 
@@ -287,14 +287,14 @@ func (u *User) CanRemoveOrganizationTrust(orgId int) bool {
 }
 
 // CanViewOrganization returns true if the given user is allowed to view the specified organization
-func (u *User) CanViewOrganization(orgId int) bool {
+func (u *User) CanViewOrganization(ctx context.Context, orgId int) bool {
 	// if user is a system admin, allow
 	if u.AdminRole == UserAdminRoleSuperAdmin || u.AdminRole == UserAdminRoleSalesAdmin {
 		return true
 	}
 
 	// make sure we're checking current user orgs
-	if err := DB.Load(u, "UserOrganizations"); err != nil {
+	if err := Tx(ctx).Load(u, "UserOrganizations"); err != nil {
 		return false
 	}
 
@@ -307,14 +307,14 @@ func (u *User) CanViewOrganization(orgId int) bool {
 	return false
 }
 
-func (u *User) CanEditOrganization(orgId int) bool {
+func (u *User) CanEditOrganization(ctx context.Context, orgId int) bool {
 	// if user is a system admin, allow
 	if u.AdminRole == UserAdminRoleSuperAdmin || u.AdminRole == UserAdminRoleSalesAdmin {
 		return true
 	}
 
 	// make sure we're checking current user orgs
-	if err := DB.Load(u, "UserOrganizations"); err != nil {
+	if err := Tx(ctx).Load(u, "UserOrganizations"); err != nil {
 		return false
 	}
 
@@ -342,7 +342,7 @@ func (u *User) CanUpdateRequestStatus(request Request, newStatus RequestStatus) 
 	return request.canUserChangeStatus(*u, newStatus)
 }
 
-func (u *User) CanViewRequest(request Request) bool {
+func (u *User) CanViewRequest(ctx context.Context, request Request) bool {
 	if u.AdminRole == UserAdminRoleSuperAdmin {
 		return true
 	}
@@ -356,8 +356,10 @@ func (u *User) CanViewRequest(request Request) bool {
 		return true
 	}
 
+	tx := Tx(ctx)
+
 	// If the user has a matching org, then yes
-	uOrgIDs := u.GetOrgIDs()
+	uOrgIDs := u.GetOrgIDs(tx)
 	for _, oID := range uOrgIDs {
 		if oID == request.OrganizationID {
 			return true
@@ -372,7 +374,7 @@ func (u *User) CanViewRequest(request Request) bool {
 	// Check Trusted Orgs
 	var orgTrust OrganizationTrust
 	for _, oID := range uOrgIDs {
-		err := orgTrust.FindByOrgIDs(request.OrganizationID, oID)
+		err := orgTrust.FindByOrgIDs(tx, request.OrganizationID, oID)
 		if err == nil {
 			return true
 		}
@@ -382,12 +384,12 @@ func (u *User) CanViewRequest(request Request) bool {
 }
 
 // FindByUUID find a User with the given UUID and loads it from the database.
-func (u *User) FindByUUID(uuid string) error {
+func (u *User) FindByUUID(ctx context.Context, uuid string) error {
 	if uuid == "" {
 		return errors.New("error: uuid must not be blank")
 	}
 
-	if err := DB.Where("uuid = ?", uuid).First(u); err != nil {
+	if err := Tx(ctx).Where("uuid = ?", uuid).First(u); err != nil {
 		return fmt.Errorf("error finding user by uuid: %s", err.Error())
 	}
 
@@ -395,12 +397,12 @@ func (u *User) FindByUUID(uuid string) error {
 }
 
 // FindByID finds a User with a given ID and loads it from the database
-func (u *User) FindByID(id int, eagerFields ...string) error {
+func (u *User) FindByID(tx *pop.Connection, id int, eagerFields ...string) error {
 	if id <= 0 {
 		return errors.New("error finding user: id must be a positive number")
 	}
 
-	if err := DB.Eager(eagerFields...).Find(u, id); err != nil {
+	if err := tx.Eager(eagerFields...).Find(u, id); err != nil {
 		return fmt.Errorf("error finding user by id: %v, ... %v", id, err.Error())
 	}
 
@@ -408,8 +410,8 @@ func (u *User) FindByID(id int, eagerFields ...string) error {
 }
 
 // FindByEmail finds a User with a matching email
-func (u *User) FindByEmail(email string) error {
-	if err := DB.Where("email = ?", email).First(u); err != nil {
+func (u *User) FindByEmail(tx *pop.Connection, email string) error {
+	if err := tx.Where("email = ?", email).First(u); err != nil {
 		return fmt.Errorf("error finding user by email: %s, ... %s",
 			email, err.Error())
 	}
@@ -418,20 +420,20 @@ func (u *User) FindByEmail(email string) error {
 }
 
 // FindByEmailAndSocialAuthProvider finds a User with a matching email and social_auth_provider
-func (u *User) FindByEmailAndSocialAuthProvider(email, auth_provider string) error {
-	err := DB.Where("email = ? and social_auth_provider = ?", email, auth_provider).First(u)
+func (u *User) FindByEmailAndSocialAuthProvider(tx *pop.Connection, email, authProvider string) error {
+	err := tx.Where("email = ? and social_auth_provider = ?", email, authProvider).First(u)
 	if err != nil {
 		return fmt.Errorf("error finding user by email and auth provider: %s, %s, ... %s",
-			email, auth_provider, err.Error())
+			email, authProvider, err.Error())
 	}
 
 	return nil
 }
 
 // FindByIDs finds all Users associated with the given IDs and loads them from the database
-func (u *Users) FindByIDs(ids []int) error {
+func (u *Users) FindByIDs(tx *pop.Connection, ids []int) error {
 	ids = domain.UniquifyIntSlice(ids)
-	return DB.Where("id in (?)", ids).All(u)
+	return tx.Where("id in (?)", ids).All(u)
 }
 
 // HashClientIdAccessToken just returns a sha256.Sum256 of the input value
@@ -439,48 +441,48 @@ func HashClientIdAccessToken(accessToken string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(accessToken)))
 }
 
-func (u *User) GetOrganizations() (Organizations, error) {
-	if err := DB.Load(u, "Organizations"); err != nil {
+func (u *User) GetOrganizations(ctx context.Context) (Organizations, error) {
+	if err := Tx(ctx).Load(u, "Organizations"); err != nil {
 		return nil, fmt.Errorf("error getting organizations for user id %v ... %v", u.ID, err)
 	}
 
 	return u.Organizations, nil
 }
 
-func (u *User) FindUserOrganization(org Organization) (UserOrganization, error) {
+func (u *User) FindUserOrganization(tx *pop.Connection, org Organization) (UserOrganization, error) {
 	var userOrg UserOrganization
-	if err := DB.Where("user_id = ? AND organization_id = ?", u.ID, org.ID).First(&userOrg); err != nil {
+	if err := tx.Where("user_id = ? AND organization_id = ?", u.ID, org.ID).First(&userOrg); err != nil {
 		return UserOrganization{}, fmt.Errorf("association not found for user '%v' and org '%v' (%s)", u.Nickname, org.Name, err.Error())
 	}
 
 	return userOrg, nil
 }
 
-func (u *User) Requests(requestRole string) ([]Request, error) {
+func (u *User) Requests(ctx context.Context, requestRole string) ([]Request, error) {
 	fk := map[string]string{
 		RequestsCreated:   "created_by_id=?",
 		RequestsProviding: "provider_id=?",
 	}
 	var requests Requests
-	if err := DB.Where(fk[requestRole], u.ID).Order("updated_at desc").All(&requests); err != nil {
+	if err := Tx(ctx).Where(fk[requestRole], u.ID).Order("updated_at desc").All(&requests); err != nil {
 		return nil, fmt.Errorf("error getting requests for user id %v ... %v", u.ID, err)
 	}
 	return requests, nil
 }
 
 // AttachPhoto assigns a previously-stored File to this User as a profile photo
-func (u *User) AttachPhoto(fileID string) (File, error) {
-	return addFile(u, fileID)
+func (u *User) AttachPhoto(ctx context.Context, fileID string) (File, error) {
+	return addFile(Tx(ctx), u, fileID)
 }
 
 // RemoveFile removes an attached file from the User profile
-func (u *User) RemoveFile() error {
-	return removeFile(u)
+func (u *User) RemoveFile(ctx context.Context) error {
+	return removeFile(Tx(ctx), u)
 }
 
 // GetPhotoID retrieves the UUID of the User's photo file
-func (u *User) GetPhotoID() (*string, error) {
-	if err := DB.Load(u, "PhotoFile"); err != nil {
+func (u *User) GetPhotoID(ctx context.Context) (*string, error) {
+	if err := Tx(ctx).Load(u, "PhotoFile"); err != nil {
 		return nil, err
 	}
 	if u.FileID.Valid {
@@ -492,8 +494,9 @@ func (u *User) GetPhotoID() (*string, error) {
 }
 
 // GetPhotoURL retrieves the photo URL from the attached file
-func (u *User) GetPhotoURL() (*string, error) {
-	if err := DB.Load(u, "PhotoFile"); err != nil {
+func (u *User) GetPhotoURL(ctx context.Context) (*string, error) {
+	tx := Tx(ctx)
+	if err := tx.Load(u, "PhotoFile"); err != nil {
 		return nil, err
 	}
 
@@ -505,19 +508,19 @@ func (u *User) GetPhotoURL() (*string, error) {
 		return &url, nil
 	}
 
-	if err := u.PhotoFile.RefreshURL(); err != nil {
+	if err := u.PhotoFile.RefreshURL(tx); err != nil {
 		return nil, err
 	}
 	return &u.PhotoFile.URL, nil
 }
 
-// Save wraps DB.Save() call to check for errors and operate on attached object
-func (u *User) Save() error {
+// Save wraps tx.Save() call to check for errors and operate on attached object
+func (u *User) Save(ctx context.Context) error {
 	u.Nickname = domain.RemoveUnwantedChars(u.Nickname, "-_ .,'&@")
-	return save(u)
+	return save(Tx(ctx), u)
 }
 
-func (u *User) uniquifyNickname(prefixes [30]string) error {
+func (u *User) uniquifyNickname(tx *pop.Connection, prefixes [30]string) error {
 	simpleNN := u.Nickname
 	if simpleNN == "" {
 		simpleNN = u.FirstName
@@ -533,7 +536,7 @@ func (u *User) uniquifyNickname(prefixes [30]string) error {
 		u.Nickname = p + " " + simpleNN
 
 		var existingUser User
-		err = DB.Where("nickname = ?", u.Nickname).First(&existingUser)
+		err = tx.Where("nickname = ?", u.Nickname).First(&existingUser)
 
 		// We didn't find a match, so we're good with the current nickname
 		if existingUser.Nickname == "" {
@@ -550,12 +553,12 @@ func (u *User) uniquifyNickname(prefixes [30]string) error {
 }
 
 // GetLocation reads the location record, if it exists, and returns the Location object.
-func (u *User) GetLocation() (*Location, error) {
+func (u *User) GetLocation(ctx context.Context) (*Location, error) {
 	if !u.LocationID.Valid {
 		return nil, nil
 	}
 	location := Location{}
-	if err := DB.Find(&location, u.LocationID); err != nil {
+	if err := Tx(ctx).Find(&location, u.LocationID); err != nil {
 		return nil, err
 	}
 
@@ -563,26 +566,27 @@ func (u *User) GetLocation() (*Location, error) {
 }
 
 // SetLocation sets the user location fields, creating a new record in the database if necessary.
-func (u *User) SetLocation(location Location) error {
+func (u *User) SetLocation(ctx context.Context, location Location) error {
+	tx := Tx(ctx)
 	if u.LocationID.Valid {
 		location.ID = u.LocationID.Int
 		u.Location = location
-		return u.Location.Update()
+		return u.Location.Update(tx)
 	}
-	if err := location.Create(); err != nil {
+	if err := location.Create(ctx); err != nil {
 		return err
 	}
 	u.LocationID = nulls.NewInt(location.ID)
-	return u.Save()
+	return u.Save(ctx)
 }
 
 // RemoveLocation removes the location record associated with the user
-func (u *User) RemoveLocation() error {
+func (u *User) RemoveLocation(ctx context.Context) error {
 	if !u.LocationID.Valid {
 		return nil
 	}
 
-	if err := DB.Destroy(&Location{ID: u.LocationID.Int}); err != nil {
+	if err := Tx(ctx).Destroy(&Location{ID: u.LocationID.Int}); err != nil {
 		return err
 	}
 	u.LocationID = nulls.Int{}
@@ -597,18 +601,18 @@ type UnreadThread struct {
 
 // UnreadMessageCount returns an entry for each thread that has other users' messages
 // that have not yet been read by this this user.
-func (u *User) UnreadMessageCount() ([]UnreadThread, error) {
+func (u *User) UnreadMessageCount(ctx context.Context) ([]UnreadThread, error) {
 	emptyUnreads := []UnreadThread{}
 
 	threadPs := ThreadParticipants{}
-	if err := DB.Eager("Thread").Where("user_id = ?", u.ID).All(&threadPs); err != nil {
+	if err := Tx(ctx).Eager("Thread").Where("user_id = ?", u.ID).All(&threadPs); err != nil {
 		return emptyUnreads, err
 	}
 
 	unreads := []UnreadThread{}
 
 	for _, tp := range threadPs {
-		msgCount, err := tp.Thread.UnreadMessageCount(u.ID, tp.LastViewedAt)
+		msgCount, err := tp.Thread.UnreadMessageCount(ctx, u.ID, tp.LastViewedAt)
 		if err != nil {
 			domain.ErrLogger.Printf("error getting count of unread messages for thread %s ... %v",
 				tp.Thread.UUID, err)
@@ -624,9 +628,9 @@ func (u *User) UnreadMessageCount() ([]UnreadThread, error) {
 }
 
 // GetThreads finds all threads that the user is participating in.
-func (u *User) GetThreads() (Threads, error) {
+func (u *User) GetThreads(ctx context.Context) (Threads, error) {
 	var t Threads
-	query := DB.Q().
+	query := Tx(ctx).Q().
 		LeftJoin("thread_participants tp", "threads.id = tp.thread_id").
 		Where("tp.user_id = ?", u.ID).
 		Order("updated_at desc")
@@ -638,25 +642,25 @@ func (u *User) GetThreads() (Threads, error) {
 }
 
 // WantsRequestNotification answers the question "Does the user want notifications for this request?"
-func (u *User) WantsRequestNotification(request Request) bool {
+func (u *User) WantsRequestNotification(tx *pop.Connection, request Request) bool {
 	if request.CreatedByID == u.ID {
 		return false
 	}
 
-	if u.isNearRequest(request) {
+	if u.isNearRequest(tx, request) {
 		return true
 	}
 
-	return u.hasMatchingWatch(request)
+	return u.hasMatchingWatch(tx, request)
 }
 
-func (u *User) isNearRequest(request Request) bool {
-	if err := DB.Load(u, "Location"); err != nil {
+func (u *User) isNearRequest(tx *pop.Connection, request Request) bool {
+	if err := tx.Load(u, "Location"); err != nil {
 		domain.ErrLogger.Printf("load of user location failed, %s", err)
 		return false
 	}
 
-	requestOrigin, err := request.GetOrigin()
+	requestOrigin, err := request.GetOrigin(tx)
 	if err != nil {
 		domain.ErrLogger.Printf("failed to get request origin, %s", err)
 		return false
@@ -671,14 +675,14 @@ func (u *User) isNearRequest(request Request) bool {
 	return false
 }
 
-func (u *User) hasMatchingWatch(request Request) bool {
+func (u *User) hasMatchingWatch(tx *pop.Connection, request Request) bool {
 	watches := Watches{}
-	if err := watches.FindByUser(*u); err != nil {
+	if err := watches.FindByUser(tx, *u); err != nil {
 		domain.ErrLogger.Printf("failed to get watch list, %s", err)
 		return false
 	}
 	for _, watch := range watches {
-		if watch.matchesRequest(request) {
+		if watch.matchesRequest(tx, request) {
 			return true
 		}
 	}
@@ -687,8 +691,8 @@ func (u *User) hasMatchingWatch(request Request) bool {
 }
 
 // GetPreferences returns a StandardPreferences struct
-func (u *User) GetPreferences() (StandardPreferences, error) {
-	if err := DB.Load(u, "UserPreferences"); err != nil {
+func (u *User) GetPreferences(tx *pop.Connection) (StandardPreferences, error) {
+	if err := tx.Load(u, "UserPreferences"); err != nil {
 		err := errors.New("error getting user preferences ... " + err.Error())
 		return StandardPreferences{}, err
 	}
@@ -726,16 +730,17 @@ func (u *User) GetPreferences() (StandardPreferences, error) {
 }
 
 // UpdateStandardPreferences validates and updates a user's standard preferences
-func (u *User) UpdateStandardPreferences(prefs StandardPreferences) (StandardPreferences, error) {
-	if err := updateUsersStandardPreferences(*u, prefs); err != nil {
+func (u *User) UpdateStandardPreferences(ctx context.Context, prefs StandardPreferences) (StandardPreferences, error) {
+	tx := Tx(ctx)
+	if err := updateUsersStandardPreferences(tx, *u, prefs); err != nil {
 		return StandardPreferences{}, err
 	}
 
-	return u.GetPreferences()
+	return u.GetPreferences(tx)
 }
 
-func (u User) GetLanguagePreference() string {
-	prefs, err := u.GetPreferences()
+func (u User) GetLanguagePreference(tx *pop.Connection) string {
+	prefs, err := u.GetPreferences(tx)
 	if err != nil || prefs.Language == "" {
 		return domain.UserPreferenceLanguageEnglish
 	}
@@ -749,9 +754,9 @@ func (u *User) GetRealName() string {
 }
 
 // HasOrganization returns true if the user has one or more organization connections
-func (u *User) HasOrganization() bool {
+func (u *User) HasOrganization(tx *pop.Connection) bool {
 	var c Count
-	err := DB.RawQuery("SELECT COUNT(*) FROM user_organizations WHERE user_id = ?", u.ID).First(&c)
+	err := tx.RawQuery("SELECT COUNT(*) FROM user_organizations WHERE user_id = ?", u.ID).First(&c)
 	if err != nil {
 		domain.ErrLogger.Printf("error counting user organizations, user = '%s', err = %s", u.UUID, err)
 		return false
@@ -769,7 +774,7 @@ func (u *User) isSuperAdmin() bool {
 // MeetingsAsParticipant returns all meetings in which the user is a participant
 func (u *User) MeetingsAsParticipant(ctx context.Context) ([]Meeting, error) {
 	m := Meetings{}
-	if err := DB.
+	if err := Tx(ctx).
 		Where("meeting_participants.user_id=?", u.ID).
 		Join("meeting_participants", "meeting_participants.meeting_id=meetings.id").
 		All(&m); err != nil {
@@ -779,27 +784,27 @@ func (u *User) MeetingsAsParticipant(ctx context.Context) ([]Meeting, error) {
 	return m, nil
 }
 
-func (u *User) CanCreateMeetingInvite(ctx buffalo.Context, meeting Meeting) bool {
+func (u *User) CanCreateMeetingInvite(ctx context.Context, meeting Meeting) bool {
 	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }
 
-func (u *User) CanRemoveMeetingInvite(ctx buffalo.Context, meeting Meeting) bool {
+func (u *User) CanRemoveMeetingInvite(ctx context.Context, meeting Meeting) bool {
 	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }
 
-func (u *User) CanCreateMeetingParticipant(ctx buffalo.Context, meeting Meeting) bool {
+func (u *User) CanCreateMeetingParticipant(ctx context.Context, meeting Meeting) bool {
 	return u.ID == meeting.CreatedByID || meeting.isVisible(ctx, u.ID) || u.isSuperAdmin()
 }
 
-func (u *User) CanRemoveMeetingParticipant(ctx buffalo.Context, meeting Meeting) bool {
+func (u *User) CanRemoveMeetingParticipant(ctx context.Context, meeting Meeting) bool {
 	return u.ID == meeting.CreatedByID || meeting.isOrganizer(ctx, u.ID) || u.isSuperAdmin()
 }
 
 // RemovePreferences removes all of the users's preferences
-func (u *User) RemovePreferences() error {
+func (u *User) RemovePreferences(ctx context.Context) error {
 	if u == nil || u.ID < 1 {
 		return nil
 	}
 	var p UserPreference
-	return p.removeAll(u.ID)
+	return p.removeAll(Tx(ctx), u.ID)
 }

--- a/application/models/user_fixtures_test.go
+++ b/application/models/user_fixtures_test.go
@@ -96,8 +96,8 @@ func CreateFixturesForUserGetRequests(ms *ModelSuite) UserRequestFixtures {
 
 	requests := createRequestFixtures(ms.DB, 4, false)
 	userID := users[1].UUID.String()
-	requests[0].SetProviderWithStatus(RequestStatusAccepted, &userID)
-	requests[1].SetProviderWithStatus(RequestStatusAccepted, &userID)
+	requests[0].SetProviderWithStatus(Ctx(), RequestStatusAccepted, &userID)
+	requests[1].SetProviderWithStatus(Ctx(), RequestStatusAccepted, &userID)
 	requests[2].Status = RequestStatusAccepted
 	requests[3].Status = RequestStatusAccepted
 	ms.NoError(ms.DB.Save(&requests))
@@ -142,13 +142,13 @@ func CreateFixturesForUserCanViewRequest(ms *ModelSuite) UserRequestFixtures {
 	})
 
 	// Switch User2's org to Org2
-	uo, err := users[2].FindUserOrganization(orgs[0])
+	uo, err := users[2].FindUserOrganization(ms.DB, orgs[0])
 	ms.NoError(err)
 	uo.OrganizationID = orgs[2].ID
 	ms.NoError(DB.UpdateColumns(&uo, "organization_id"))
 
 	// Switch User3's org to Org2
-	uo, err = users[3].FindUserOrganization(orgs[0])
+	uo, err = users[3].FindUserOrganization(ms.DB, orgs[0])
 	ms.NoError(err)
 	uo.OrganizationID = orgs[2].ID
 	ms.NoError(DB.UpdateColumns(&uo, "organization_id"))
@@ -178,7 +178,7 @@ func CreateFixturesForUserCanViewRequest(ms *ModelSuite) UserRequestFixtures {
 func createFixturesForTestUserGetPhoto(ms *ModelSuite) UserRequestFixtures {
 	ms.NoError(aws.CreateS3Bucket())
 
-	fileFixtures := createFileFixtures(2)
+	fileFixtures := createFileFixtures(ms.DB, 2)
 
 	unique := domain.GetUUID()
 	users := Users{
@@ -402,12 +402,12 @@ func CreateFixturesForUserWantsRequestNotification(ms *ModelSuite) UserRequestFi
 	}
 
 	requests := createRequestFixtures(ms.DB, 3, false)
-	requestOneLocation, err := requests[1].GetOrigin()
+	requestOneLocation, err := requests[1].GetOrigin(ms.DB)
 	ms.NoError(err)
-	ms.NoError(users[1].SetLocation(*requestOneLocation))
+	ms.NoError(users[1].SetLocation(Ctx(), *requestOneLocation))
 
 	// make a copy of the request destination and assign it to a watch
-	watchLocation, err := requests[2].GetDestination()
+	watchLocation, err := requests[2].GetDestination(ms.DB)
 	ms.NoError(err)
 	createFixture(ms, watchLocation)
 	watch := Watch{

--- a/application/models/useraccesstoken.go
+++ b/application/models/useraccesstoken.go
@@ -59,15 +59,15 @@ func (u *UserAccessToken) ValidateUpdate(tx *pop.Connection) (*validate.Errors, 
 	return validate.NewErrors(), nil
 }
 
-func (u *UserAccessToken) DeleteByBearerToken(bearerToken string) error {
-	if err := u.FindByBearerToken(bearerToken); err != nil {
+func (u *UserAccessToken) DeleteByBearerToken(tx *pop.Connection, bearerToken string) error {
+	if err := u.FindByBearerToken(tx, bearerToken); err != nil {
 		return err
 	}
-	return DB.Destroy(u)
+	return tx.Destroy(u)
 }
 
-func (u *UserAccessToken) FindByBearerToken(bearerToken string) error {
-	if err := DB.Where("access_token = ?", HashClientIdAccessToken(bearerToken)).First(u); err != nil {
+func (u *UserAccessToken) FindByBearerToken(tx *pop.Connection, bearerToken string) error {
+	if err := tx.Where("access_token = ?", HashClientIdAccessToken(bearerToken)).First(u); err != nil {
 		l := len(bearerToken)
 		if l > 5 {
 			l = 5
@@ -79,9 +79,9 @@ func (u *UserAccessToken) FindByBearerToken(bearerToken string) error {
 }
 
 // GetOrganization returns the Organization of the UserOrganization of the UserAccessToken
-func (u *UserAccessToken) GetOrganization() (Organization, error) {
+func (u *UserAccessToken) GetOrganization(tx *pop.Connection) (Organization, error) {
 	if u.UserOrganization.ID <= 0 {
-		if err := DB.Load(u, "UserOrganization"); err != nil {
+		if err := tx.Load(u, "UserOrganization"); err != nil {
 			return Organization{}, fmt.Errorf("error loading user organization for user access token id %v ... %v",
 				u.ID, err)
 		}
@@ -94,7 +94,7 @@ func (u *UserAccessToken) GetOrganization() (Organization, error) {
 	}
 
 	if uOrg.Organization.ID <= 0 {
-		if err := DB.Load(&uOrg, "Organization"); err != nil {
+		if err := tx.Load(&uOrg, "Organization"); err != nil {
 			return Organization{}, fmt.Errorf("error loading user organization for user access token id %v ... %v",
 				u.ID, err)
 		}
@@ -111,17 +111,17 @@ func createAccessTokenExpiry() time.Time {
 }
 
 // Renew extends the token expiration to the configured token lifetime
-func (u *UserAccessToken) Renew() error {
+func (u *UserAccessToken) Renew(tx *pop.Connection) error {
 	u.ExpiresAt = createAccessTokenExpiry()
-	if err := u.Update(); err != nil {
+	if err := u.Update(tx); err != nil {
 		return fmt.Errorf("error renewing access token, %s", err)
 	}
 	return nil
 }
 
 // GetUser returns the User associated with this access token
-func (u *UserAccessToken) GetUser() (User, error) {
-	if err := DB.Load(u, "User"); err != nil {
+func (u *UserAccessToken) GetUser(tx *pop.Connection) (User, error) {
+	if err := tx.Load(u, "User"); err != nil {
 		return User{}, err
 	}
 	if u.User.ID <= 0 {
@@ -132,9 +132,9 @@ func (u *UserAccessToken) GetUser() (User, error) {
 
 // DeleteIfExpired checks the token expiration and returns `true` if expired. Also deletes
 // the token from the database if it is expired.
-func (u *UserAccessToken) DeleteIfExpired() (bool, error) {
+func (u *UserAccessToken) DeleteIfExpired(tx *pop.Connection) (bool, error) {
 	if u.ExpiresAt.Before(time.Now()) {
-		err := DB.Destroy(u)
+		err := tx.Destroy(u)
 		if err != nil {
 			return true, fmt.Errorf("unable to delete expired userAccessToken, id: %v", u.ID)
 		}
@@ -144,14 +144,14 @@ func (u *UserAccessToken) DeleteIfExpired() (bool, error) {
 }
 
 // DeleteExpired removes all expired UserAccessToken records
-func (u *UserAccessTokens) DeleteExpired() (int, error) {
+func (u *UserAccessTokens) DeleteExpired(tx *pop.Connection) (int, error) {
 	var c Count
-	err := DB.RawQuery("SELECT COUNT(*) FROM user_access_tokens WHERE expires_at < ?", time.Now()).First(&c)
+	err := tx.RawQuery("SELECT COUNT(*) FROM user_access_tokens WHERE expires_at < ?", time.Now()).First(&c)
 	if err != nil || c.N == 0 {
 		return 0, err
 	}
 
-	err = DB.RawQuery("DELETE FROM user_access_tokens WHERE expires_at < ?", time.Now()).Exec()
+	err = tx.RawQuery("DELETE FROM user_access_tokens WHERE expires_at < ?", time.Now()).Exec()
 	if err != nil {
 		return 0, err
 	}
@@ -160,11 +160,11 @@ func (u *UserAccessTokens) DeleteExpired() (int, error) {
 }
 
 // Create stores the UserAccessToken data as a new record in the database.
-func (u *UserAccessToken) Create() error {
-	return create(u)
+func (u *UserAccessToken) Create(tx *pop.Connection) error {
+	return create(tx, u)
 }
 
 // Update writes the UserAccessToken data to an existing database record.
-func (u *UserAccessToken) Update() error {
-	return update(u)
+func (u *UserAccessToken) Update(tx *pop.Connection) error {
+	return update(tx, u)
 }

--- a/application/models/useraccesstoken_test.go
+++ b/application/models/useraccesstoken_test.go
@@ -75,7 +75,7 @@ func (ms *ModelSuite) TestUserAccessToken_DeleteByBearerToken() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var uat UserAccessToken
-			err := uat.DeleteByBearerToken(test.token)
+			err := uat.DeleteByBearerToken(ms.DB, test.token)
 			if err != nil && !test.wantErr {
 				t.Errorf("DeleteAccessToken() returned an unexpected error: %s", err)
 			} else if err == nil && test.wantErr {
@@ -104,7 +104,7 @@ func (ms *ModelSuite) TestUserAccessToken_FindByBearerToken() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var u UserAccessToken
-			err := u.FindByBearerToken(test.token)
+			err := u.FindByBearerToken(ms.DB, test.token)
 			if test.wantErr {
 				ms.Error(err)
 				return
@@ -252,7 +252,7 @@ func (ms *ModelSuite) TestUserAccessToken_GetOrganization() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			u := test.token
-			got, err := u.GetOrganization()
+			got, err := u.GetOrganization(ms.DB)
 			if test.wantErr {
 				if err == nil {
 					t.Errorf("Expected an error, but did not get one")
@@ -291,7 +291,7 @@ func (ms *ModelSuite) TestUserAccessToken_GetUser() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			u := test.token
-			got, err := u.GetUser()
+			got, err := u.GetUser(ms.DB)
 			if test.wantErr {
 				if err == nil {
 					t.Errorf("Expected an error, but did not get one")
@@ -353,7 +353,7 @@ func (ms *ModelSuite) TestUserAccessToken_DeleteIfExpired() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			u := test.token
-			got, err := u.DeleteIfExpired()
+			got, err := u.DeleteIfExpired(ms.DB)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 				return
@@ -409,8 +409,8 @@ func (ms *ModelSuite) TestUserAccessToken_Renew() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			u := test.token
-			_ = u.Renew()
-			ms.False(u.DeleteIfExpired())
+			_ = u.Renew(ms.DB)
+			ms.False(u.DeleteIfExpired(ms.DB))
 		})
 	}
 }
@@ -453,7 +453,7 @@ func (ms *ModelSuite) TestUserAccessToken_DeleteExpired() {
 	starting, err := ms.DB.Count(&uats)
 	ms.NoError(err)
 
-	got, err := uats.DeleteExpired()
+	got, err := uats.DeleteExpired(ms.DB)
 
 	ms.NoError(err)
 

--- a/application/models/userorganization.go
+++ b/application/models/userorganization.go
@@ -67,7 +67,7 @@ func (u *UserOrganization) ValidateUpdate(tx *pop.Connection) (*validate.Errors,
 
 // FindByAuthEmail finds UserOrganizations for the given email address. However, if the
 // orgID param is greater than zero, it will find only the one with both that authEmail and orgID.
-func (u *UserOrganizations) FindByAuthEmail(authEmail string, orgID int) error {
+func (u *UserOrganizations) FindByAuthEmail(tx *pop.Connection, authEmail string, orgID int) error {
 	// Validate email address before query
 	errs := validate.Validate(&validators.EmailIsPresent{Field: authEmail})
 	if len(errs.Errors) > 0 {
@@ -82,7 +82,7 @@ func (u *UserOrganizations) FindByAuthEmail(authEmail string, orgID int) error {
 		params = append(params, orgID)
 	}
 
-	if err := DB.Eager().Where(where, params...).All(u); err != nil {
+	if err := tx.Eager().Where(where, params...).All(u); err != nil {
 		return fmt.Errorf("error finding user by email: %s", err.Error())
 	}
 
@@ -90,6 +90,6 @@ func (u *UserOrganizations) FindByAuthEmail(authEmail string, orgID int) error {
 }
 
 // Create stores the UserOrganization data as a new record in the database.
-func (u *UserOrganization) Create() error {
-	return create(u)
+func (u *UserOrganization) Create(tx *pop.Connection) error {
+	return create(tx, u)
 }

--- a/application/models/userorganization_test.go
+++ b/application/models/userorganization_test.go
@@ -68,7 +68,7 @@ func (ms *ModelSuite) TestUserOrganization_FindByAuthEmail() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got UserOrganizations
-			err := got.FindByAuthEmail(tt.args.authEmail, 0)
+			err := got.FindByAuthEmail(ms.DB, tt.args.authEmail, 0)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FindByAuthEmail() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/application/models/userpreference_test.go
+++ b/application/models/userpreference_test.go
@@ -128,7 +128,7 @@ func (ms *ModelSuite) TestUserPreference_FindByUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var u UserPreference
-			err := u.FindByUUID(test.uuid)
+			err := u.FindByUUID(ms.DB, test.uuid)
 			if test.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), test.wantErr)
@@ -175,7 +175,7 @@ func (ms *ModelSuite) TestUserPreference_Save() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.pref.Save()
+			err := test.pref.Save(ms.DB)
 			if test.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), test.wantErr)
@@ -184,7 +184,7 @@ func (ms *ModelSuite) TestUserPreference_Save() {
 			ms.NoError(err)
 
 			var u UserPreference
-			ms.NoError(u.FindByUUID(test.pref.UUID.String()))
+			ms.NoError(u.FindByUUID(ms.DB, test.pref.UUID.String()))
 			ms.Equal(test.pref.UserID, u.UserID)
 			ms.Equal(test.pref.Key, u.Key)
 			ms.Equal(test.pref.Value, u.Value)
@@ -292,7 +292,7 @@ func (ms *ModelSuite) TestUserPreference_updateForUserByKey() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := UserPreference{}
-			err := p.updateForUserByKey(test.user, test.key, test.value)
+			err := p.updateForUserByKey(ms.DB, test.user, test.key, test.value)
 			ms.NoError(err)
 
 			if test.want.ID > 0 {
@@ -336,7 +336,7 @@ func (ms *ModelSuite) TestUserPreference_remove() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := UserPreference{}
-			err := p.remove(test.user, test.key)
+			err := p.remove(ms.DB, test.user, test.key)
 			ms.NoError(err, "unexpected error from UserPreference.remove()")
 
 			err = ms.DB.Where("user_id = ? AND key = ?", test.user.ID, test.key).First(&p)

--- a/application/models/watch.go
+++ b/application/models/watch.go
@@ -53,22 +53,22 @@ func (w *Watch) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // Create stores the Watch data as a new record in the database.
-func (w *Watch) Create() error {
-	return create(w)
+func (w *Watch) Create(ctx context.Context) error {
+	return create(Tx(ctx), w)
 }
 
 // Update writes the Watch data to an existing database record.
-func (w *Watch) Update() error {
-	return update(w)
+func (w *Watch) Update(ctx context.Context) error {
+	return update(Tx(ctx), w)
 }
 
 // FindByUUID loads from DB the Watch record identified by the given UUID
-func (w *Watch) FindByUUID(id string) error {
+func (w *Watch) FindByUUID(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("error: watch uuid must not be blank")
 	}
 
-	if err := DB.Where("uuid = ?", id).First(w); err != nil {
+	if err := Tx(ctx).Where("uuid = ?", id).First(w); err != nil {
 		return fmt.Errorf("error finding watch by uuid: %s", err.Error())
 	}
 
@@ -76,8 +76,8 @@ func (w *Watch) FindByUUID(id string) error {
 }
 
 // FindByUser returns all watches owned by the given user.
-func (w *Watches) FindByUser(user User) error {
-	if err := DB.Where("owner_id = ?", user.ID).Order("updated_at desc").All(w); err != nil {
+func (w *Watches) FindByUser(tx *pop.Connection, user User) error {
+	if err := tx.Where("owner_id = ?", user.ID).Order("updated_at desc").All(w); err != nil {
 		return err
 	}
 
@@ -85,67 +85,69 @@ func (w *Watches) FindByUser(user User) error {
 }
 
 // GetOwner returns the owner of the watch.
-func (w *Watch) GetOwner() (*User, error) {
+func (w *Watch) GetOwner(ctx context.Context) (*User, error) {
 	owner := User{}
-	if err := DB.Find(&owner, w.OwnerID); err != nil {
+	if err := Tx(ctx).Find(&owner, w.OwnerID); err != nil {
 		return nil, err
 	}
 	return &owner, nil
 }
 
 // GetDestination does not check authorization
-func (w *Watch) GetDestination() (*Location, error) {
+func (w *Watch) GetDestination(tx *pop.Connection) (*Location, error) {
 	location := &Location{}
 	if !w.DestinationID.Valid {
 		return nil, nil
 	}
-	if err := DB.Find(location, w.DestinationID); err != nil {
+	if err := tx.Find(location, w.DestinationID); err != nil {
 		return nil, err
 	}
 	return location, nil
 }
 
 // GetOrigin does not check authorization
-func (w *Watch) GetOrigin() (*Location, error) {
+func (w *Watch) GetOrigin(tx *pop.Connection) (*Location, error) {
 	location := &Location{}
 	if !w.OriginID.Valid {
 		return nil, nil
 	}
-	if err := DB.Find(location, w.OriginID); err != nil {
+	if err := tx.Find(location, w.OriginID); err != nil {
 		return nil, err
 	}
 	return location, nil
 }
 
 // SetDestination sets the destination field, creating a new record in the database if necessary.
-func (w *Watch) SetDestination(location Location) error {
+func (w *Watch) SetDestination(ctx context.Context, location Location) error {
+	tx := Tx(ctx)
 	if w.DestinationID.Valid {
 		location.ID = w.DestinationID.Int
-		return location.Update()
+		return location.Update(tx)
 	}
-	if err := location.Create(); err != nil {
+	if err := location.Create(ctx); err != nil {
 		return err
 	}
 	w.DestinationID = nulls.NewInt(location.ID)
-	return w.Update()
+	return w.Update(ctx)
 }
 
 // SetOrigin sets the origin field, creating a new record in the database if necessary.
-func (w *Watch) SetOrigin(location Location) error {
+func (w *Watch) SetOrigin(ctx context.Context, location Location) error {
+	tx := Tx(ctx)
 	if w.OriginID.Valid {
 		location.ID = w.OriginID.Int
-		return location.Update()
+		return location.Update(tx)
 	}
-	if err := location.Create(); err != nil {
+	if err := location.Create(ctx); err != nil {
 		return err
 	}
 	w.OriginID = nulls.NewInt(location.ID)
-	return w.Update()
+	return w.Update(ctx)
 }
 
 // Destroy wraps the Pop function of the same name
-func (w *Watch) Destroy() error {
-	return DB.Destroy(w)
+func (w *Watch) Destroy(ctx context.Context) error {
+	return Tx(ctx).Destroy(w)
 }
 
 func (w *Watch) Meeting(ctx context.Context) (*Meeting, error) {
@@ -153,19 +155,19 @@ func (w *Watch) Meeting(ctx context.Context) (*Meeting, error) {
 		return nil, nil
 	}
 	meeting := &Meeting{}
-	if err := DB.Find(meeting, w.MeetingID); err != nil {
+	if err := Tx(ctx).Find(meeting, w.MeetingID); err != nil {
 		return nil, err
 	}
 	return meeting, nil
 }
 
 // matchesRequest returns true if all non-null watch criteria match the request
-func (w *Watch) matchesRequest(request Request) bool {
+func (w *Watch) matchesRequest(tx *pop.Connection, request Request) bool {
 	if w == nil {
 		domain.ErrLogger.Printf("nil receiver in Watch.matchesRequest")
 		return false
 	}
-	matchFunctions := []func(*Watch, Request) bool{
+	matchFunctions := []func(*Watch, *pop.Connection, Request) bool{
 		(*Watch).sizeMatches,
 		(*Watch).textMatches,
 		(*Watch).meetingMatches,
@@ -173,7 +175,7 @@ func (w *Watch) matchesRequest(request Request) bool {
 		(*Watch).originMatches,
 	}
 	for _, c := range matchFunctions {
-		if !c(w, request) {
+		if !c(w, tx, request) {
 			return false
 		}
 	}
@@ -181,7 +183,7 @@ func (w *Watch) matchesRequest(request Request) bool {
 }
 
 // destinationMatches returns true if watch destination is not provided or passes the IsNear test
-func (w *Watch) destinationMatches(request Request) bool {
+func (w *Watch) destinationMatches(tx *pop.Connection, request Request) bool {
 	if w == nil {
 		domain.ErrLogger.Printf("nil receiver in Watch.destinationMatches")
 		return false
@@ -189,12 +191,12 @@ func (w *Watch) destinationMatches(request Request) bool {
 	if !w.DestinationID.Valid {
 		return true
 	}
-	requestDestination, err := request.GetDestination()
+	requestDestination, err := request.GetDestination(tx)
 	if err != nil {
 		domain.ErrLogger.Printf("failed to get request %s destination in destinationMatches, %s", request.UUID, err)
 		return false
 	}
-	watchDestination, err := w.GetDestination()
+	watchDestination, err := w.GetDestination(tx)
 	if err != nil {
 		domain.ErrLogger.Printf("failed to get watch %s destination in destinationMatches, %s", w.UUID, err)
 	}
@@ -202,7 +204,7 @@ func (w *Watch) destinationMatches(request Request) bool {
 }
 
 // originMatches returns true if watch origin is not provided or passes the IsNear test
-func (w *Watch) originMatches(request Request) bool {
+func (w *Watch) originMatches(tx *pop.Connection, request Request) bool {
 	if w == nil {
 		domain.ErrLogger.Printf("nil receiver in Watch.originMatches")
 		return false
@@ -210,12 +212,12 @@ func (w *Watch) originMatches(request Request) bool {
 	if !w.OriginID.Valid {
 		return true
 	}
-	requestOrigin, err := request.GetOrigin()
+	requestOrigin, err := request.GetOrigin(tx)
 	if err != nil {
 		domain.ErrLogger.Printf("failed to get request %s origin in originMatches, %s", request.UUID, err)
 		return false
 	}
-	watchOrigin, err := w.GetOrigin()
+	watchOrigin, err := w.GetOrigin(tx)
 	if err != nil {
 		domain.ErrLogger.Printf("failed to get watch %s origin in originMatches, %s", w.UUID, err)
 	}
@@ -223,7 +225,7 @@ func (w *Watch) originMatches(request Request) bool {
 }
 
 // meetingMatches returns true if watch meeting is not provided or is identical to the request meeting
-func (w *Watch) meetingMatches(request Request) bool {
+func (w *Watch) meetingMatches(tx *pop.Connection, request Request) bool {
 	if w == nil {
 		domain.ErrLogger.Printf("nil receiver in Watch.meetingMatches")
 		return false
@@ -235,7 +237,7 @@ func (w *Watch) meetingMatches(request Request) bool {
 }
 
 // textMatches returns true if watch text is not provided or is in the request title, description or creator's nickname
-func (w *Watch) textMatches(request Request) bool {
+func (w *Watch) textMatches(tx *pop.Connection, request Request) bool {
 	if w == nil {
 		domain.ErrLogger.Printf("nil receiver in Watch.textMatches")
 		return false
@@ -249,7 +251,7 @@ func (w *Watch) textMatches(request Request) bool {
 	if strings.Contains(request.Description.String, w.SearchText.String) {
 		return true
 	}
-	creator, err := request.Creator()
+	creator, err := request.Creator(tx)
 	if err != nil {
 		domain.ErrLogger.Printf("failed to get request %s creator in textMatches, %s", request.UUID, err)
 		return false
@@ -261,7 +263,7 @@ func (w *Watch) textMatches(request Request) bool {
 }
 
 // sizeMatches returns true if watch size is larger or the same as the request size
-func (w *Watch) sizeMatches(request Request) bool {
+func (w *Watch) sizeMatches(tx *pop.Connection, request Request) bool {
 	if w == nil {
 		domain.ErrLogger.Printf("nil receiver in Watch.sizeMatches")
 		return false


### PR DESCRIPTION
- There are a few unrelated minor changes mixed in, I got on a brief tangent of cleaning up lint warnings
- I am not convinced the mix of `*pop.Connection` and `context.Context` parameters is a good thing. I've gone back and forth on this, and haven't come to a solid conclusion. Cannot use `context.Context` everywhere because some functions are called places that do not have a context. Cannot use `*pop.Connection` everywhere unless a handful of functions are changed to accept the current user. Also, context is helpful for logging extras and calling domain.Logger with context.