### PR TITLE
Expect simple dates for meeting StartDate and EndDate

### DIFF
--- a/application/actions/meetings.go
+++ b/application/actions/meetings.go
@@ -90,13 +90,27 @@ func meetingsCreate(c buffalo.Context) error {
 func convertMeetingCreateInput(ctx context.Context, input api.MeetingCreateInput) (models.Meeting, error) {
 	tx := models.Tx(ctx)
 
+	startDate, err := time.Parse(domain.DateFormat, input.StartDate)
+	if err != nil {
+		err = errors.New("failed to parse StartDate, " + err.Error())
+		appErr := api.NewAppError(err, api.ErrorCreateMeetingInvalidStartDate, api.CategoryUser)
+		return models.Meeting{}, appErr
+	}
+
+	endDate, err := time.Parse(domain.DateFormat, input.EndDate)
+	if err != nil {
+		err = errors.New("failed to parse EndDate, " + err.Error())
+		appErr := api.NewAppError(err, api.ErrorCreateMeetingInvalidEndDate, api.CategoryUser)
+		return models.Meeting{}, appErr
+	}
+
 	meeting := models.Meeting{
 		CreatedByID: models.CurrentUser(ctx).ID,
 		Name:        input.Name,
 		Description: input.Description,
 		MoreInfoURL: input.MoreInfoURL,
-		StartDate:   input.StartDate,
-		EndDate:     input.EndDate,
+		StartDate:   startDate,
+		EndDate:     endDate,
 	}
 
 	if input.ImageFileID.Valid {

--- a/application/api/errorcodes.go
+++ b/application/api/errorcodes.go
@@ -81,10 +81,12 @@ const (
 
 	// Meeting
 
-	ErrorMeetingsGet                  = ErrorKey("ErrorMeetingsGet")
-	ErrorMeetingsConvert              = ErrorKey("ErrorMeetingsConvert")
-	ErrorCreateMeeting                = ErrorKey("ErrorCreateMeeting")
-	ErrorCreateMeetingImageIDNotFound = ErrorKey("ErrorCreateMeetingImageIDNotFound")
+	ErrorMeetingsGet                   = ErrorKey("ErrorMeetingsGet")
+	ErrorMeetingsConvert               = ErrorKey("ErrorMeetingsConvert")
+	ErrorCreateMeeting                 = ErrorKey("ErrorCreateMeeting")
+	ErrorCreateMeetingImageIDNotFound  = ErrorKey("ErrorCreateMeetingImageIDNotFound")
+	ErrorCreateMeetingInvalidEndDate   = ErrorKey("ErrorCreateMeetingInvalidEndDate")
+	ErrorCreateMeetingInvalidStartDate = ErrorKey("ErrorCreateMeetingInvalidStartDate")
 
 	// Message
 

--- a/application/api/meetings.go
+++ b/application/api/meetings.go
@@ -66,11 +66,11 @@ type MeetingCreateInput struct {
 	// text-only description, limited to 4096 characters
 	Description nulls.String `json:"description"`
 
-	// date of the first day of the meeting (event)"
-	StartDate time.Time `json:"start_date"`
+	// date (yyyy-mm-dd) of the first day of the meeting (event)"
+	StartDate string `json:"start_date"`
 
-	// date of the last day of the meeting (event)"
-	EndDate time.Time `json:"end_date"`
+	// date (yyyy-mm-dd) of the last day of the meeting (event)"
+	EndDate string `json:"end_date"`
 
 	// meeting (event) information URL -- should be a full website, but could be an information document such as a pdf"
 	MoreInfoURL nulls.String `json:"more_info_url"`

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -226,6 +226,11 @@ func (m *Meeting) GetLocation(tx *pop.Connection) (Location, error) {
 
 // Create stores the Meeting data as a new record in the database.
 func (m *Meeting) Create(tx *pop.Connection) error {
+	if m.EndDate.Before(m.StartDate) {
+		return fmt.Errorf(
+			"invalid meeting dates. StartDate must not come after EndDate. Got %v and %v.",
+			m.StartDate, m.EndDate)
+	}
 	return create(tx, m)
 }
 

--- a/application/models/meeting.go
+++ b/application/models/meeting.go
@@ -226,11 +226,6 @@ func (m *Meeting) GetLocation(tx *pop.Connection) (Location, error) {
 
 // Create stores the Meeting data as a new record in the database.
 func (m *Meeting) Create(tx *pop.Connection) error {
-	if m.EndDate.Before(m.StartDate) {
-		return fmt.Errorf(
-			"invalid meeting dates. StartDate must not come after EndDate. Got %v and %v.",
-			m.StartDate, m.EndDate)
-	}
 	return create(tx, m)
 }
 


### PR DESCRIPTION
I considered factoring out the time.Parse blocks, but it looked like it would only save a few lines of code and reduce clarity.