### PR TITLE
GET /requests/{id}

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -100,7 +100,10 @@ func App() *buffalo.App {
 		threadsGroup.GET("/", threadsMine)
 		threadsGroup.PUT("/{thread_id}/read", threadsMarkAsRead)
 
-		app.GET("/requests", requestsList)
+		requestsGroup := app.Group("/requests")
+		requestsGroup.GET("/", requestsList)
+		requestsGroup.GET("/{request_id}", requestsGet)
+
 		watchesGroup := app.Group("/watches")
 		watchesGroup.GET("/", watchesMine)
 		watchesGroup.DELETE("/{watch_id}", watchesRemove)

--- a/application/actions/requests.go
+++ b/application/actions/requests.go
@@ -207,7 +207,11 @@ func convertRequestAbridged(ctx context.Context, request models.Request) (api.Re
 }
 
 func loadRequestCreatedBy(ctx context.Context, request models.Request) (api.User, error) {
-	createdBy, _ := request.GetCreator(models.Tx(ctx))
+	createdBy, err := request.GetCreator(models.Tx(ctx))
+	if err != nil {
+		return api.User{}, errors.New("loading request creator, " + err.Error())
+	}
+
 	outputCreatedBy, err := convertUser(ctx, *createdBy)
 	if err != nil {
 		err = errors.New("error converting request created_by user: " + err.Error())

--- a/application/actions/requests.go
+++ b/application/actions/requests.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gobuffalo/buffalo"
 	"github.com/gobuffalo/buffalo/render"
-	"github.com/gobuffalo/pop/v5"
+	"github.com/silinternational/wecarry-api/domain"
 
 	"github.com/silinternational/wecarry-api/api"
 	"github.com/silinternational/wecarry-api/models"
@@ -42,13 +42,50 @@ func requestsList(c buffalo.Context) error {
 	return c.Render(200, render.JSON(output))
 }
 
+// swagger:operation GET /requests/{request_id} RequestsGet
+//
+// gets a single request
+//
+// ---
+// responses:
+//   '200':
+//     description: get a request
+//     schema:
+//       "$ref": "#/definitions/Request"
+func requestsGet(c buffalo.Context) error {
+	cUser := models.CurrentUser(c)
+	tx := models.Tx(c)
+
+	id, err := getUUIDFromParam(c, "request_id")
+	if err != nil {
+		return reportError(c, err)
+	}
+	domain.NewExtra(c, "requestID", id)
+
+	request := models.Request{}
+	if err := request.FindByUUID(tx, id.String()); err != nil {
+		return reportError(c, api.NewAppError(err, api.ErrorGetRequest, api.CategoryInternal))
+	}
+
+	if !cUser.CanViewRequest(tx, request) {
+		return reportError(c, api.NewAppError(err, api.ErrorGetRequestUserNotAllowed, api.CategoryForbidden))
+	}
+
+	output, err := convertRequest(c, request)
+	if err != nil {
+		return reportError(c, err)
+	}
+
+	return c.Render(200, render.JSON(output))
+}
+
 // converts list of model.Request into api.RequestAbridged
 func convertRequestsAbridged(ctx context.Context, requests []models.Request) ([]api.RequestAbridged, error) {
 	output := make([]api.RequestAbridged, len(requests))
 
 	for i, request := range requests {
 		var err error
-		output[i], err = convertRequestToAPITypeAbridged(ctx, request)
+		output[i], err = convertRequestAbridged(ctx, request)
 		if err != nil {
 			return []api.RequestAbridged{}, err
 		}
@@ -57,8 +94,8 @@ func convertRequestsAbridged(ctx context.Context, requests []models.Request) ([]
 	return output, nil
 }
 
-// converts model.Request into api.Request
-func convertRequestToAPIType(ctx context.Context, request models.Request) (api.Request, error) {
+// convertRequest converts model.Request into api.Request
+func convertRequest(ctx context.Context, request models.Request) (api.Request, error) {
 	var output api.Request
 	if err := api.ConvertToOtherType(request, &output); err != nil {
 		err = errors.New("error converting request to api.request: " + err.Error())
@@ -66,45 +103,68 @@ func convertRequestToAPIType(ctx context.Context, request models.Request) (api.R
 	}
 	output.ID = request.UUID
 
-	// Hydrate nested request fields for api.RequestAbridged
 	tx := models.Tx(ctx)
-	createdBy, err := hydrateRequestCreatedBy(ctx, request, tx)
+	user := models.CurrentUser(ctx)
+
+	createdBy, err := loadRequestCreatedBy(ctx, request)
 	if err != nil {
 		return api.Request{}, err
 	}
-	output.CreatedBy = &createdBy
+	output.CreatedBy = createdBy
 
-	origin, err := hydrateRequestOrigin(ctx, request, tx)
+	origin, err := loadRequestOrigin(ctx, request)
 	if err != nil {
 		return api.Request{}, err
 	}
-	output.Origin = &origin
+	output.Origin = origin
 
-	destination, err := hydrateRequestDestination(ctx, request, tx)
+	destination, err := loadRequestDestination(ctx, request)
 	if err != nil {
 		return api.Request{}, err
 	}
-	output.Destination = &destination
+	output.Destination = destination
 
-	provider, err := hydrateProvider(ctx, request, tx)
+	provider, err := loadProvider(ctx, request)
 	if err != nil {
 		return api.Request{}, err
 	}
-	output.Provider = &provider
+	output.Provider = provider
 
-	photo, err := hydrateRequestPhoto(ctx, request, tx)
+	photo, err := loadRequestPhoto(ctx, request)
 	if err != nil {
 		return api.Request{}, err
 	}
-	output.Photo = &photo
+	output.Photo = photo
 
-	// TODO: hydrate other nested request fields after reconciling api.Request struct with the UI field list
+	potentialProviders, err := loadPotentialProviders(ctx, request, user)
+	if err != nil {
+		return api.Request{}, err
+	}
+	output.PotentialProviders = potentialProviders
+
+	organization, err := loadRequestOrganization(ctx, request)
+	if err != nil {
+		return api.Request{}, err
+	}
+	output.Organization = organization
+
+	meeting, err := loadRequestMeeting(ctx, request)
+	if err != nil {
+		return api.Request{}, err
+	}
+	output.Meeting = meeting
+
+	isEditable, err := request.IsEditable(tx, user)
+	if err != nil {
+		return api.Request{}, err
+	}
+	output.IsEditable = isEditable
 
 	return output, nil
 }
 
-// converts model.Request into api.RequestAbridged
-func convertRequestToAPITypeAbridged(ctx context.Context, request models.Request) (api.RequestAbridged, error) {
+// convertRequestAbridged converts model.Request into api.RequestAbridged
+func convertRequestAbridged(ctx context.Context, request models.Request) (api.RequestAbridged, error) {
 	var output api.RequestAbridged
 	if err := api.ConvertToOtherType(request, &output); err != nil {
 		err = errors.New("error converting request to api.request: " + err.Error())
@@ -113,42 +173,41 @@ func convertRequestToAPITypeAbridged(ctx context.Context, request models.Request
 	output.ID = request.UUID
 
 	// Hydrate nested request fields
-	tx := models.Tx(ctx)
-	createdBy, err := hydrateRequestCreatedBy(ctx, request, tx)
+	createdBy, err := loadRequestCreatedBy(ctx, request)
 	if err != nil {
 		return api.RequestAbridged{}, err
 	}
 	output.CreatedBy = &createdBy
 
-	origin, err := hydrateRequestOrigin(ctx, request, tx)
+	origin, err := loadRequestOrigin(ctx, request)
 	if err != nil {
 		return api.RequestAbridged{}, err
 	}
-	output.Origin = &origin
+	output.Origin = origin
 
-	destination, err := hydrateRequestDestination(ctx, request, tx)
+	destination, err := loadRequestDestination(ctx, request)
 	if err != nil {
 		return api.RequestAbridged{}, err
 	}
 	output.Destination = &destination
 
-	provider, err := hydrateProvider(ctx, request, tx)
+	provider, err := loadProvider(ctx, request)
 	if err != nil {
 		return api.RequestAbridged{}, err
 	}
-	output.Provider = &provider
+	output.Provider = provider
 
-	photo, err := hydrateRequestPhoto(ctx, request, tx)
+	photo, err := loadRequestPhoto(ctx, request)
 	if err != nil {
 		return api.RequestAbridged{}, err
 	}
-	output.Photo = &photo
+	output.Photo = photo
 
 	return output, nil
 }
 
-func hydrateRequestCreatedBy(ctx context.Context, request models.Request, tx *pop.Connection) (api.User, error) {
-	createdBy, _ := request.GetCreator(tx)
+func loadRequestCreatedBy(ctx context.Context, request models.Request) (api.User, error) {
+	createdBy, _ := request.GetCreator(models.Tx(ctx))
 	outputCreatedBy, err := convertUser(ctx, *createdBy)
 	if err != nil {
 		err = errors.New("error converting request created_by user: " + err.Error())
@@ -157,22 +216,27 @@ func hydrateRequestCreatedBy(ctx context.Context, request models.Request, tx *po
 	return outputCreatedBy, nil
 }
 
-func hydrateRequestOrigin(ctx context.Context, request models.Request, tx *pop.Connection) (api.Location, error) {
-	origin, err := request.GetOrigin(tx)
+func loadRequestOrigin(ctx context.Context, request models.Request) (*api.Location, error) {
+	origin, err := request.GetOrigin(models.Tx(ctx))
 	if err != nil {
 		err = errors.New("error converting request origin: " + err.Error())
-		return api.Location{}, err
+		return nil, err
 	}
+
+	if origin == nil {
+		return nil, nil
+	}
+
 	var outputOrigin api.Location
 	if err := api.ConvertToOtherType(origin, &outputOrigin); err != nil {
 		err = errors.New("error converting origin to api.Location: " + err.Error())
-		return api.Location{}, err
+		return nil, err
 	}
-	return outputOrigin, nil
+	return &outputOrigin, nil
 }
 
-func hydrateRequestDestination(ctx context.Context, request models.Request, tx *pop.Connection) (api.Location, error) {
-	destination, err := request.GetDestination(tx)
+func loadRequestDestination(ctx context.Context, request models.Request) (api.Location, error) {
+	destination, err := request.GetDestination(models.Tx(ctx))
 	if err != nil {
 		err = errors.New("error converting request destination: " + err.Error())
 		return api.Location{}, err
@@ -185,36 +249,96 @@ func hydrateRequestDestination(ctx context.Context, request models.Request, tx *
 	return outputDestination, nil
 }
 
-func hydrateProvider(ctx context.Context, request models.Request, tx *pop.Connection) (api.User, error) {
+func loadProvider(ctx context.Context, request models.Request) (*api.User, error) {
+	tx := models.Tx(ctx)
+
 	provider, err := request.GetProvider(tx)
 	if err != nil {
 		err = errors.New("error converting request provider: " + err.Error())
-		return api.User{}, err
+		return nil, err
 	}
-	var outputProvider api.User
-	if err := api.ConvertToOtherType(provider, &outputProvider); err != nil {
-		err = errors.New("error converting provider to api.User: " + err.Error())
-		return api.User{}, err
+
+	if provider == nil {
+		return nil, nil
 	}
-	if provider != nil {
-		outputProvider.ID = provider.UUID
+
+	outputProvider, err := convertUser(ctx, *provider)
+	if err != nil {
+		return nil, err
 	}
-	return outputProvider, nil
+
+	return &outputProvider, nil
 }
 
-func hydrateRequestPhoto(ctx context.Context, request models.Request, tx *pop.Connection) (api.File, error) {
-	photo, err := request.GetPhoto(tx)
+func loadPotentialProviders(ctx context.Context, request models.Request, user models.User) (api.Users, error) {
+	tx := models.Tx(ctx)
+
+	potentialProviders, err := request.GetPotentialProviders(tx, user)
+	if err != nil {
+		err = errors.New("error converting request potential providers: " + err.Error())
+		return nil, err
+	}
+
+	outputProviders, err := convertUsers(ctx, potentialProviders)
+	if err != nil {
+		return nil, err
+	}
+
+	return outputProviders, nil
+}
+
+func loadRequestPhoto(ctx context.Context, request models.Request) (*api.File, error) {
+	photo, err := request.GetPhoto(models.Tx(ctx))
 	if err != nil {
 		err = errors.New("error converting request photo: " + err.Error())
-		return api.File{}, err
+		return nil, err
 	}
+
+	if photo == nil {
+		return nil, nil
+	}
+
 	var outputPhoto api.File
 	if err := api.ConvertToOtherType(photo, &outputPhoto); err != nil {
 		err = errors.New("error converting photo to api.File: " + err.Error())
-		return api.File{}, err
+		return nil, err
 	}
-	if photo != nil {
-		outputPhoto.ID = photo.UUID
+	outputPhoto.ID = photo.UUID
+	return &outputPhoto, nil
+}
+
+func loadRequestOrganization(ctx context.Context, request models.Request) (api.Organization, error) {
+	organization, err := request.GetOrganization(models.Tx(ctx))
+	if err != nil {
+		err = errors.New("error converting request organization: " + err.Error())
+		return api.Organization{}, err
 	}
-	return outputPhoto, nil
+
+	var outputOrganization api.Organization
+	if err := api.ConvertToOtherType(organization, &outputOrganization); err != nil {
+		err = errors.New("error converting organization to api.File: " + err.Error())
+		return api.Organization{}, err
+	}
+	outputOrganization.ID = organization.UUID
+	return outputOrganization, nil
+}
+
+func loadRequestMeeting(ctx context.Context, request models.Request) (*api.Meeting, error) {
+	meeting, err := request.Meeting(models.Tx(ctx))
+	if err != nil {
+		err = errors.New("error converting request meeting: " + err.Error())
+		return nil, err
+	}
+
+	if meeting == nil {
+		return nil, nil
+	}
+
+	var outputMeeting api.Meeting
+	if err := api.ConvertToOtherType(meeting, &outputMeeting); err != nil {
+		err = errors.New("error converting meeting to api.Meeting: " + err.Error())
+		return nil, err
+	}
+	outputMeeting.ID = meeting.UUID
+	return &outputMeeting, nil
 }

--- a/application/actions/requests.go
+++ b/application/actions/requests.go
@@ -320,7 +320,7 @@ func loadRequestOrganization(ctx context.Context, request models.Request) (api.O
 
 	var outputOrganization api.Organization
 	if err := api.ConvertToOtherType(organization, &outputOrganization); err != nil {
-		err = errors.New("error converting organization to api.File: " + err.Error())
+		err = errors.New("error converting organization to api.Organization: " + err.Error())
 		return api.Organization{}, err
 	}
 	outputOrganization.ID = organization.UUID

--- a/application/actions/requests_fixtures_test.go
+++ b/application/actions/requests_fixtures_test.go
@@ -99,7 +99,7 @@ func createFixturesForRequestsList(as *ActionSuite) RequestsListFixtures {
 	requests[1].Status = models.RequestStatusCompleted
 	requests[1].CompletedOn = nulls.NewTime(time.Now())
 	requests[1].ProviderID = nulls.NewInt(usersFixtures.Users[2].ID)
-	as.NoError(as.DB.Save(&requests[2]))
+	as.NoError(as.DB.Save(&requests[1]))
 
 	photo := test.CreateFileFixture(as.DB)
 	requests[0].FileID = nulls.NewInt(photo.ID)

--- a/application/actions/threads.go
+++ b/application/actions/threads.go
@@ -140,12 +140,17 @@ func convertThread(ctx context.Context, thread models.Thread) (api.Thread, error
 		output.Participants[i].ID = thread.Participants[i].UUID
 	}
 
-	requestOutput, err := convertRequestToAPIType(ctx, thread.Request)
-	if err != nil {
-		return api.Thread{}, err
+	if thread.Request.ID > 0 {
+		requestOutput, err := convertRequest(ctx, thread.Request)
+		if err != nil {
+			return api.Thread{}, err
+		}
+
+		output.Request = &requestOutput
+	} else {
+		output.Request = nil
 	}
 
-	output.Request = &requestOutput
 	output.ID = thread.UUID
 	return output, nil
 }

--- a/application/actions/users.go
+++ b/application/actions/users.go
@@ -121,6 +121,18 @@ func convertUserPrivate(ctx context.Context, user models.User) (api.UserPrivate,
 	return output, nil
 }
 
+func convertUsers(ctx context.Context, users models.Users) (api.Users, error) {
+	output := make(api.Users, len(users))
+	for i := range output {
+		var err error
+		output[i], err = convertUser(ctx, users[i])
+		if err != nil {
+			return output, err
+		}
+	}
+	return output, nil
+}
+
 func convertUser(ctx context.Context, user models.User) (api.User, error) {
 	tx := models.Tx(ctx)
 

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -84,7 +84,9 @@ const (
 
 	// Request
 
-	ErrorGetRequests = ErrorKey("ErrorGetRequests")
+	ErrorGetRequests              = ErrorKey("ErrorGetRequests")
+	ErrorGetRequest               = ErrorKey("ErrorGetRequest")
+	ErrorGetRequestUserNotAllowed = ErrorKey("ErrorGetRequestUserNotAllowed")
 
 	// Thread
 

--- a/application/api/file.go
+++ b/application/api/file.go
@@ -23,7 +23,7 @@ type File struct {
 	Url string `json:"url"`
 
 	// expiration time of the URL, re-issue the query to get a new URL and expiration time
-	UrlExpiration time.Time `json:"urlExpiration"`
+	UrlExpiration time.Time `json:"url_expiration"`
 
 	// filename with extension, limited to 255 characters, e.g. `image.jpg`
 	Name string `json:"name"`
@@ -32,5 +32,5 @@ type File struct {
 	Size int `json:"size"`
 
 	// MIME content type, limited to 255 characters, e.g. 'image/jpeg'
-	ContentType string `json:"contentType"`
+	ContentType string `json:"content_type"`
 }

--- a/application/api/requests.go
+++ b/application/api/requests.go
@@ -3,8 +3,11 @@ package api
 import (
 	"time"
 
+	"github.com/gobuffalo/nulls"
 	"github.com/gofrs/uuid"
 )
+
+type RequestVisibility string
 
 // swagger:model
 type Requests []Request
@@ -12,7 +15,6 @@ type Requests []Request
 // Request is a hand carry request
 //
 // swagger:model
-// TODO: reconcile api.Request struct with the UI field list
 type Request struct {
 	// unique identifier for the Request
 	//
@@ -22,58 +24,61 @@ type Request struct {
 	ID uuid.UUID `json:"id"`
 
 	// Whether request is editable by current user
-	IsEditable bool `json:"isEditable"`
+	IsEditable bool `json:"is_editable"`
 
 	// Request status: OPEN, ACCEPTED, DELIVERED, RECEIVED, COMPLETED, REMOVED
 	RequestStatus string `json:"status"`
 
 	// Profile of the user that created this request
-	CreatedBy *User `json:"created_by"`
+	CreatedBy User `json:"created_by"`
 
 	// Profile of the user that is the provider for this request
-	Provider *User `json:"provider,omitempty"`
+	Provider *User `json:"provider"`
 
 	// Users that have offered to carry this request
-	PotentialProviders *[]User `json:"potentialProviders"`
+	PotentialProviders []User `json:"potential_providers"`
 
 	// Organization associated with this request
-	Organization *Organization `json:"organization,omitempty"`
+	Organization Organization `json:"organization"`
+
+	// Visibility restrictions for this request
+	Visibility RequestVisibility `json:"visibility"`
 
 	// Short description of item, limited to 255 characters
 	Title string `json:"title"`
 
 	// Optional, longer description of the item, limited to 4,096 characters
-	Description string `json:"description"`
+	Description nulls.String `json:"description"`
 
 	// Geographic location where item is needed
-	Destination *Location `json:"destination"`
+	Destination Location `json:"destination"`
 
 	// Optional geographic location where the item can be picked up, purchased, or otherwise obtained
-	Origin *Location `json:"origin,omitempty"`
+	Origin *Location `json:"origin"`
 
 	// Broad category of the size of item
 	Size string `json:"size"`
 
-	// List of message threads associated with this request
-	Threads *Threads `json:"threads"`
-
 	// Date and time this request was created
-	CreatedAt *time.Time `json:"createdAt"`
+	CreatedAt time.Time `json:"created_at"`
 
 	// Date and time this request was last updated
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt time.Time `json:"updated_at"`
 
 	// Date (yyyy-mm-dd) before which the item will be needed. The record may be hidden or removed after this date
-	NeededBefore time.Time `json:"neededBefore"`
+	NeededBefore nulls.Time `json:"needed_before"`
 
 	// Optional weight of the item, measured in kilograms
-	Kilograms float64 `json:"kilograms"`
+	Kilograms nulls.Float64 `json:"kilograms"`
 
 	// Optional URL to further describe or point to detail about the item, limited to 255 characters
-	Url string `json:"url"`
+	Url nulls.String `json:"url"`
 
 	// Photo of the item
 	Photo *File `json:"photo"`
+
+	// Meeting associated with this request. Affects visibility of the request.
+	Meeting *Meeting `json:"meeting"`
 }
 
 // swagger:model
@@ -94,7 +99,7 @@ type RequestAbridged struct {
 	CreatedBy *User `json:"created_by"`
 
 	// Profile of the user that is the provider for this request
-	Provider *User `json:"provider,omitempty"`
+	Provider *User `json:"provider"`
 
 	// Short description of item, limited to 255 characters
 	Title string `json:"title"`
@@ -103,7 +108,7 @@ type RequestAbridged struct {
 	Destination *Location `json:"destination"`
 
 	// Optional geographic location where the item can be picked up, purchased, or otherwise obtained
-	Origin *Location `json:"origin,omitempty"`
+	Origin *Location `json:"origin"`
 
 	// Broad category of the size of item
 	Size string `json:"size"`


### PR DESCRIPTION
Looks like "omitempty" isn't the solution I expected. I reserve the right to change my mind a few more times on this, haha.

Changed nullable fields to either a pointer or a `nulls` type. This made the /requests test more complicated since `"photo":null` looks very different than `"photo":{"id":"fc428c80-2832-4a28-8f86-c55cc1b089aa"`.  Also removed pointers from some that are NOT nullable.

Also includes some fixes on GET /requests. Using related items on the fixtures is problematic because they don't come back from the fixture generation fully-loaded. So we have to specifically go fetch that data to use as a test comparison value. Also, there was a `Save` call on the wrong request, so that had strange side-effects. Fixing that, we now get one fewer requests in the response because one is completed.

Some of the json tags were camel case, which is non-standard for our REST APIs. I changed them to snake case, but that means we'll have to change the UI accordingly.

Just realized that I never went back to make a test for `GET /requests/{id}`. I'll do that right after this is merged. Don't want to lose all this typing. Whew.
