### PR TITLE
Use port 5001 as macs use 5000 for airplay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ AWS_ACCESS_KEY_ID=abc123
 AWS_SECRET_ACCESS_KEY=abcd1234
 
 # User Interface URL
-UI_URL=http://wecarry.local:5000
+UI_URL=http://wecarry.local:5001
 
 # User access token lifetime (seconds) past the time last used successfully. Default is 3600.
 #ACCESS_TOKEN_LIFETIME_SECONDS=3600

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -12,7 +12,7 @@ app:
     ADDR: 0.0.0.0
     HOST: http://wecarry.local:3000
     PORT: 3000
-    UI_URL: http://wecarry.local:5000
+    UI_URL: http://wecarry.local:5001
     DATABASE_URL: postgres://wecarry:wecarry@testdb:5432/wecarry_test?sslmode=disable
     EMAIL_SERVICE: dummy
     GO_ENV: test


### PR DESCRIPTION
## Changed
- UI_URL to 5001 due to MacOs Monterey using 5000 for airplay

note - changes will be made to UI in <https://github.com/silinternational/wecarry-ui/pull/226>