### PR TITLE
fix bug in GET /requests

### DIFF
--- a/application/actions/requests_fixtures_test.go
+++ b/application/actions/requests_fixtures_test.go
@@ -101,6 +101,10 @@ func createFixturesForRequestsList(as *ActionSuite) RequestsListFixtures {
 	requests[1].ProviderID = nulls.NewInt(usersFixtures.Users[2].ID)
 	as.NoError(as.DB.Save(&requests[2]))
 
+	photo := test.CreateFileFixture(as.DB)
+	requests[0].FileID = nulls.NewInt(photo.ID)
+	as.NoError(as.DB.Save(&requests[0]))
+
 	return RequestsListFixtures{
 		Users:    usersFixtures.Users,
 		Requests: requests,

--- a/application/models/file.go
+++ b/application/models/file.go
@@ -36,7 +36,7 @@ func (f *FileUploadError) Error() string {
 }
 
 type File struct {
-	ID            int       `json:"id" db:"id"`
+	ID            int       `json:"-" db:"id"`
 	UUID          uuid.UUID `json:"uuid" db:"uuid"`
 	URL           string    `json:"url" db:"url"`
 	URLExpiration time.Time `json:"url_expiration" db:"url_expiration"`


### PR DESCRIPTION
Fixed bug in GET /requests with photo ID, identified with error message:
> error converting photo to api.File: failed to convert to api. unmarshal error: json: cannot unmarshal number into Go struct field File.id of type uuid.UUID