### PR TITLE
test GET /requests/{id}

### DIFF
--- a/application/actions/requests.go
+++ b/application/actions/requests.go
@@ -63,11 +63,16 @@ func requestsGet(c buffalo.Context) error {
 	domain.NewExtra(c, "requestID", id)
 
 	request := models.Request{}
-	if err := request.FindByUUID(tx, id.String()); err != nil {
-		return reportError(c, api.NewAppError(err, api.ErrorGetRequest, api.CategoryInternal))
+	if err = request.FindByUUID(tx, id.String()); err != nil {
+		appError := api.NewAppError(err, api.ErrorGetRequest, api.CategoryNotFound)
+		if domain.IsOtherThanNoRows(err) {
+			appError.Category = api.CategoryInternal
+		}
+		return reportError(c, appError)
 	}
 
 	if !cUser.CanViewRequest(tx, request) {
+		err = errors.New("user not allowed to view request")
 		return reportError(c, api.NewAppError(err, api.ErrorGetRequestUserNotAllowed, api.CategoryForbidden))
 	}
 

--- a/application/actions/requests_fixtures_test.go
+++ b/application/actions/requests_fixtures_test.go
@@ -47,7 +47,7 @@ func createFixturesForRequestQuery(as *ActionSuite) RequestQueryFixtures {
 	org2 := models.Organization{Name: "org2", AuthType: AuthTypeGoogle, AuthConfig: "{}"}
 	as.NoError(org2.Save(as.DB))
 
-	requests := test.CreateRequestFixtures(as.DB, 4, true)
+	requests := test.CreateRequestFixtures(as.DB, 4, true, users[0].ID)
 	requests[0].Status = models.RequestStatusAccepted
 	requests[0].ProviderID = nulls.NewInt(users[1].ID)
 

--- a/application/actions/requests_fixtures_test.go
+++ b/application/actions/requests_fixtures_test.go
@@ -44,14 +44,19 @@ func createFixturesForRequestQuery(as *ActionSuite) RequestQueryFixtures {
 	org := userFixtures.Organization
 	users := userFixtures.Users
 
-	requests := test.CreateRequestFixtures(as.DB, 3, true)
+	org2 := models.Organization{Name: "org2", AuthType: AuthTypeGoogle, AuthConfig: "{}"}
+	as.NoError(org2.Save(as.DB))
+
+	requests := test.CreateRequestFixtures(as.DB, 4, true)
 	requests[0].Status = models.RequestStatusAccepted
 	requests[0].ProviderID = nulls.NewInt(users[1].ID)
-	as.NoError(as.DB.Save(&requests))
 
 	requests[2].Status = models.RequestStatusCompleted
 	requests[2].CompletedOn = nulls.NewTime(time.Now())
 	requests[2].ProviderID = nulls.NewInt(users[1].ID)
+
+	requests[3].OrganizationID = org2.ID
+
 	as.NoError(as.DB.Save(&requests))
 
 	threads := []models.Thread{


### PR DESCRIPTION
Implemented a test for the GET /requests/{id} endpoint

In the process, found a couple issues:
- the authz check responded with a generic 500 because no error message was assigned
- the not-found condition produced a 500 rather than a 404