### PR TITLE
make models signatures consistent

### DIFF
--- a/application/actions/auth_test.go
+++ b/application/actions/auth_test.go
@@ -411,7 +411,7 @@ func (as *ActionSuite) Test_newAuthUser() {
 	}
 
 	var user models.User
-	err := user.FindOrCreateFromAuthUser(test.Ctx(), orgFixture.ID, &authUser)
+	err := user.FindOrCreateFromAuthUser(as.DB, orgFixture.ID, &authUser)
 	if err != nil {
 		t.Errorf("could not run test because of error calling user.FindOrCreateFromAuthUser ...\n %v", err)
 		return

--- a/application/actions/authsocial.go
+++ b/application/actions/authsocial.go
@@ -329,7 +329,7 @@ func socialLoginBasedAuthCallback(c buffalo.Context, authEmail, clientID string)
 	// if we have an authuser, find or create user in local db and finish login
 	var user models.User
 
-	if err := user.FindOrCreateFromOrglessAuthUser(c, callbackValues.authResp.AuthUser, authType); err != nil {
+	if err := user.FindOrCreateFromOrglessAuthUser(models.Tx(c), callbackValues.authResp.AuthUser, authType); err != nil {
 		return logErrorAndRedirect(c, domain.ErrorWithAuthUser, err.Error())
 	}
 

--- a/application/actions/meeting_fixtures_test.go
+++ b/application/actions/meeting_fixtures_test.go
@@ -95,7 +95,7 @@ func createFixturesForMeetings(as *ActionSuite) meetingQueryFixtures {
 		},
 	}
 	for i := range invites {
-		as.NoError(invites[i].Create(test.Ctx()))
+		as.NoError(invites[i].Create(as.DB))
 	}
 
 	participants := models.MeetingParticipants{

--- a/application/actions/message_test.go
+++ b/application/actions/message_test.go
@@ -1,7 +1,5 @@
 package actions
 
-import "github.com/silinternational/wecarry-api/internal/test"
-
 type messageResponse struct {
 	Message struct {
 		ID      string `json:"id"`
@@ -64,7 +62,7 @@ func (as *ActionSuite) TestCreateMessage() {
 	thread, err := f.Messages[0].GetThread(as.DB)
 	as.NoError(err)
 
-	messages, err := thread.Messages(test.Ctx())
+	messages, err := thread.Messages(as.DB)
 	as.NoError(err)
 	as.Equal(3, len(messages), "incorrect number of thread messages")
 

--- a/application/actions/organization_test.go
+++ b/application/actions/organization_test.go
@@ -70,7 +70,7 @@ func (as *ActionSuite) Test_CreateOrganization() {
 	as.Equal(f.Organizations[1].AuthType, orgs[0].AuthType, "AuthType doesn't match")
 	as.Equal(f.Organizations[1].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
 
-	domains, _ := orgs[0].Domains(test.Ctx())
+	domains, _ := orgs[0].Domains(as.DB)
 	as.Equal(0, len(domains), "new organization has unexpected domains")
 
 	as.Equal(resp.Organization.ID, orgs[0].UUID.String(), "UUID doesn't match")
@@ -453,7 +453,7 @@ func (as *ActionSuite) Test_UpdateOrganization() {
 	as.Equal(f.Organizations[0].Url, orgs[0].Url, "URL doesn't match")
 	as.Equal(f.Organizations[0].AuthType, orgs[0].AuthType, "AuthType doesn't match")
 	as.Equal(f.Organizations[0].AuthConfig, orgs[0].AuthConfig, "AuthConfig doesn't match")
-	dbDomains, _ := orgs[0].Domains(test.Ctx())
+	dbDomains, _ := orgs[0].Domains(as.DB)
 	as.Equal(2, len(dbDomains), "updated organization has unexpected domains")
 	as.Equal(resp.Organization.ID, orgs[0].UUID.String(), "UUID from query doesn't match database")
 }

--- a/application/actions/organizationdomain_test.go
+++ b/application/actions/organizationdomain_test.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"fmt"
 
-	"github.com/silinternational/wecarry-api/internal/test"
 	"github.com/silinternational/wecarry-api/models"
 )
 
@@ -42,7 +41,7 @@ func (as *ActionSuite) Test_CreateUpdateOrganizationDomain() {
 	as.NoError(err)
 
 	as.GreaterOrEqual(1, len(orgs), "no Organization found")
-	domains, err := orgs[0].Domains(test.Ctx())
+	domains, err := orgs[0].Domains(as.DB)
 	as.NoError(err)
 	as.Equal(1, len(domains), "wrong number of domains in DB")
 	as.Equal(testDomain, domains[0].Domain, "wrong domain in DB")

--- a/application/actions/request_test.go
+++ b/application/actions/request_test.go
@@ -532,7 +532,7 @@ func (as *ActionSuite) Test_UpdateRequestStatus_DestroyPotentialProviders() {
 
 	request0 := f.Requests[0]
 	request0.Status = models.RequestStatusAccepted
-	err := request0.Update(test.Ctx())
+	err := request0.Update(as.DB)
 	as.NoError(err, "unable to change Requests's status to prepare for test")
 
 	steps := []struct {
@@ -720,7 +720,7 @@ func (as *ActionSuite) Test_RequestActions() {
 	acceptedRequest.Status = models.RequestStatusAccepted
 	acceptedRequest.ProviderID = nulls.NewInt(provider.ID)
 
-	err := acceptedRequest.Update(test.Ctx())
+	err := acceptedRequest.Update(as.DB)
 	as.NoError(err, "unable to change Requests's status to prepare for test")
 
 	testCases := []struct {

--- a/application/actions/user_fixtures_test.go
+++ b/application/actions/user_fixtures_test.go
@@ -75,7 +75,7 @@ func fixturesForUserQuery(as *ActionSuite) UserQueryFixtures {
 
 	f := test.CreateFileFixture(as.DB)
 
-	_, err := users[1].AttachPhoto(test.Ctx(), f.UUID.String())
+	_, err := users[1].AttachPhoto(as.DB, f.UUID.String())
 	as.NoError(err, "unexpected error attaching photo to user")
 
 	meetings := models.Meetings{

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -268,6 +268,10 @@ type AppError struct {
 	// Don't change the value of these Key entries without making a corresponding change on the UI,
 	// since these will be converted to human-friendly texts on the UI
 	Key string `json:"key"`
+
+	// Message providing detail about the error condition, only provided in development mode
+	DebugMsg string `json:"debug_msg,omitempty"`
+	Message  string
 }
 
 // ErrLogProxy wraps standard error logger plus sends to Rollbar

--- a/application/domain/domain.go
+++ b/application/domain/domain.go
@@ -269,9 +269,7 @@ type AppError struct {
 	// since these will be converted to human-friendly texts on the UI
 	Key string `json:"key"`
 
-	// Message providing detail about the error condition, only provided in development mode
 	DebugMsg string `json:"debug_msg,omitempty"`
-	Message  string
 }
 
 // ErrLogProxy wraps standard error logger plus sends to Rollbar

--- a/application/gqlgen/generated.go
+++ b/application/gqlgen/generated.go
@@ -284,6 +284,7 @@ type MeetingResolver interface {
 	Organizers(ctx context.Context, obj *models.Meeting) ([]PublicProfile, error)
 }
 type MeetingInviteResolver interface {
+	Meeting(ctx context.Context, obj *models.MeetingInvite) (*models.Meeting, error)
 	Inviter(ctx context.Context, obj *models.MeetingInvite) (*PublicProfile, error)
 
 	AvatarURL(ctx context.Context, obj *models.MeetingInvite) (string, error)
@@ -399,6 +400,7 @@ type UserResolver interface {
 	UnreadMessageCount(ctx context.Context, obj *models.User) (int, error)
 	Organizations(ctx context.Context, obj *models.User) ([]models.Organization, error)
 	Requests(ctx context.Context, obj *models.User, role RequestRole) ([]models.Request, error)
+	MeetingsAsParticipant(ctx context.Context, obj *models.User) ([]models.Meeting, error)
 }
 type UserPreferencesResolver interface {
 	Language(ctx context.Context, obj *models.StandardPreferences) (*PreferredLanguage, error)
@@ -411,7 +413,7 @@ type WatchResolver interface {
 
 	Destination(ctx context.Context, obj *models.Watch) (*models.Location, error)
 	Origin(ctx context.Context, obj *models.Watch) (*models.Location, error)
-
+	Meeting(ctx context.Context, obj *models.Watch) (*models.Meeting, error)
 	SearchText(ctx context.Context, obj *models.Watch) (*string, error)
 }
 
@@ -4145,7 +4147,7 @@ func (ec *executionContext) _MeetingInvite_meeting(ctx context.Context, field gr
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Meeting(ctx)
+		return ec.resolvers.MeetingInvite().Meeting(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4157,9 +4159,9 @@ func (ec *executionContext) _MeetingInvite_meeting(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(models.Meeting)
+	res := resTmp.(*models.Meeting)
 	fc.Result = res
-	return ec.marshalNMeeting2githubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
+	return ec.marshalNMeeting2ᚖgithubᚗcomᚋsilinternationalᚋwecarryᚑapiᚋmodelsᚐMeeting(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _MeetingInvite_inviter(ctx context.Context, field graphql.CollectedField, obj *models.MeetingInvite) (ret graphql.Marshaler) {
@@ -8300,7 +8302,7 @@ func (ec *executionContext) _User_meetingsAsParticipant(ctx context.Context, fie
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.MeetingsAsParticipant(ctx)
+		return ec.resolvers.User().MeetingsAsParticipant(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8591,7 +8593,7 @@ func (ec *executionContext) _Watch_meeting(ctx context.Context, field graphql.Co
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Meeting(ctx)
+		return ec.resolvers.Watch().Meeting(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/application/gqlgen/message.go
+++ b/application/gqlgen/message.go
@@ -59,7 +59,7 @@ func (r *queryResolver) Message(ctx context.Context, id *string) (*models.Messag
 	currentUser := models.CurrentUser(ctx)
 	var message models.Message
 
-	if err := message.FindByUserAndUUID(ctx, currentUser, *id); err != nil {
+	if err := message.FindByUserAndUUID(models.Tx(ctx), currentUser, *id); err != nil {
 		return &models.Message{}, domain.ReportError(ctx, err, "GetMessage")
 	}
 
@@ -69,7 +69,7 @@ func (r *queryResolver) Message(ctx context.Context, id *string) (*models.Messag
 // CreateMessage is a mutation resolver for creating a new message
 func (r *mutationResolver) CreateMessage(ctx context.Context, input CreateMessageInput) (*models.Message, error) {
 	var message models.Message
-	if err := message.Create(ctx, input.RequestID, input.ThreadID, input.Content); err != nil {
+	if err := message.Create(models.Tx(ctx), models.CurrentUser(ctx), input.RequestID, input.ThreadID, input.Content); err != nil {
 		return &models.Message{}, domain.ReportError(ctx, err, "CreateMessage")
 	}
 

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -33,8 +33,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input CreateO
 
 	tx := models.Tx(ctx)
 	if input.LogoFileID != nil {
-		if _, err := org.AttachLogo(
-			tx, *input.LogoFileID); err != nil {
+		if _, err := org.AttachLogo(tx, *input.LogoFileID); err != nil {
 			return &models.Organization{}, domain.ReportError(ctx, err, "CreateOrganization.LogoFileNotFound")
 		}
 	}

--- a/application/gqlgen/mutations.go
+++ b/application/gqlgen/mutations.go
@@ -31,13 +31,15 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input CreateO
 		AuthConfig: input.AuthConfig,
 	}
 
+	tx := models.Tx(ctx)
 	if input.LogoFileID != nil {
-		if _, err := org.AttachLogo(ctx, *input.LogoFileID); err != nil {
+		if _, err := org.AttachLogo(
+			tx, *input.LogoFileID); err != nil {
 			return &models.Organization{}, domain.ReportError(ctx, err, "CreateOrganization.LogoFileNotFound")
 		}
 	}
 
-	if err := org.Save(ctx); err != nil {
+	if err := org.Save(tx); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "CreateOrganization")
 	}
 
@@ -48,11 +50,12 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input CreateO
 func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateOrganizationInput) (*models.Organization, error) {
 	cUser := models.CurrentUser(ctx)
 	var org models.Organization
-	if err := org.FindByUUID(models.Tx(ctx), input.ID); err != nil {
+	tx := models.Tx(ctx)
+	if err := org.FindByUUID(tx, input.ID); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "UpdateOrganization.NotFound")
 	}
 
-	if !cUser.CanEditOrganization(ctx, org.ID) {
+	if !cUser.CanEditOrganization(tx, org.ID) {
 		err := errors.New("insufficient permissions")
 		return &models.Organization{}, domain.ReportError(ctx, err, "UpdateOrganization.Unauthorized")
 	}
@@ -60,11 +63,11 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 	org.Url = models.ConvertStringPtrToNullsString(input.URL)
 
 	if input.LogoFileID != nil {
-		if _, err := org.AttachLogo(ctx, *input.LogoFileID); err != nil {
+		if _, err := org.AttachLogo(tx, *input.LogoFileID); err != nil {
 			return &models.Organization{}, domain.ReportError(ctx, err, "UpdateOrganization.LogoFileNotFound")
 		}
 	} else {
-		if err := org.RemoveFile(ctx); err != nil {
+		if err := org.RemoveFile(tx); err != nil {
 			return &models.Organization{}, domain.ReportError(ctx, err, "UpdateOrganization.RemoveLogo")
 		}
 	}
@@ -72,7 +75,7 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 	org.Name = input.Name
 	org.AuthType = input.AuthType
 	org.AuthConfig = input.AuthConfig
-	if err := org.Save(ctx); err != nil {
+	if err := org.Save(tx); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "UpdateOrganization")
 	}
 
@@ -83,20 +86,21 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input UpdateO
 func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error) {
 	cUser := models.CurrentUser(ctx)
 	var org models.Organization
-	if err := org.FindByUUID(models.Tx(ctx), input.OrganizationID); err != nil {
+	tx := models.Tx(ctx)
+	if err := org.FindByUUID(tx, input.OrganizationID); err != nil {
 		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain.NotFound")
 	}
 
-	if !cUser.CanEditOrganization(ctx, org.ID) {
+	if !cUser.CanEditOrganization(tx, org.ID) {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain.Unauthorized")
 	}
 
-	if err := org.AddDomain(ctx, input.Domain, input.AuthType, domain.ConvertStrPtrToString(input.AuthConfig)); err != nil {
+	if err := org.AddDomain(tx, input.Domain, input.AuthType, domain.ConvertStrPtrToString(input.AuthConfig)); err != nil {
 		return nil, domain.ReportError(ctx, err, "CreateOrganizationDomain")
 	}
 
-	domains, err2 := org.Domains(ctx)
+	domains, err2 := org.Domains(tx)
 	if err2 != nil {
 		// don't return an error since the AddDomain operation succeeded
 		_ = domain.ReportError(ctx, err2, "")
@@ -109,27 +113,28 @@ func (r *mutationResolver) CreateOrganizationDomain(ctx context.Context, input C
 func (r *mutationResolver) UpdateOrganizationDomain(ctx context.Context, input CreateOrganizationDomainInput) ([]models.OrganizationDomain, error) {
 	cUser := models.CurrentUser(ctx)
 	var org models.Organization
-	if err := org.FindByUUID(models.Tx(ctx), input.OrganizationID); err != nil {
+	tx := models.Tx(ctx)
+	if err := org.FindByUUID(tx, input.OrganizationID); err != nil {
 		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.NotFound")
 	}
 
-	if !cUser.CanEditOrganization(ctx, org.ID) {
+	if !cUser.CanEditOrganization(tx, org.ID) {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.Unauthorized")
 	}
 
 	var orgDomain models.OrganizationDomain
-	if err := orgDomain.FindByDomain(ctx, input.Domain); err != nil {
+	if err := orgDomain.FindByDomain(tx, input.Domain); err != nil {
 		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.NotFound")
 	}
 
 	orgDomain.AuthType = input.AuthType
 	orgDomain.AuthConfig = domain.ConvertStrPtrToString(input.AuthConfig)
-	if err := orgDomain.Save(ctx); err != nil {
+	if err := orgDomain.Save(tx); err != nil {
 		return nil, domain.ReportError(ctx, err, "UpdateOrganizationDomain.SaveError")
 	}
 
-	domains, err2 := org.Domains(ctx)
+	domains, err2 := org.Domains(tx)
 	if err2 != nil {
 		// don't return an error since the operation succeeded
 		_ = domain.ReportError(ctx, err2, "")
@@ -142,20 +147,21 @@ func (r *mutationResolver) UpdateOrganizationDomain(ctx context.Context, input C
 func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input RemoveOrganizationDomainInput) ([]models.OrganizationDomain, error) {
 	cUser := models.CurrentUser(ctx)
 	var org models.Organization
-	if err := org.FindByUUID(models.Tx(ctx), input.OrganizationID); err != nil {
+	tx := models.Tx(ctx)
+	if err := org.FindByUUID(tx, input.OrganizationID); err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain.NotFound")
 	}
 
-	if !cUser.CanEditOrganization(ctx, org.ID) {
+	if !cUser.CanEditOrganization(tx, org.ID) {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain.Unauthorized")
 	}
 
-	if err := org.RemoveDomain(ctx, input.Domain); err != nil {
+	if err := org.RemoveDomain(tx, input.Domain); err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveOrganizationDomain")
 	}
 
-	domains, err2 := org.Domains(ctx)
+	domains, err2 := org.Domains(tx)
 	if err2 != nil {
 		// don't return an error since the RemoveDomain operation succeeded
 		_ = domain.ReportError(ctx, err2, "")
@@ -168,11 +174,12 @@ func (r *mutationResolver) RemoveOrganizationDomain(ctx context.Context, input R
 func (r *mutationResolver) SetThreadLastViewedAt(ctx context.Context, input SetThreadLastViewedAtInput) (*models.Thread, error) {
 	cUser := models.CurrentUser(ctx)
 	var thread models.Thread
-	if err := thread.FindByUUID(models.Tx(ctx), input.ThreadID); err != nil {
+	tx := models.Tx(ctx)
+	if err := thread.FindByUUID(tx, input.ThreadID); err != nil {
 		return &models.Thread{}, domain.ReportError(ctx, err, "SetThreadLastViewedAt.NotFound")
 	}
 
-	if err := thread.UpdateLastViewedAt(ctx, cUser.ID, input.Time); err != nil {
+	if err := thread.UpdateLastViewedAt(tx, cUser.ID, input.Time); err != nil {
 		return &models.Thread{}, domain.ReportError(ctx, err, "SetThreadLastViewedAt")
 	}
 
@@ -183,7 +190,8 @@ func (r *mutationResolver) SetThreadLastViewedAt(ctx context.Context, input SetT
 func (r *mutationResolver) CreateOrganizationTrust(ctx context.Context, input CreateOrganizationTrustInput) (*models.Organization, error) {
 	cUser := models.CurrentUser(ctx)
 	var organization models.Organization
-	if err := organization.FindByUUID(models.Tx(ctx), input.PrimaryID); err != nil {
+	tx := models.Tx(ctx)
+	if err := organization.FindByUUID(tx, input.PrimaryID); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "CreateOrganizationTrust.FindPrimaryOrganization")
 	}
 
@@ -192,7 +200,7 @@ func (r *mutationResolver) CreateOrganizationTrust(ctx context.Context, input Cr
 		return &models.Organization{}, domain.ReportError(ctx, err, "CreateOrganizationTrust.Unauthorized")
 	}
 
-	if err := organization.CreateTrust(ctx, input.SecondaryID); err != nil {
+	if err := organization.CreateTrust(tx, input.SecondaryID); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "CreateOrganizationTrust")
 	}
 
@@ -203,16 +211,17 @@ func (r *mutationResolver) CreateOrganizationTrust(ctx context.Context, input Cr
 func (r *mutationResolver) RemoveOrganizationTrust(ctx context.Context, input RemoveOrganizationTrustInput) (*models.Organization, error) {
 	cUser := models.CurrentUser(ctx)
 	var organization models.Organization
-	if err := organization.FindByUUID(models.Tx(ctx), input.PrimaryID); err != nil {
+	tx := models.Tx(ctx)
+	if err := organization.FindByUUID(tx, input.PrimaryID); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "RemoveOrganizationTrust.FindPrimaryOrganization")
 	}
 
-	if !cUser.CanRemoveOrganizationTrust(ctx, organization.ID) {
+	if !cUser.CanRemoveOrganizationTrust(tx, organization.ID) {
 		err := errors.New("insufficient permissions")
 		return &models.Organization{}, domain.ReportError(ctx, err, "RemoveOrganizationTrust.Unauthorized")
 	}
 
-	if err := organization.RemoveTrust(ctx, input.SecondaryID); err != nil {
+	if err := organization.RemoveTrust(tx, input.SecondaryID); err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "RemoveOrganizationTrust")
 	}
 
@@ -225,11 +234,16 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 	cUser := models.CurrentUser(ctx)
 
 	var m models.Meeting
-	if err := m.FindByUUID(models.Tx(ctx), input.MeetingID); err != nil {
+	tx := models.Tx(ctx)
+	if err := m.FindByUUID(tx, input.MeetingID); err != nil {
 		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.FindMeeting")
 	}
 
-	if !cUser.CanCreateMeetingInvite(ctx, m) {
+	can, err := cUser.CanCreateMeetingInvite(tx, m)
+	if err != nil {
+		domain.Error(ctx, err.Error())
+	}
+	if !can {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.Unauthorized")
 	}
@@ -242,7 +256,7 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 	badEmails := make([]string, 0)
 	for _, email := range input.Emails {
 		inv.Email = email
-		if err := inv.Create(ctx); err != nil {
+		if err := inv.Create(tx); err != nil {
 			badEmails = append(badEmails, email)
 			domain.ErrLogger.Printf("error creating meeting invite for email '%s', %s", email, err)
 		}
@@ -252,7 +266,7 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 		graphql.AddError(ctx, gqlerror.Errorf("problem creating invite for %v", emailList))
 	}
 
-	invites, err := m.Invites(ctx)
+	invites, err := m.Invites(tx, models.CurrentUser(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "CreateMeetingInvite.ListInvites")
 	}
@@ -261,21 +275,26 @@ func (r *mutationResolver) CreateMeetingInvites(ctx context.Context, input Creat
 
 func (r *mutationResolver) RemoveMeetingInvite(ctx context.Context, input RemoveMeetingInviteInput) ([]models.MeetingInvite, error) {
 	var meeting models.Meeting
-	if err := meeting.FindByUUID(models.Tx(ctx), input.MeetingID); err != nil {
+	tx := models.Tx(ctx)
+	if err := meeting.FindByUUID(tx, input.MeetingID); err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingInvite.FindMeeting")
 	}
 
 	cUser := models.CurrentUser(ctx)
-	if !cUser.CanRemoveMeetingInvite(ctx, meeting) {
+	can, err := cUser.CanRemoveMeetingInvite(tx, meeting)
+	if err != nil {
+		domain.Error(ctx, err.Error())
+	}
+	if !can {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingInvite.Unauthorized")
 	}
 
-	if err := meeting.RemoveInvite(ctx, input.Email); err != nil {
+	if err := meeting.RemoveInvite(tx, input.Email); err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingInvite")
 	}
 
-	invites, err := meeting.Invites(ctx)
+	invites, err := meeting.Invites(tx, models.CurrentUser(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingInvite.ListInvites")
 	}
@@ -286,35 +305,41 @@ func (r *mutationResolver) RemoveMeetingInvite(ctx context.Context, input Remove
 func (r *mutationResolver) CreateMeetingParticipant(ctx context.Context, input CreateMeetingParticipantInput) (
 	*models.MeetingParticipant, error) {
 	var meeting models.Meeting
-	if err := meeting.FindByUUID(models.Tx(ctx), input.MeetingID); err != nil {
+	tx := models.Tx(ctx)
+	if err := meeting.FindByUUID(tx, input.MeetingID); err != nil {
 		return &models.MeetingParticipant{}, domain.ReportError(ctx, err, "CreateMeetingParticipant.FindMeeting")
 	}
 
 	var participant models.MeetingParticipant
-	if err := participant.FindOrCreate(ctx, meeting, input.Code); err != nil {
+	if err := participant.FindOrCreate(tx, meeting, models.CurrentUser(ctx), input.Code); err != nil {
 		// MeetingParticipant.Create returns localized error messages
-		return &models.MeetingParticipant{}, err
+		return &models.MeetingParticipant{}, domain.ReportError(ctx, errors.New(err.DebugMsg), err.Key)
 	}
 	return &participant, nil
 }
 
 func (r *mutationResolver) RemoveMeetingParticipant(ctx context.Context, input RemoveMeetingParticipantInput) ([]models.MeetingParticipant, error) {
 	var meeting models.Meeting
-	if err := meeting.FindByUUID(models.Tx(ctx), input.MeetingID); err != nil {
+	tx := models.Tx(ctx)
+	if err := meeting.FindByUUID(tx, input.MeetingID); err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingParticipant.FindMeeting")
 	}
 
 	cUser := models.CurrentUser(ctx)
-	if !cUser.CanRemoveMeetingParticipant(ctx, meeting) {
+	can, err := cUser.CanRemoveMeetingParticipant(tx, meeting)
+	if err != nil {
+		domain.Error(ctx, err.Error())
+	}
+	if !can {
 		err := errors.New("insufficient permissions")
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingParticipant.Unauthorized")
 	}
 
-	if err := meeting.RemoveParticipant(ctx, input.UserID); err != nil {
+	if err := meeting.RemoveParticipant(tx, input.UserID); err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingParticipant")
 	}
 
-	participants, err := meeting.Participants(ctx)
+	participants, err := meeting.Participants(tx, models.CurrentUser(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "RemoveMeetingParticipant.ListParticipants")
 	}

--- a/application/gqlgen/organization.go
+++ b/application/gqlgen/organization.go
@@ -20,7 +20,7 @@ func (r *queryResolver) Organizations(ctx context.Context) ([]models.Organizatio
 
 	// get list of orgs that cUser is allowed to see
 	orgs := models.Organizations{}
-	if err := orgs.AllWhereUserIsOrgAdmin(ctx, cUser); err != nil {
+	if err := orgs.AllWhereUserIsOrgAdmin(models.Tx(ctx), cUser); err != nil {
 		return orgs, domain.ReportError(ctx, err, "ListOrganizations.Error")
 	}
 
@@ -36,7 +36,7 @@ func (r *queryResolver) Organization(ctx context.Context, id *string) (*models.O
 		return org, domain.ReportError(ctx, err, "ViewOrganization.Error")
 	}
 
-	if org.ID != 0 && cUser.CanViewOrganization(ctx, org.ID) {
+	if org.ID != 0 && cUser.CanViewOrganization(models.Tx(ctx), org.ID) {
 		return org, nil
 	}
 
@@ -66,7 +66,7 @@ func (r *organizationResolver) Domains(ctx context.Context, obj *models.Organiza
 		return nil, nil
 	}
 
-	domains, err := obj.Domains(ctx)
+	domains, err := obj.Domains(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationDomains")
 	}
@@ -80,7 +80,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *models.Organiza
 		return nil, nil
 	}
 
-	logoURL, err := obj.LogoURL(ctx)
+	logoURL, err := obj.LogoURL(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationLogoURL")
 	}
@@ -94,7 +94,7 @@ func (r *organizationResolver) TrustedOrganizations(ctx context.Context, obj *mo
 		return nil, nil
 	}
 
-	organizations, err := obj.TrustedOrganizations(ctx)
+	organizations, err := obj.TrustedOrganizations(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetOrganizationTrustedOrganizations")
 	}

--- a/application/gqlgen/organizationdomain.go
+++ b/application/gqlgen/organizationdomain.go
@@ -22,7 +22,7 @@ func (r *organizationDomainResolver) Organization(ctx context.Context, obj *mode
 		return &models.Organization{}, nil
 	}
 
-	organization, err := obj.Organization(ctx)
+	organization, err := obj.Organization(models.Tx(ctx))
 	if err != nil {
 		return &models.Organization{}, domain.ReportError(ctx, err, "GetOrganizationDomainOrganization")
 	}

--- a/application/gqlgen/request.go
+++ b/application/gqlgen/request.go
@@ -26,11 +26,12 @@ func (r *queryResolver) Request(ctx context.Context, id *string) (*models.Reques
 	domain.NewExtra(ctx, "requestUUID", *id)
 
 	request := models.Request{}
-	if err := request.FindByUUID(models.Tx(ctx), *id); err != nil {
+	tx := models.Tx(ctx)
+	if err := request.FindByUUID(tx, *id); err != nil {
 		return &request, domain.ReportError(ctx, err, "ViewRequest.Error")
 	}
 
-	if request.ID != 0 && cUser.CanViewRequest(ctx, request) {
+	if request.ID != 0 && cUser.CanViewRequest(tx, request) {
 		return &request, nil
 	}
 
@@ -87,7 +88,7 @@ func (r *requestResolver) PotentialProviders(ctx context.Context, obj *models.Re
 		return nil, nil
 	}
 
-	providers, err := obj.GetPotentialProviders(ctx, models.CurrentUser(ctx))
+	providers, err := obj.GetPotentialProviders(models.Tx(ctx), models.CurrentUser(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetPotentialProviders")
 	}
@@ -176,7 +177,7 @@ func (r *requestResolver) Actions(ctx context.Context, obj *models.Request) ([]s
 
 	user := models.CurrentUser(ctx)
 
-	actions, err := obj.GetCurrentActions(ctx, user)
+	actions, err := obj.GetCurrentActions(models.Tx(ctx), user)
 	if err != nil {
 		return actions, domain.ReportError(ctx, err, "GetRequestActions")
 	}
@@ -191,7 +192,7 @@ func (r *requestResolver) Threads(ctx context.Context, obj *models.Request) ([]m
 	}
 
 	user := models.CurrentUser(ctx)
-	threads, err := obj.GetThreads(ctx, user)
+	threads, err := obj.GetThreads(models.Tx(ctx), user)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetRequestThreads")
 	}
@@ -247,7 +248,7 @@ func (r *requestResolver) PhotoID(ctx context.Context, obj *models.Request) (*st
 		return nil, nil
 	}
 
-	photoID, err := obj.GetPhotoID(ctx)
+	photoID, err := obj.GetPhotoID(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetUserPhotoID")
 	}
@@ -260,7 +261,7 @@ func (r *requestResolver) Files(ctx context.Context, obj *models.Request) ([]mod
 	if obj == nil {
 		return nil, nil
 	}
-	files, err := obj.GetFiles(ctx)
+	files, err := obj.GetFiles(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetRequestFiles")
 	}
@@ -291,7 +292,7 @@ func (r *requestResolver) IsEditable(ctx context.Context, obj *models.Request) (
 		return false, nil
 	}
 	cUser := models.CurrentUser(ctx)
-	return obj.IsEditable(ctx, cUser)
+	return obj.IsEditable(models.Tx(ctx), cUser)
 }
 
 // Requests resolves the `requests` query
@@ -306,7 +307,7 @@ func (r *queryResolver) Requests(ctx context.Context, destination, origin *Locat
 		Origin:      convertOptionalLocation(origin),
 		SearchText:  searchText,
 	}
-	err := requests.FindByUser(ctx, cUser, filter)
+	err := requests.FindByUser(models.Tx(ctx), cUser, filter)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetRequests")
 	}
@@ -337,8 +338,9 @@ func (r *queryResolver) Requests(ctx context.Context, destination, origin *Locat
 func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, currentUser models.User) (models.Request, error) {
 	request := models.Request{}
 
+	tx := models.Tx(ctx)
 	if input.ID != nil {
-		if err := request.FindByUUID(models.Tx(ctx), *input.ID); err != nil {
+		if err := request.FindByUUID(tx, *input.ID); err != nil {
 			return request, err
 		}
 	} else {
@@ -349,7 +351,7 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 
 	if input.OrgID != nil {
 		var org models.Organization
-		err := org.FindByUUID(models.Tx(ctx), *input.OrgID)
+		err := org.FindByUUID(tx, *input.OrgID)
 		if err != nil {
 			return models.Request{}, err
 		}
@@ -385,12 +387,12 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 
 	if input.PhotoID == nil {
 		if request.ID > 0 {
-			if err := request.RemoveFile(ctx); err != nil {
+			if err := request.RemoveFile(tx); err != nil {
 				return models.Request{}, err
 			}
 		}
 	} else {
-		if _, err := request.AttachPhoto(ctx, *input.PhotoID); err != nil {
+		if _, err := request.AttachPhoto(tx, *input.PhotoID); err != nil {
 			return models.Request{}, err
 		}
 	}
@@ -399,7 +401,7 @@ func convertGqlRequestInputToDBRequest(ctx context.Context, input requestInput, 
 		request.MeetingID = nulls.Int{}
 	} else {
 		var meeting models.Meeting
-		if err := meeting.FindByUUID(models.Tx(ctx), *input.MeetingID); err != nil {
+		if err := meeting.FindByUUID(tx, *input.MeetingID); err != nil {
 			return models.Request{}, fmt.Errorf("invalid meetingID, %s", err)
 		}
 		request.MeetingID = nulls.NewInt(meeting.ID)
@@ -434,20 +436,21 @@ func (r *mutationResolver) CreateRequest(ctx context.Context, input requestInput
 		return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest.ProcessInput")
 	}
 
+	tx := models.Tx(ctx)
 	if !request.MeetingID.Valid {
 		dest := convertLocation(*input.Destination)
-		if err = dest.Create(ctx); err != nil {
+		if err = dest.Create(tx); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest.SetDestination")
 		}
 		request.DestinationID = dest.ID
 	}
 
-	if err = request.Create(ctx); err != nil {
+	if err = request.Create(tx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest")
 	}
 
 	if input.Origin != nil {
-		if err = request.SetOrigin(ctx, convertLocation(*input.Origin)); err != nil {
+		if err = request.SetOrigin(tx, convertLocation(*input.Origin)); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "CreateRequest.SetOrigin")
 		}
 	}
@@ -465,30 +468,31 @@ func (r *mutationResolver) UpdateRequest(ctx context.Context, input requestInput
 	}
 
 	var dbRequest models.Request
-	_ = dbRequest.FindByID(models.Tx(ctx), request.ID)
-	if editable, err := dbRequest.IsEditable(ctx, cUser); err != nil {
+	tx := models.Tx(ctx)
+	_ = dbRequest.FindByID(tx, request.ID)
+	if editable, err := dbRequest.IsEditable(tx, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.GetEditable")
 	} else if !editable {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("attempt to update a non-editable request"),
 			"UpdateRequest.NotEditable")
 	}
 
-	if err := request.Update(ctx); err != nil {
+	if err := request.Update(tx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest")
 	}
 
 	if input.Destination != nil {
-		if err := request.SetDestination(ctx, convertLocation(*input.Destination)); err != nil {
+		if err := request.SetDestination(tx, convertLocation(*input.Destination)); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.SetDestination")
 		}
 	}
 
 	if input.Origin == nil {
-		if err := request.RemoveOrigin(ctx); err != nil {
+		if err := request.RemoveOrigin(tx); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.RemoveOrigin")
 		}
 	} else {
-		if err := request.SetOrigin(ctx, convertLocation(*input.Origin)); err != nil {
+		if err := request.SetOrigin(tx, convertLocation(*input.Origin)); err != nil {
 			return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequest.SetOrigin")
 		}
 	}
@@ -499,7 +503,8 @@ func (r *mutationResolver) UpdateRequest(ctx context.Context, input requestInput
 // UpdateRequestStatus resolves the `updateRequestStatus` mutation.
 func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input UpdateRequestStatusInput) (*models.Request, error) {
 	var request models.Request
-	if err := request.FindByUUID(models.Tx(ctx), input.ID); err != nil {
+	tx := models.Tx(ctx)
+	if err := request.FindByUUID(tx, input.ID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequestStatus.FindRequest")
 	}
 
@@ -512,16 +517,16 @@ func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input Update
 			"UpdateRequestStatus.Unauthorized")
 	}
 
-	if err := request.SetProviderWithStatus(ctx, input.Status, input.ProviderUserID); err != nil {
+	if err := request.SetProviderWithStatus(tx, input.Status, input.ProviderUserID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error setting provider with status: "+err.Error()),
 			"UpdateRequestStatus.SetProvider")
 	}
 
-	if err := request.Update(ctx); err != nil {
+	if err := request.Update(tx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequestStatus")
 	}
 
-	if err := request.DestroyPotentialProviders(ctx, input.Status, cUser); err != nil {
+	if err := request.DestroyPotentialProviders(tx, input.Status, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error destroying request's potential providers: "+err.Error()),
 			"UpdateRequestStatus.DestroyPotentialProviders")
 	}
@@ -532,7 +537,8 @@ func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input Update
 func (r *mutationResolver) AddMeAsPotentialProvider(ctx context.Context, requestID string) (*models.Request, error) {
 	cUser := models.CurrentUser(ctx)
 	var request models.Request
-	if err := request.FindByUUIDForCurrentUser(ctx, requestID, cUser); err != nil {
+	tx := models.Tx(ctx)
+	if err := request.FindByUUIDForCurrentUser(tx, requestID, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "AddMeAsPotentialProvider.FindRequest")
 	}
 
@@ -543,12 +549,12 @@ func (r *mutationResolver) AddMeAsPotentialProvider(ctx context.Context, request
 	}
 
 	var provider models.PotentialProvider
-	if err := provider.NewWithRequestUUID(ctx, requestID, cUser.ID); err != nil {
+	if err := provider.NewWithRequestUUID(tx, requestID, cUser.ID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error preparing potential provider: "+err.Error()),
 			"AddMeAsPotentialProvider")
 	}
 
-	if err := provider.Create(ctx); err != nil {
+	if err := provider.Create(tx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error creating potential provider: "+err.Error()),
 			"AddMeAsPotentialProvider")
 	}
@@ -561,24 +567,25 @@ func (r *mutationResolver) RemoveMeAsPotentialProvider(ctx context.Context, requ
 
 	var provider models.PotentialProvider
 
-	if err := provider.FindWithRequestUUIDAndUserUUID(ctx, requestID, cUser.UUID.String(), cUser); err != nil {
+	tx := models.Tx(ctx)
+	if err := provider.FindWithRequestUUIDAndUserUUID(tx, requestID, cUser.UUID.String(), cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
 			"RemoveMeAsPotentialProvider")
 	}
 
 	var request models.Request
-	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
+	if err := request.FindByUUID(tx, requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemoveMeAsPotentialProvider.FindRequest")
 	}
 
 	domain.NewExtra(ctx, "request", request.UUID)
 
-	if err := provider.Destroy(ctx); err != nil {
+	if err := provider.Destroy(tx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error removing potential provider: "+err.Error()),
 			"RemoveMeAsPotentialProvider")
 	}
 
-	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
+	if err := request.FindByUUID(tx, requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemoveMeAsPotentialProvider.FindRequest")
 	}
 
@@ -588,24 +595,25 @@ func (r *mutationResolver) RemoveMeAsPotentialProvider(ctx context.Context, requ
 func (r *mutationResolver) RejectPotentialProvider(ctx context.Context, requestID, userID string) (*models.Request, error) {
 	cUser := models.CurrentUser(ctx)
 	var provider models.PotentialProvider
-	if err := provider.FindWithRequestUUIDAndUserUUID(ctx, requestID, userID, cUser); err != nil {
+	tx := models.Tx(ctx)
+	if err := provider.FindWithRequestUUIDAndUserUUID(tx, requestID, userID, cUser); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("unable to find PotentialProvider in order to delete it: "+err.Error()),
 			"RemovePotentialProvider")
 	}
 
 	var request models.Request
-	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
+	if err := request.FindByUUID(tx, requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemovePotentialProvider.FindRequest")
 	}
 
 	domain.NewExtra(ctx, "request", request.UUID)
 
-	if err := provider.Destroy(ctx); err != nil {
+	if err := provider.Destroy(tx); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, errors.New("error removing potential provider: "+err.Error()),
 			"RemovePotentialProvider")
 	}
 
-	if err := request.FindByUUID(models.Tx(ctx), requestID); err != nil {
+	if err := request.FindByUUID(tx, requestID); err != nil {
 		return &models.Request{}, domain.ReportError(ctx, err, "RemovePotentialProvider.FindRequest")
 	}
 

--- a/application/gqlgen/resolver.go
+++ b/application/gqlgen/resolver.go
@@ -43,7 +43,7 @@ func (m *meetingInviteResolver) Meeting(ctx context.Context, obj *models.Meeting
 		return nil, nil
 	}
 
-	mtg, err := obj.Meeting(ctx)
+	mtg, err := obj.Meeting(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "MeetingInvite.Meeting")
 	}
@@ -55,7 +55,7 @@ func (m *meetingInviteResolver) Inviter(ctx context.Context, obj *models.Meeting
 		return nil, nil
 	}
 
-	inviter, err := obj.Inviter(ctx)
+	inviter, err := obj.Inviter(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "MeetingInvite.Inviter")
 	}
@@ -76,7 +76,7 @@ func (m *meetingParticipantResolver) Meeting(ctx context.Context, obj *models.Me
 		return nil, nil
 	}
 
-	mtg, err := obj.Meeting(ctx)
+	mtg, err := obj.Meeting(models.Tx(ctx))
 	if err != nil {
 		domain.NewExtra(ctx, "meetingParticipant", *obj)
 		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Meeting")
@@ -89,7 +89,7 @@ func (m *meetingParticipantResolver) User(ctx context.Context, obj *models.Meeti
 		return nil, nil
 	}
 
-	user, err := obj.User(ctx)
+	user, err := obj.User(models.Tx(ctx))
 	if err != nil {
 		domain.NewExtra(ctx, "meetingParticipant", *obj)
 		return nil, domain.ReportError(ctx, err, "MeetingParticipant.User")
@@ -105,7 +105,7 @@ func (m *meetingParticipantResolver) Invite(ctx context.Context, obj *models.Mee
 		return nil, nil
 	}
 
-	inv, err := obj.Invite(ctx)
+	inv, err := obj.Invite(models.Tx(ctx))
 	if err != nil {
 		domain.NewExtra(ctx, "meetingParticipant", *obj)
 		return nil, domain.ReportError(ctx, err, "MeetingParticipant.Invite")

--- a/application/gqlgen/thread.go
+++ b/application/gqlgen/thread.go
@@ -46,7 +46,7 @@ func (r *threadResolver) LastViewedAt(ctx context.Context, obj *models.Thread) (
 	}
 
 	currentUser := models.CurrentUser(ctx)
-	lastViewedAt, err := obj.GetLastViewedAt(ctx, currentUser)
+	lastViewedAt, err := obj.GetLastViewedAt(models.Tx(ctx), currentUser)
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreadLastViewedAt")
 	}
@@ -61,7 +61,7 @@ func (r *threadResolver) Messages(ctx context.Context, obj *models.Thread) ([]mo
 		return nil, nil
 	}
 
-	messages, err := obj.Messages(ctx)
+	messages, err := obj.Messages(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreadMessages")
 	}
@@ -90,7 +90,8 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 	}
 	user := models.CurrentUser(ctx)
 
-	lastViewedAt, err := obj.GetLastViewedAt(ctx, user)
+	tx := models.Tx(ctx)
+	lastViewedAt, err := obj.GetLastViewedAt(tx, user)
 	if err != nil {
 		domain.Warn(ctx, err.Error())
 		return 0, nil
@@ -102,7 +103,7 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 		return 0, nil
 	}
 
-	count, err2 := obj.UnreadMessageCount(ctx, user.ID, *lastViewedAt)
+	count, err2 := obj.UnreadMessageCount(tx, user.ID, *lastViewedAt)
 	if err2 != nil {
 		domain.Warn(ctx, err2.Error())
 		return 0, nil
@@ -115,7 +116,7 @@ func (r *threadResolver) UnreadMessageCount(ctx context.Context, obj *models.Thr
 func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
 	currentUser := models.CurrentUser(ctx)
 
-	threads, err := currentUser.GetThreads(ctx)
+	threads, err := currentUser.GetThreads(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetThreads")
 	}
@@ -127,7 +128,7 @@ func (r *queryResolver) Threads(ctx context.Context) ([]models.Thread, error) {
 func (r *queryResolver) MyThreads(ctx context.Context) ([]models.Thread, error) {
 	currentUser := models.CurrentUser(ctx)
 
-	threads, err := currentUser.GetThreads(ctx)
+	threads, err := currentUser.GetThreads(models.Tx(ctx))
 	if err != nil {
 		return nil, domain.ReportError(ctx, err, "GetMyThreads")
 	}

--- a/application/internal/test/test.go
+++ b/application/internal/test/test.go
@@ -245,7 +245,7 @@ func CreatePotentialProvidersFixtures(tx *pop.Connection) PotentialProvidersFixt
 	for i, r := range requests[:2] {
 		for _, u := range uf.Users[i+1 : 4] {
 			c := models.PotentialProvider{RequestID: r.ID, UserID: u.ID}
-			c.Create(Ctx())
+			c.Create(tx)
 			providers = append(providers, c)
 		}
 	}

--- a/application/listeners/listeners_test.go
+++ b/application/listeners/listeners_test.go
@@ -160,7 +160,7 @@ func createFixturesForSendRequestCreatedNotifications(ms *ModelSuite) RequestFix
 	ms.NoError(err)
 
 	for i := range users {
-		ms.NoError(users[i].SetLocation(test.Ctx(), *requestOrigin))
+		ms.NoError(users[i].SetLocation(ms.DB, *requestOrigin))
 	}
 
 	return RequestFixtures{

--- a/application/listeners/requesthelpers_fixtures_test.go
+++ b/application/listeners/requesthelpers_fixtures_test.go
@@ -21,7 +21,7 @@ func CreateFixtures_GetRequestUsers(ms *ModelSuite, t *testing.T) orgUserRequest
 	org := userFixtures.Organization
 	users := userFixtures.Users
 
-	_, err := users[1].UpdateStandardPreferences(test.Ctx(), models.StandardPreferences{Language: domain.UserPreferenceLanguageFrench})
+	_, err := users[1].UpdateStandardPreferences(ms.DB, models.StandardPreferences{Language: domain.UserPreferenceLanguageFrench})
 
 	ms.NoError(err, "could not create language preference for user "+users[1].Nickname)
 
@@ -48,7 +48,7 @@ func CreateFixtures_RequestStatusUpdatedNotifications(ms *ModelSuite, t *testing
 	requests := test.CreateRequestFixtures(ms.DB, 2, false)
 	requests[0].Status = models.RequestStatusAccepted
 	requests[0].ProviderID = nulls.NewInt(users[1].ID)
-	ms.NoError(requests[0].Update(test.Ctx()))
+	ms.NoError(requests[0].Update(ms.DB))
 
 	return orgUserRequestFixtures{
 		orgs:     models.Organizations{org},
@@ -173,7 +173,7 @@ func createFixturesForTestSendNewRequestNotifications(ms *ModelSuite) orgUserReq
 
 	users := test.CreateUserFixtures(ms.DB, 3).Users
 	for i := range users {
-		ms.NoError(users[i].SetLocation(test.Ctx(), *requestOrigin))
+		ms.NoError(users[i].SetLocation(ms.DB, *requestOrigin))
 	}
 
 	return orgUserRequestFixtures{

--- a/application/locales/global.en.yaml
+++ b/application/locales/global.en.yaml
@@ -316,6 +316,8 @@
   translation: We had a problem finding the Alert creator
 - id: GetWatchDestination
   translation: We had a problem finding the Alert destination
+- id: GetWatchMeeting
+  translation: We had a problem finding the Alert meeting
 - id: GetWatchOrigin
   translation: We had a problem finding the Alert origin
 - id: MyWatches

--- a/application/models/file_test.go
+++ b/application/models/file_test.go
@@ -326,7 +326,7 @@ func (ms *ModelSuite) TestFiles_DeleteUnlinked() {
 	users := createUserFixtures(ms.DB, nUsers).Users
 	userPhotos := createFileFixtures(ms.DB, nUsers)
 	for i, u := range users {
-		_, err := u.AttachPhoto(Ctx(), userPhotos[i].UUID.String())
+		_, err := u.AttachPhoto(ms.DB, userPhotos[i].UUID.String())
 		ms.NoError(err)
 	}
 

--- a/application/models/location.go
+++ b/application/models/location.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -82,8 +81,8 @@ func (v *geoValidator) IsValid(errors *validate.Errors) {
 }
 
 // Create stores the Location data as a new record in the database.
-func (l *Location) Create(ctx context.Context) error {
-	return create(Tx(ctx), l)
+func (l *Location) Create(tx *pop.Connection) error {
+	return create(tx, l)
 }
 
 // Update writes the Location data to an existing database record.

--- a/application/models/location_test.go
+++ b/application/models/location_test.go
@@ -150,7 +150,7 @@ func (ms *ModelSuite) TestLocation_Create() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.location.Create(Ctx()); (err != nil) != tt.wantErr {
+			if err := tt.location.Create(ms.DB); (err != nil) != tt.wantErr {
 				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/application/models/meeting_fixtures_test.go
+++ b/application/models/meeting_fixtures_test.go
@@ -101,15 +101,15 @@ func createMeetingFixtures_CanUpdate(ms *ModelSuite) meetingFixtures {
 
 	superUser := &uf.Users[1]
 	superUser.AdminRole = UserAdminRoleSuperAdmin
-	ms.NoError(superUser.Save(Ctx()))
+	ms.NoError(superUser.Save(ms.DB))
 
 	salesUser := &uf.Users[2]
 	salesUser.AdminRole = UserAdminRoleSalesAdmin
-	ms.NoError(salesUser.Save(Ctx()))
+	ms.NoError(salesUser.Save(ms.DB))
 
 	adminUser := &uf.Users[3]
 	adminUser.AdminRole = UserAdminRoleAdmin
-	ms.NoError(adminUser.Save(Ctx()))
+	ms.NoError(adminUser.Save(ms.DB))
 
 	meeting := Meeting{
 		CreatedByID: mtgUser.ID,

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -371,7 +371,7 @@ func (ms *ModelSuite) TestMeeting_ImageFile() {
 
 	imageFixture := createFileFixture(ms.DB)
 
-	attachedFile, err := meeting.SetImageFile(Ctx(), imageFixture.UUID.String())
+	attachedFile, err := meeting.SetImageFile(ms.DB, imageFixture.UUID.String())
 	ms.NoError(err)
 
 	if got, err := meeting.ImageFile(ms.DB); err == nil {
@@ -421,7 +421,7 @@ func (ms *ModelSuite) TestMeeting_GetSetLocation() {
 	meeting := Meeting{CreatedByID: user.ID, Name: "name", LocationID: locations[0].ID}
 	createFixture(ms, &meeting)
 
-	err := meeting.SetLocation(Ctx(), locations[1])
+	err := meeting.SetLocation(ms.DB, locations[1])
 	ms.NoError(err, "unexpected error from meeting.SetLocation()")
 
 	locationFromDB, err := meeting.GetLocation(ms.DB)
@@ -479,7 +479,7 @@ func (ms *ModelSuite) TestMeeting_GetRequests() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.Requests(Ctx())
+			got, err := tt.meeting.Requests(ms.DB)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -528,7 +528,7 @@ func (ms *ModelSuite) TestMeeting_Invites() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.Invites(createTestContext(tt.user))
+			got, err := tt.meeting.Invites(ms.DB, tt.user)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -578,7 +578,7 @@ func (ms *ModelSuite) TestMeeting_Participants() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.Participants(createTestContext(tt.user))
+			got, err := tt.meeting.Participants(ms.DB, tt.user)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -628,7 +628,7 @@ func (ms *ModelSuite) TestMeeting_Organizers() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.meeting.Organizers(createTestContext(tt.user))
+			got, err := tt.meeting.Organizers(ms.DB)
 			if tt.wantErr != "" {
 				ms.Error(err, "did not get expected error")
 				ms.Contains(err.Error(), tt.wantErr)
@@ -683,10 +683,9 @@ func (ms *ModelSuite) TestMeeting_RemoveInvite() {
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
 			// setup
-			ctx := createTestContext(tt.user)
 
 			// execute
-			err := tt.meeting.RemoveInvite(ctx, tt.email)
+			err := tt.meeting.RemoveInvite(ms.DB, tt.email)
 
 			// verify
 			if tt.wantErr != "" {
@@ -696,7 +695,7 @@ func (ms *ModelSuite) TestMeeting_RemoveInvite() {
 			}
 			ms.NoError(err, "unexpected error")
 
-			remaining, err := tt.meeting.Invites(ctx)
+			remaining, err := tt.meeting.Invites(ms.DB, tt.user)
 			ms.NoError(err)
 
 			emails := make([]string, len(remaining))
@@ -739,11 +738,8 @@ func (ms *ModelSuite) TestMeeting_RemoveParticipant() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			// setup
-			ctx := createTestContext(tt.testUser)
-
 			// execute
-			err := tt.meeting.RemoveParticipant(ctx, tt.user.UUID.String())
+			err := tt.meeting.RemoveParticipant(ms.DB, tt.user.UUID.String())
 
 			// verify
 			if tt.wantErr != "" {
@@ -753,7 +749,7 @@ func (ms *ModelSuite) TestMeeting_RemoveParticipant() {
 			}
 			ms.NoError(err, "unexpected error")
 
-			remaining, err := tt.meeting.Participants(ctx)
+			remaining, err := tt.meeting.Participants(ms.DB, tt.testUser)
 			ms.NoError(err)
 
 			ids := make([]int, len(remaining))
@@ -839,7 +835,7 @@ func (ms *ModelSuite) TestMeeting_isOrganizer() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got := tt.meeting.isOrganizer(createTestContext(tt.user), tt.user.ID)
+			got, _ := tt.meeting.isOrganizer(ms.DB, tt.user.ID)
 			ms.Equal(tt.want, got)
 		})
 	}

--- a/application/models/meeting_test.go
+++ b/application/models/meeting_test.go
@@ -835,7 +835,8 @@ func (ms *ModelSuite) TestMeeting_isOrganizer() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, _ := tt.meeting.isOrganizer(ms.DB, tt.user.ID)
+			got, err := tt.meeting.isOrganizer(ms.DB, tt.user.ID)
+			ms.NoError(err)
 			ms.Equal(tt.want, got)
 		})
 	}

--- a/application/models/meetinginvite.go
+++ b/application/models/meetinginvite.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"time"
@@ -39,11 +38,11 @@ func (m *MeetingInvite) Validate(tx *pop.Connection) (*validate.Errors, error) {
 }
 
 // Create validates and stores the MeetingInvite data as a new record in the database.
-func (m *MeetingInvite) Create(ctx context.Context) error {
+func (m *MeetingInvite) Create(tx *pop.Connection) error {
 	invite := *m
 	invite.Secret = domain.GetUUID()
 
-	err := create(Tx(ctx), &invite)
+	err := create(tx, &invite)
 	if err != nil && strings.Contains(err.Error(), `duplicate key value violates unique constraint`) {
 		err = nil
 	}
@@ -54,15 +53,15 @@ func (m *MeetingInvite) Create(ctx context.Context) error {
 }
 
 // Meeting returns the related Meeting record
-func (m *MeetingInvite) Meeting(ctx context.Context) (Meeting, error) {
+func (m *MeetingInvite) Meeting(tx *pop.Connection) (Meeting, error) {
 	var meeting Meeting
-	return meeting, Tx(ctx).Find(&meeting, m.MeetingID)
+	return meeting, tx.Find(&meeting, m.MeetingID)
 }
 
 // Inviter returns the related User record of the inviter
-func (m *MeetingInvite) Inviter(ctx context.Context) (User, error) {
+func (m *MeetingInvite) Inviter(tx *pop.Connection) (User, error) {
 	var user User
-	return user, Tx(ctx).Find(&user, m.InviterID)
+	return user, tx.Find(&user, m.InviterID)
 }
 
 // AvatarURL returns a generated gravatar URL for the inivitee

--- a/application/models/meetinginvite_test.go
+++ b/application/models/meetinginvite_test.go
@@ -91,7 +91,7 @@ func (ms *ModelSuite) TestMeetingInvite_Create() {
 		InviterID: inviter.ID,
 		Email:     "existing@example.com",
 	}
-	ms.NoError(invite.Create(Ctx()))
+	ms.NoError(invite.Create(ms.DB))
 
 	tests := []struct {
 		name    string
@@ -132,7 +132,7 @@ func (ms *ModelSuite) TestMeetingInvite_Create() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			err := tt.invite.Create(Ctx())
+			err := tt.invite.Create(ms.DB)
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")
@@ -170,7 +170,7 @@ func (ms *ModelSuite) TestMeetingInvite_Meeting() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.invite.Meeting(Ctx())
+			got, err := tt.invite.Meeting(ms.DB)
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")
@@ -205,7 +205,7 @@ func (ms *ModelSuite) TestMeetingInvite_Inviter() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.invite.Inviter(Ctx())
+			got, err := tt.invite.Inviter(ms.DB)
 			if tt.wantErr != "" {
 				ms.Error(err, `didn't get expected error: "%s"`, tt.wantErr)
 				ms.Contains(err.Error(), tt.wantErr, "wrong error message")

--- a/application/models/message_fixtures_test.go
+++ b/application/models/message_fixtures_test.go
@@ -65,7 +65,7 @@ func Fixtures_Message_Create(ms *ModelSuite, t *testing.T) MessageFixtures {
 
 	org := createOrganizationFixtures(ms.DB, 1)[0]
 	requests[0].OrganizationID = org.ID
-	ms.NoError(requests[0].Update(Ctx()))
+	ms.NoError(requests[0].Update(ms.DB))
 
 	tf := CreateThreadFixtures(ms, requests[1])
 

--- a/application/models/message_test.go
+++ b/application/models/message_test.go
@@ -182,7 +182,7 @@ func (ms *ModelSuite) TestMessage_Create() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var message Message
-			err := message.Create(createTestContext(tt.user), tt.requestUUID, tt.threadUUID, tt.content)
+			err := message.Create(ms.DB, tt.user, tt.requestUUID, tt.threadUUID, tt.content)
 
 			if tt.wantErr {
 				ms.Error(err)
@@ -321,7 +321,7 @@ func (ms *ModelSuite) TestMessage_FindByUserAndUUID() {
 			} else {
 				testUUID = *test.uuid
 			}
-			err := message.FindByUserAndUUID(Ctx(), test.user, testUUID)
+			err := message.FindByUserAndUUID(ms.DB, test.user, testUUID)
 
 			if test.wantErr != "" {
 				ms.Error(err)

--- a/application/models/models_test.go
+++ b/application/models/models_test.go
@@ -67,13 +67,6 @@ func createTestContext(user User) buffalo.Context {
 	return ctx
 }
 
-func Ctx() context.Context {
-	ctx := &testBuffaloContext{
-		params: map[interface{}]interface{}{},
-	}
-	return ctx
-}
-
 func (ms *ModelSuite) TestCurrentUser() {
 	// setup
 	user := createUserFixtures(ms.DB, 1).Users[0]

--- a/application/models/organizationdomain.go
+++ b/application/models/organizationdomain.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -36,12 +35,12 @@ func (o *OrganizationDomain) ValidateCreate(tx *pop.Connection) (*validate.Error
 }
 
 // Organization loads the Organization record
-func (o *OrganizationDomain) Organization(ctx context.Context) (Organization, error) {
+func (o *OrganizationDomain) Organization(tx *pop.Connection) (Organization, error) {
 	if o.OrganizationID <= 0 {
 		return Organization{}, errors.New("OrganizationID is not valid")
 	}
 	var organization Organization
-	if err := Tx(ctx).Find(&organization, o.OrganizationID); err != nil {
+	if err := tx.Find(&organization, o.OrganizationID); err != nil {
 		return Organization{}, err
 	}
 	return organization, nil
@@ -53,11 +52,11 @@ func (o *OrganizationDomain) Create(tx *pop.Connection) error {
 }
 
 // FindByDomain finds a record by the domain name
-func (o *OrganizationDomain) FindByDomain(ctx context.Context, domainName string) error {
-	return Tx(ctx).Where("domain = ?", domainName).First(o)
+func (o *OrganizationDomain) FindByDomain(tx *pop.Connection, domainName string) error {
+	return tx.Where("domain = ?", domainName).First(o)
 }
 
 // Save wrap tx.Save() call to check for errors and operate on attached object
-func (o *OrganizationDomain) Save(ctx context.Context) error {
-	return save(Tx(ctx), o)
+func (o *OrganizationDomain) Save(tx *pop.Connection) error {
+	return save(tx, o)
 }

--- a/application/models/organizationdomain_test.go
+++ b/application/models/organizationdomain_test.go
@@ -32,7 +32,7 @@ func (ms *ModelSuite) TestOrganizationDomain_Organization() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			o := test.orgDomain
-			got, err := o.Organization(Ctx())
+			got, err := o.Organization(ms.DB)
 
 			if test.wantErr {
 				ms.Error(err)

--- a/application/models/organizationtrust_test.go
+++ b/application/models/organizationtrust_test.go
@@ -102,7 +102,7 @@ func (ms *ModelSuite) TestTrust_Create() {
 			ms.NoError(err, "unexpected error")
 
 			org := Organization{ID: tt.trust.PrimaryID}
-			orgs, err := org.TrustedOrganizations(Ctx())
+			orgs, err := org.TrustedOrganizations(ms.DB)
 			ms.NoError(err)
 
 			ms.Equal(tt.want, len(orgs), "incorrect number of OrganizationTrust records")
@@ -143,11 +143,11 @@ func (ms *ModelSuite) TestTrust_Remove() {
 			ms.NoError(err, "unexpected error")
 
 			org1 := Organization{ID: tt.trust.PrimaryID}
-			orgs1, err := org1.TrustedOrganizations(Ctx())
+			orgs1, err := org1.TrustedOrganizations(ms.DB)
 			ms.NoError(err)
 
 			org2 := Organization{ID: tt.trust.SecondaryID}
-			orgs2, err := org2.TrustedOrganizations(Ctx())
+			orgs2, err := org2.TrustedOrganizations(ms.DB)
 			ms.NoError(err)
 
 			ms.Equal(tt.want, len(orgs1)+len(orgs2), "incorrect number of OrganizationTrust records")

--- a/application/models/potentialprovider.go
+++ b/application/models/potentialprovider.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -93,8 +92,8 @@ type PotentialProviderEventData struct {
 }
 
 // Create stores the PotentialProvider data as a new record in the database.
-func (p *PotentialProvider) Create(ctx context.Context) error {
-	if err := create(Tx(ctx), p); err != nil {
+func (p *PotentialProvider) Create(tx *pop.Connection) error {
+	if err := create(tx, p); err != nil {
 		return err
 	}
 
@@ -164,15 +163,14 @@ func (p *PotentialProvider) CanUserAccessPotentialProvider(request Request, curr
 
 // FindWithRequestUUIDAndUserUUID  finds the PotentialProvider associated with both the requestUUID and the userUUID
 // No authorization checks are performed - they must be done separately
-func (p *PotentialProvider) FindWithRequestUUIDAndUserUUID(ctx context.Context, requestUUID, userUUID string, currentUser User) error {
+func (p *PotentialProvider) FindWithRequestUUIDAndUserUUID(tx *pop.Connection, requestUUID, userUUID string, currentUser User) error {
 	var request Request
-	tx := Tx(ctx)
 	if err := request.FindByUUID(tx, requestUUID); err != nil {
 		return errors.New("unable to find Request in order to find PotentialProvider: " + err.Error())
 	}
 
 	var user User
-	if err := user.FindByUUID(ctx, userUUID); err != nil {
+	if err := user.FindByUUID(tx, userUUID); err != nil {
 		return errors.New("unable to find User in order to find PotentialProvider: " + err.Error())
 	}
 
@@ -188,9 +186,8 @@ func (p *PotentialProvider) FindWithRequestUUIDAndUserUUID(ctx context.Context, 
 }
 
 // NewWithRequestUUID populates a new PotentialProvider but does not save it
-func (p *PotentialProvider) NewWithRequestUUID(ctx context.Context, requestUUID string, userID int) error {
+func (p *PotentialProvider) NewWithRequestUUID(tx *pop.Connection, requestUUID string, userID int) error {
 	var user User
-	tx := Tx(ctx)
 	if err := user.FindByID(tx, userID); err != nil {
 		return err
 	}
@@ -211,8 +208,8 @@ func (p *PotentialProvider) NewWithRequestUUID(ctx context.Context, requestUUID 
 }
 
 // Destroy destroys the PotentialProvider
-func (p *PotentialProvider) Destroy(ctx context.Context) error {
-	return Tx(ctx).Destroy(p)
+func (p *PotentialProvider) Destroy(tx *pop.Connection) error {
+	return tx.Destroy(p)
 }
 
 // DestroyAllWithRequestUUID Destroys all the PotentialProviders associated with a Request depending

--- a/application/models/potentialprovider_test.go
+++ b/application/models/potentialprovider_test.go
@@ -108,7 +108,7 @@ func (ms *ModelSuite) TestPotentialProvider_FindWithRequestUUIDAndUserUUID() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := PotentialProvider{}
-			err := provider.FindWithRequestUUIDAndUserUUID(Ctx(), tt.request.UUID.String(),
+			err := provider.FindWithRequestUUIDAndUserUUID(ms.DB, tt.request.UUID.String(),
 				tt.ppUserUUID.String(), tt.currentUser)
 
 			if tt.wantErr != "" {
@@ -212,7 +212,7 @@ func (ms *ModelSuite) TestNewWithRequestUUID() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			provider := PotentialProvider{}
-			err := provider.NewWithRequestUUID(Ctx(), test.request.UUID.String(), test.userID)
+			err := provider.NewWithRequestUUID(ms.DB, test.request.UUID.String(), test.userID)
 			if test.wantErr != "" {
 				ms.Error(err, "expected an error but did not get one")
 				ms.Equal(test.wantErr, err.Error(), "incorrect error message")

--- a/application/models/request_test.go
+++ b/application/models/request_test.go
@@ -2120,6 +2120,7 @@ func (ms *ModelSuite) TestRequest_IsVisible() {
 		user    User
 		request Request
 		want    bool
+		wantErr bool
 	}{
 		{name: "request in same org", user: f.Users[0], request: f.Requests[0], want: true},
 		{name: "COMPLETED request in same org", user: f.Users[0], request: f.Requests[2], want: false},
@@ -2127,12 +2128,16 @@ func (ms *ModelSuite) TestRequest_IsVisible() {
 		{name: "request visibility ALL in trusted org", user: f.Users[0], request: f.Requests[5], want: true},
 		{name: "request visibility TRUSTED in trusted org", user: f.Users[0], request: f.Requests[6], want: true},
 		{name: "request visibility SAME in trusted org", user: f.Users[0], request: f.Requests[7], want: false},
-		{name: "bad user", user: User{}, request: f.Requests[5], want: false},
+		{name: "bad user", user: User{}, request: f.Requests[5], wantErr: true},
 		{name: "bad request", user: f.Users[0], request: Request{}, want: false},
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
 			got, err := tt.request.IsVisible(ms.DB, tt.user)
+			if tt.wantErr {
+				ms.Error(err)
+				return
+			}
 			ms.NoError(err)
 			ms.Equal(tt.want, got)
 		})

--- a/application/models/request_test.go
+++ b/application/models/request_test.go
@@ -763,7 +763,7 @@ func (ms *ModelSuite) TestRequest_Create() {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.request.Create(Ctx())
+			err := test.request.Create(ms.DB)
 			if test.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), test.wantErr, "unexpected error message")
@@ -808,7 +808,7 @@ func (ms *ModelSuite) TestRequest_Update() {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.request.Update(Ctx())
+			err := test.request.Update(ms.DB)
 			if test.wantErr != "" {
 				ms.Error(err)
 				ms.Contains(err.Error(), test.wantErr, "unexpected error message")
@@ -1224,7 +1224,7 @@ func (ms *ModelSuite) TestRequest_GetPotentialProviderActions() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.request.GetPotentialProviderActions(Ctx(), tt.user)
+			got, err := tt.request.GetPotentialProviderActions(ms.DB, tt.user)
 			ms.NoError(err)
 			ms.Equal(tt.want, got, "incorrect actions")
 		})
@@ -1282,7 +1282,7 @@ func (ms *ModelSuite) TestRequest_GetCurrentActions() {
 
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, err := tt.request.GetCurrentActions(Ctx(), tt.user)
+			got, err := tt.request.GetCurrentActions(ms.DB, tt.user)
 			ms.NoError(err)
 			ms.Equal(tt.want, got, "incorrect actions")
 		})
@@ -1333,7 +1333,7 @@ func (ms *ModelSuite) TestRequest_GetThreads() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.request.GetThreads(Ctx(), users[0])
+			got, err := test.request.GetThreads(ms.DB, users[0])
 			if err != nil {
 				t.Errorf("GetThreads() error: %v", err)
 			} else {
@@ -1394,7 +1394,7 @@ func (ms *ModelSuite) TestRequest_AttachFile() {
 func (ms *ModelSuite) TestRequest_GetFiles() {
 	f := CreateFixturesForRequestsGetFiles(ms)
 
-	files, err := f.Requests[0].GetFiles(Ctx())
+	files, err := f.Requests[0].GetFiles(ms.DB)
 	ms.NoError(err, "failed to get files list for request, %s", err)
 
 	ms.Equal(len(f.Files), len(files))
@@ -1421,7 +1421,7 @@ func (ms *ModelSuite) TestRequest_GetPhotoID() {
 
 	photoFixture := createFileFixture(ms.DB)
 
-	attachedFile, err := request.AttachPhoto(Ctx(), photoFixture.UUID.String())
+	attachedFile, err := request.AttachPhoto(ms.DB, photoFixture.UUID.String())
 	ms.NoError(err, "failed to attach photo to request")
 	ms.Equal(photoFixture.Name, attachedFile.Name)
 	ms.True(attachedFile.ID != 0)
@@ -1431,7 +1431,7 @@ func (ms *ModelSuite) TestRequest_GetPhotoID() {
 
 	ms.Equal(photoFixture.Name, request.PhotoFile.Name)
 
-	got, err := request.GetPhotoID(Ctx())
+	got, err := request.GetPhotoID(ms.DB)
 	ms.NoError(err, "unexpected error")
 	attachedFileUUID := attachedFile.UUID.String()
 	ms.Equal(&attachedFileUUID, got)
@@ -1444,7 +1444,7 @@ func (ms *ModelSuite) TestRequest_GetPhoto() {
 
 	photoFixture := createFileFixture(ms.DB)
 
-	attachedFile, err := request.AttachPhoto(Ctx(), photoFixture.UUID.String())
+	attachedFile, err := request.AttachPhoto(ms.DB, photoFixture.UUID.String())
 	ms.NoError(err, "failed to attach photo to request")
 	ms.Equal(photoFixture.Name, attachedFile.Name)
 	ms.True(attachedFile.ID != 0)
@@ -1483,7 +1483,7 @@ func (ms *ModelSuite) TestRequest_GetPhoto() {
 //	for _, test := range tests {
 //		t.Run(test.name, func(t *testing.T) {
 //			var request Request
-//			err := request.FindByUserAndUUID(Ctx(), test.user, test.request.UUID.String())
+//			err := request.FindByUserAndUUID(ms.DB, test.user, test.request.UUID.String())
 //
 //			if test.wantErr != "" {
 //				ms.Error(err)
@@ -1525,7 +1525,7 @@ func (ms *ModelSuite) TestRequest_GetSetDestination() {
 	request := Request{CreatedByID: user.ID, OrganizationID: organization.ID, DestinationID: locations[0].ID}
 	createFixture(ms, &request)
 
-	err := request.SetDestination(Ctx(), locations[1])
+	err := request.SetDestination(ms.DB, locations[1])
 	ms.NoError(err, "unexpected error from request.SetDestination()")
 
 	locationFromDB, err := request.GetDestination(ms.DB)
@@ -1559,7 +1559,7 @@ func (ms *ModelSuite) TestRequest_Origin() {
 		},
 	}
 
-	err := request.SetOrigin(Ctx(), locationFixtures[0])
+	err := request.SetOrigin(ms.DB, locationFixtures[0])
 	ms.NoError(err, "unexpected error from request.SetOrigin()")
 
 	locationFromDB, err := request.GetOrigin(ms.DB)
@@ -1568,7 +1568,7 @@ func (ms *ModelSuite) TestRequest_Origin() {
 	locationFixtures[0].ID = locationFromDB.ID
 	ms.Equal(locationFixtures[0], *locationFromDB, "origin data doesn't match new location")
 
-	err = request.SetOrigin(Ctx(), locationFixtures[1])
+	err = request.SetOrigin(ms.DB, locationFixtures[1])
 	ms.NoError(err, "unexpected error from request.SetOrigin()")
 
 	locationFromDB, err = request.GetOrigin(ms.DB)
@@ -1583,7 +1583,7 @@ func (ms *ModelSuite) TestRequest_Origin() {
 	ms.False(locationFromDB.Latitude.Valid)
 	ms.False(locationFromDB.Longitude.Valid)
 
-	ms.NoError(request.RemoveOrigin(Ctx()))
+	ms.NoError(request.RemoveOrigin(ms.DB))
 	ms.False(request.OriginID.Valid, "expected the origin to have been removed")
 	err = ms.DB.Find(locationFromDB, locationFromDB.ID)
 	ms.Error(err, "expected error when looking for removed origin")
@@ -1633,7 +1633,7 @@ func (ms *ModelSuite) TestRequest_SetProviderWithStatus() {
 		t.Run(test.name, func(t *testing.T) {
 			var request Request
 			userID := user.UUID.String()
-			err := request.SetProviderWithStatus(Ctx(), test.status, &userID)
+			err := request.SetProviderWithStatus(ms.DB, test.status, &userID)
 			ms.NoError(err)
 
 			ms.Equal(test.wantProviderID, request.ProviderID)
@@ -1682,7 +1682,7 @@ func (ms *ModelSuite) TestRequests_FindByUser() {
 				Origin:      test.orig,
 				RequestID:   test.requestID,
 			}
-			err := requests.FindByUser(Ctx(), test.user, filter)
+			err := requests.FindByUser(ms.DB, test.user, filter)
 
 			if test.wantErr {
 				ms.Error(err)
@@ -1730,7 +1730,7 @@ func (ms *ModelSuite) TestRequests_GetPotentialProviders() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request := tt.request
-			pps, err := request.GetPotentialProviders(Ctx(), tt.user)
+			pps, err := request.GetPotentialProviders(ms.DB, tt.user)
 			ms.NoError(err, "unexpected error")
 
 			ids := make([]int, len(pps))
@@ -1773,7 +1773,7 @@ func (ms *ModelSuite) TestRequests_FindByUser_SearchText() {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			requests := Requests{}
-			err := requests.FindByUser(Ctx(), test.user, RequestFilterParams{SearchText: &test.matchText})
+			err := requests.FindByUser(ms.DB, test.user, RequestFilterParams{SearchText: &test.matchText})
 
 			if test.wantErr {
 				ms.Error(err)
@@ -1810,7 +1810,7 @@ func (ms *ModelSuite) TestRequest_IsEditable() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			editable, err := test.request.IsEditable(Ctx(), test.user)
+			editable, err := test.request.IsEditable(ms.DB, test.user)
 
 			if test.wantErr {
 				ms.Error(err)
@@ -2088,7 +2088,7 @@ func (ms *ModelSuite) TestRequest_DestroyPotentialProviders() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.request.DestroyPotentialProviders(Ctx(), test.status, test.currentUser)
+			err := test.request.DestroyPotentialProviders(ms.DB, test.status, test.currentUser)
 
 			if test.wantErr != "" {
 				ms.Error(err, "did not get error as expected")
@@ -2132,7 +2132,7 @@ func (ms *ModelSuite) TestRequest_IsVisible() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got := tt.request.IsVisible(createTestContext(tt.user), tt.user)
+			got, _ := tt.request.IsVisible(ms.DB, tt.user)
 			ms.Equal(tt.want, got)
 		})
 	}

--- a/application/models/request_test.go
+++ b/application/models/request_test.go
@@ -2132,7 +2132,8 @@ func (ms *ModelSuite) TestRequest_IsVisible() {
 	}
 	for _, tt := range tests {
 		ms.T().Run(tt.name, func(t *testing.T) {
-			got, _ := tt.request.IsVisible(ms.DB, tt.user)
+			got, err := tt.request.IsVisible(ms.DB, tt.user)
+			ms.NoError(err)
 			ms.Equal(tt.want, got)
 		})
 	}

--- a/application/models/testutils_test.go
+++ b/application/models/testutils_test.go
@@ -49,7 +49,7 @@ func createOrganizationFixtures(tx *pop.Connection, n int) Organizations {
 		organizations[i].Name = fmt.Sprintf("Org%v", i+1)
 		organizations[i].AuthType = AuthTypeSaml
 		organizations[i].AuthConfig = "{}"
-		if _, err := organizations[i].AttachLogo(Ctx(), files[i].UUID.String()); err != nil {
+		if _, err := organizations[i].AttachLogo(tx, files[i].UUID.String()); err != nil {
 			panic("error attaching logo to org fixture, " + err.Error())
 		}
 
@@ -153,7 +153,7 @@ func createRequestFixtures(tx *pop.Connection, nRequests int, createFiles bool) 
 		requests[i].Visibility = RequestVisibilitySame
 
 		if createFiles {
-			if _, err := requests[i].AttachPhoto(Ctx(), files[i].UUID.String()); err != nil {
+			if _, err := requests[i].AttachPhoto(tx, files[i].UUID.String()); err != nil {
 				panic("error attaching photo to request fixture, " + err.Error())
 			}
 		}
@@ -265,7 +265,7 @@ func createPotentialProvidersFixtures(ms *ModelSuite) potentialProvidersFixtures
 	for i, p := range requests[:2] {
 		for _, u := range uf.Users[i+1:] {
 			c := PotentialProvider{RequestID: p.ID, UserID: u.ID}
-			c.Create(Ctx())
+			c.Create(ms.DB)
 			providers = append(providers, c)
 		}
 	}
@@ -321,7 +321,7 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 		meetings[i].StartDate = time.Now()
 		meetings[i].EndDate = time.Now().Add(time.Hour * 24)
 		meetings[i].InviteCode = nulls.NewUUID(domain.GetUUID())
-		if _, err := meetings[i].SetImageFile(Ctx(), files[i].UUID.String()); err != nil {
+		if _, err := meetings[i].SetImageFile(tx, files[i].UUID.String()); err != nil {
 			panic("error attaching image to meeting fixture, " + err.Error())
 		}
 		mustCreate(tx, &meetings[i])
@@ -341,7 +341,7 @@ func createMeetingFixtures(tx *pop.Connection, nMeetings int) meetingFixtures {
 		}
 		invites[i].MeetingID = meetings[i/invitesPerMeeting].ID
 		invites[i].InviterID = user.ID
-		if err := invites[i].Create(Ctx()); err != nil {
+		if err := invites[i].Create(tx); err != nil {
 			panic(fmt.Sprintf("error creating invite fixture %d, %s", i, err))
 		}
 	}

--- a/application/models/thread_test.go
+++ b/application/models/thread_test.go
@@ -165,7 +165,7 @@ func (ms *ModelSuite) TestThread_GetMessages() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := test.thread.Messages(Ctx())
+			got, err := test.thread.Messages(ms.DB)
 			if test.wantErr {
 				if (err != nil) != test.wantErr {
 					t.Errorf("Messages() did not return expected error")
@@ -373,7 +373,7 @@ func (ms *ModelSuite) TestThread_GetLastViewedAt() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			lastViewedAt, err := test.thread.GetLastViewedAt(Ctx(), test.user)
+			lastViewedAt, err := test.thread.GetLastViewedAt(ms.DB, test.user)
 			if test.wantErr {
 				ms.Error(err, "did not get expected error")
 				return
@@ -403,7 +403,7 @@ func (ms *ModelSuite) TestThread_UpdateLastViewedAt() {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.thread.UpdateLastViewedAt(Ctx(), test.user.ID, test.lastViewedAt)
+			err := test.thread.UpdateLastViewedAt(ms.DB, test.user.ID, test.lastViewedAt)
 
 			if test.wantErr != "" {
 				ms.Error(err)
@@ -412,7 +412,7 @@ func (ms *ModelSuite) TestThread_UpdateLastViewedAt() {
 			}
 			ms.NoError(err)
 
-			lastViewedAt, err := test.thread.GetLastViewedAt(Ctx(), test.user)
+			lastViewedAt, err := test.thread.GetLastViewedAt(ms.DB, test.user)
 			ms.NoError(err)
 			ms.WithinDuration(test.lastViewedAt, *lastViewedAt, time.Second,
 				fmt.Sprintf("time not correct, got %v, wanted %v", lastViewedAt, test.lastViewedAt))
@@ -463,7 +463,7 @@ func (ms *ModelSuite) TestThread_UnreadMessageCount() {
 			err := DB.Load(&test.threadP)
 			ms.NoError(err)
 
-			got, err := test.threadP.Thread.UnreadMessageCount(Ctx(), test.user.ID, test.threadP.LastViewedAt)
+			got, err := test.threadP.Thread.UnreadMessageCount(ms.DB, test.user.ID, test.threadP.LastViewedAt)
 			if test.wantErr {
 				ms.Error(err, "did not get expected error")
 				return

--- a/application/models/user_fixtures_test.go
+++ b/application/models/user_fixtures_test.go
@@ -96,8 +96,8 @@ func CreateFixturesForUserGetRequests(ms *ModelSuite) UserRequestFixtures {
 
 	requests := createRequestFixtures(ms.DB, 4, false)
 	userID := users[1].UUID.String()
-	requests[0].SetProviderWithStatus(Ctx(), RequestStatusAccepted, &userID)
-	requests[1].SetProviderWithStatus(Ctx(), RequestStatusAccepted, &userID)
+	requests[0].SetProviderWithStatus(ms.DB, RequestStatusAccepted, &userID)
+	requests[1].SetProviderWithStatus(ms.DB, RequestStatusAccepted, &userID)
 	requests[2].Status = RequestStatusAccepted
 	requests[3].Status = RequestStatusAccepted
 	ms.NoError(ms.DB.Save(&requests))
@@ -404,7 +404,7 @@ func CreateFixturesForUserWantsRequestNotification(ms *ModelSuite) UserRequestFi
 	requests := createRequestFixtures(ms.DB, 3, false)
 	requestOneLocation, err := requests[1].GetOrigin(ms.DB)
 	ms.NoError(err)
-	ms.NoError(users[1].SetLocation(Ctx(), *requestOneLocation))
+	ms.NoError(users[1].SetLocation(ms.DB, *requestOneLocation))
 
 	// make a copy of the request destination and assign it to a watch
 	watchLocation, err := requests[2].GetDestination(ms.DB)


### PR DESCRIPTION
found it to be confusing having some function accept context.Context and some accept *pop.Connection, so switched all of them over to *pop.Connection