### PR TITLE
update request status endpoint (PUT /requests/{request_id}/status)

### DIFF
--- a/application/actions/actions_test.go
+++ b/application/actions/actions_test.go
@@ -108,12 +108,12 @@ func convertFloat64ToIntString(input float64) string {
 	return fmt.Sprintf("%v", int(input))
 }
 
-func (as *ActionSuite) verifyResponseData(wantData []string, body string) {
+func (as *ActionSuite) verifyResponseData(wantData []string, body string, msg string) {
 	var b bytes.Buffer
 	as.NoError(json.Indent(&b, []byte(body), "", "    "))
 	for _, w := range wantData {
 		if !strings.Contains(body, w) {
-			as.Fail(fmt.Sprintf("response data is not correct\nwanted: %s\nin body:\n%s\n", w, b.String()))
+			as.Fail(fmt.Sprintf("%s response data is not correct\nwanted: %s\nin body:\n%s\n", msg, w, b.String()))
 		}
 	}
 }

--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -109,6 +109,7 @@ func App() *buffalo.App {
 		requestsGroup.POST("/", requestsCreate)
 		requestsGroup.GET("/{request_id}", requestsGet)
 		requestsGroup.PUT("/{request_id}", requestsUpdate)
+		requestsGroup.PUT("/{request_id}/status", requestsUpdateStatus)
 
 		requestsGroup.POST("/{request_id}/potentialprovider", requestsAddMeAsPotentialProvider)
 

--- a/application/actions/potentialproviders_test.go
+++ b/application/actions/potentialproviders_test.go
@@ -175,7 +175,7 @@ func (as *ActionSuite) Test_AddMeAsPotentialProvider() {
 
 			body := res.Body.String()
 			as.Equal(tc.wantHttpStatus, res.Code, "incorrect status code returned, body: %s", body)
-			as.verifyResponseData(tc.wantContains, body)
+			as.verifyResponseData(tc.wantContains, body, "")
 		})
 	}
 }

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -107,6 +107,9 @@ const (
 	ErrorCreateRequestPhotoIDNotFound         = ErrorKey("ErrorCreateRequestPhotoIDNotFound")
 	ErrorUpdateRequest                        = ErrorKey("ErrorUpdateRequest")
 	ErrorUpdateRequestPhotoIDNotFound         = ErrorKey("ErrorUpdateRequestPhotoIDNotFound")
+	ErrorUpdateRequestStatusNotFound    = ErrorKey("ErrorUpdateRequestStatusNotFound")
+	ErrorUpdateRequestStatusBadStatus   = ErrorKey("ErrorUpdateRequestStatusBadStatus")
+	ErrorUpdateRequestStatusBadProvider = ErrorKey("ErrorUpdateRequestStatusBadProvider")
 
 	// Thread
 

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -107,9 +107,9 @@ const (
 	ErrorCreateRequestPhotoIDNotFound         = ErrorKey("ErrorCreateRequestPhotoIDNotFound")
 	ErrorUpdateRequest                        = ErrorKey("ErrorUpdateRequest")
 	ErrorUpdateRequestPhotoIDNotFound         = ErrorKey("ErrorUpdateRequestPhotoIDNotFound")
-	ErrorUpdateRequestStatusNotFound    = ErrorKey("ErrorUpdateRequestStatusNotFound")
-	ErrorUpdateRequestStatusBadStatus   = ErrorKey("ErrorUpdateRequestStatusBadStatus")
-	ErrorUpdateRequestStatusBadProvider = ErrorKey("ErrorUpdateRequestStatusBadProvider")
+	ErrorUpdateRequestStatusNotFound          = ErrorKey("ErrorUpdateRequestStatusNotFound")
+	ErrorUpdateRequestStatusBadStatus         = ErrorKey("ErrorUpdateRequestStatusBadStatus")
+	ErrorUpdateRequestStatusBadProvider       = ErrorKey("ErrorUpdateRequestStatusBadProvider")
 
 	// Thread
 

--- a/application/api/requests.go
+++ b/application/api/requests.go
@@ -189,3 +189,14 @@ type RequestUpdateInput struct {
 	// Visibility restrictions for this request. If omitted or `null`, no change is made.
 	Visibility *RequestVisibility `json:"visibility"`
 }
+
+// RequestUpdateStatusInput includes the fields for updating the status of a Request
+//
+// swagger:model
+type RequestUpdateStatusInput struct {
+	// New Status. Only a limited set of transitions are allowed.
+	Status RequestStatus `json:"status"`
+
+	// User ID of the accepted provider. Required if `status` is ACCEPTED and ignored otherwise.
+	ProviderUserID *string `json:"provider_user_id"`
+}

--- a/application/gqlgen/request.go
+++ b/application/gqlgen/request.go
@@ -526,11 +526,6 @@ func (r *mutationResolver) UpdateRequestStatus(ctx context.Context, input Update
 		return &models.Request{}, domain.ReportError(ctx, err, "UpdateRequestStatus")
 	}
 
-	if err := request.DestroyPotentialProviders(tx, input.Status, cUser); err != nil {
-		return &models.Request{}, domain.ReportError(ctx, errors.New("error destroying request's potential providers: "+err.Error()),
-			"UpdateRequestStatus.DestroyPotentialProviders")
-	}
-
 	return &request, nil
 }
 

--- a/application/models/potentialprovider.go
+++ b/application/models/potentialprovider.go
@@ -211,22 +211,3 @@ func (p *PotentialProvider) NewWithRequestUUID(tx *pop.Connection, requestUUID s
 func (p *PotentialProvider) Destroy(tx *pop.Connection) error {
 	return tx.Destroy(p)
 }
-
-// DestroyAllWithRequestUUID Destroys all the PotentialProviders associated with a Request depending
-//  on whether the current user is a SuperAdmin or the Request's creator.
-func (p *PotentialProviders) DestroyAllWithRequestUUID(tx *pop.Connection, requestUUID string, currentUser User) error {
-	var request Request
-	if err := request.FindByUUID(tx, requestUUID); err != nil {
-		return errors.New("unable to find Request in order to remove PotentialProviders: " + err.Error())
-	}
-
-	if currentUser.AdminRole != UserAdminRoleSuperAdmin && currentUser.ID != request.CreatedByID {
-		return fmt.Errorf("user %v has insufficient permissions to destroy PotentialProviders for Request %v",
-			currentUser.ID, request.ID)
-	}
-
-	if err := tx.Where("request_id = ?", request.ID).All(p); err != nil {
-		return errors.New("unable to find Request's Potential Providers in order to remove them: " + err.Error())
-	}
-	return tx.Destroy(p)
-}

--- a/application/models/potentialprovider_test.go
+++ b/application/models/potentialprovider_test.go
@@ -123,67 +123,6 @@ func (ms *ModelSuite) TestPotentialProvider_FindWithRequestUUIDAndUserUUID() {
 	}
 }
 
-func (ms *ModelSuite) TestPotentialProviders_DestroyAllWithRequestUUID() {
-	f := createPotentialProvidersFixtures(ms)
-	requests := f.Requests
-	users := f.Users
-	pps := f.PotentialProviders
-	t := ms.T()
-	tests := []struct {
-		name        string
-		currentUser User
-		request     Request
-		wantIDs     []int
-		wantErr     string
-	}{
-		{
-			name:        "good: Request Creator as current user",
-			currentUser: users[0],
-			request:     requests[0],
-			wantIDs:     []int{pps[3].ID, pps[4].ID},
-		},
-		{
-			name:        "bad: current user is potential provider but not Request Creator",
-			currentUser: users[2],
-			request:     requests[0],
-			wantErr: fmt.Sprintf(`user %v has insufficient permissions to destroy PotentialProviders for Request %v`,
-				users[2].ID, requests[0].ID),
-		},
-		{
-			name:        "bad: current user is not Request Creator",
-			currentUser: users[1],
-			request:     requests[1],
-			wantErr: fmt.Sprintf(`user %v has insufficient permissions to destroy PotentialProviders for Request %v`,
-				users[1].ID, requests[1].ID),
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			providers := PotentialProviders{}
-			err := providers.DestroyAllWithRequestUUID(ms.DB, test.request.UUID.String(), test.currentUser)
-
-			if test.wantErr != "" {
-				ms.Error(err, "did not get error as expected")
-				ms.Equal(test.wantErr, err.Error(), "wrong error message")
-				return
-			}
-
-			ms.NoError(err, "unexpected error")
-
-			var provs PotentialProviders
-			err = DB.All(&provs)
-			ms.NoError(err, "error just getting PotentialProviders back out of the DB.")
-
-			pIDs := make([]int, len(provs))
-			for i, p := range provs {
-				pIDs[i] = p.ID
-			}
-
-			ms.Equal(test.wantIDs, pIDs)
-		})
-	}
-}
-
 func (ms *ModelSuite) TestNewWithRequestUUID() {
 	f := createPotentialProvidersFixtures(ms)
 	users := f.Users


### PR DESCRIPTION
- also moved the deletion of potential providers to the `Request` `AfterUpdate` callback