### PR TITLE
fix Buffalo worker

### DIFF
--- a/application/actions/app.go
+++ b/application/actions/app.go
@@ -34,6 +34,7 @@ import (
 	i18n "github.com/gobuffalo/mw-i18n/v2"
 	paramlogger "github.com/gobuffalo/mw-paramlogger"
 	"github.com/rs/cors"
+	"github.com/silinternational/wecarry-api/job"
 
 	"github.com/silinternational/wecarry-api/domain"
 	"github.com/silinternational/wecarry-api/listeners"
@@ -146,6 +147,8 @@ func App() *buffalo.App {
 		users.PUT("/me", usersMeUpdate)
 
 		listeners.RegisterListener()
+
+		job.Init(&app.Worker)
 	}
 
 	return app

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -18,7 +18,7 @@ const (
 	TokenCleanup     = "token_cleanup"
 )
 
-var Worker *worker.Worker
+var w *worker.Worker
 
 var handlers = map[string]func(worker.Args) error{
 	NewThreadMessage: newThreadMessageHandler,
@@ -27,10 +27,10 @@ var handlers = map[string]func(worker.Args) error{
 	TokenCleanup:     tokenCleanupHandler,
 }
 
-func Init(w *worker.Worker) {
-	Worker = w
+func Init(appWorker *worker.Worker) {
+	w = appWorker
 	for key, handler := range handlers {
-		if err := (*Worker).Register(key, handler); err != nil {
+		if err := (*w).Register(key, handler); err != nil {
 			domain.ErrLogger.Printf("error registering '%s' handler, %s", key, err)
 		}
 	}
@@ -143,7 +143,7 @@ func SubmitDelayed(handler string, delay time.Duration, args map[string]interfac
 		Args:    args,
 		Handler: handler,
 	}
-	return (*Worker).PerformIn(job, delay)
+	return (*w).PerformIn(job, delay)
 }
 
 // Submit enqueues a new Worker job for the given handler. Arguments can be provided in `args`.
@@ -153,5 +153,5 @@ func Submit(handler string, args map[string]interface{}) error {
 		Args:    args,
 		Handler: handler,
 	}
-	return (*Worker).Perform(job)
+	return (*w).Perform(job)
 }

--- a/application/job/job.go
+++ b/application/job/job.go
@@ -18,7 +18,7 @@ const (
 	TokenCleanup     = "token_cleanup"
 )
 
-var w worker.Worker
+var Worker *worker.Worker
 
 var handlers = map[string]func(worker.Args) error{
 	NewThreadMessage: newThreadMessageHandler,
@@ -27,10 +27,10 @@ var handlers = map[string]func(worker.Args) error{
 	TokenCleanup:     tokenCleanupHandler,
 }
 
-func init() {
-	w = worker.NewSimple()
+func Init(w *worker.Worker) {
+	Worker = w
 	for key, handler := range handlers {
-		if err := w.Register(key, handler); err != nil {
+		if err := (*Worker).Register(key, handler); err != nil {
 			domain.ErrLogger.Printf("error registering '%s' handler, %s", key, err)
 		}
 	}
@@ -143,7 +143,7 @@ func SubmitDelayed(handler string, delay time.Duration, args map[string]interfac
 		Args:    args,
 		Handler: handler,
 	}
-	return w.PerformIn(job, delay)
+	return (*Worker).PerformIn(job, delay)
 }
 
 // Submit enqueues a new Worker job for the given handler. Arguments can be provided in `args`.
@@ -153,5 +153,5 @@ func Submit(handler string, args map[string]interface{}) error {
 		Args:    args,
 		Handler: handler,
 	}
-	return w.Perform(job)
+	return (*Worker).Perform(job)
 }

--- a/application/job/job_test.go
+++ b/application/job/job_test.go
@@ -99,18 +99,3 @@ func (js *JobSuite) TestNewThreadMessageHandler() {
 		})
 	}
 }
-
-func (js *JobSuite) TestSubmitDelayed() {
-	var buf bytes.Buffer
-	domain.ErrLogger.SetOutput(&buf)
-
-	defer func() {
-		domain.ErrLogger.SetOutput(os.Stderr)
-	}()
-
-	err := SubmitDelayed("no_handler", time.Second, nil)
-	js.NoError(err)
-
-	errLog := buf.String()
-	js.Equal("", errLog, "Got an unexpected error log entry")
-}


### PR DESCRIPTION
After Buffalo update, worker wasn't started automatically. Switch to using the worker included in the app object.